### PR TITLE
Content negotiation broken when Result has no content type set.

### DIFF
--- a/ninja-core-test/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-core-test/src/main/java/ninja/utils/FakeContext.java
@@ -47,6 +47,14 @@ public class FakeContext implements Context {
     private Object body;
     private Validation validation = new ValidationImpl(new LangImpl(MockNinjaProperties.create("","")));
 
+    private String acceptContentType;
+
+    private String acceptEncoding;
+
+    private String acceptLanguage;
+
+    private String acceptCharset;
+
     public FakeContext setRequestContentType(String requestContentType) {
         this.requestContentType = requestContentType;
         return this;
@@ -289,5 +297,41 @@ public class FakeContext implements Context {
     @Override
     public String getPathParameterEncoded(String name) {
         return this.getPathParameterEncoded(name);
+    }
+
+    public void setAcceptContentType(String acceptContentType) {
+        this.acceptContentType = acceptContentType;
+    }
+
+    @Override
+    public String getAcceptContentType() {
+        return acceptContentType;
+    }
+
+    public void setAcceptEncoding(String acceptEncoding) {
+        this.acceptEncoding = acceptEncoding;
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return acceptEncoding;
+    }
+
+    public void setAcceptLanguage(String acceptLanguage) {
+        this.acceptLanguage = acceptLanguage;
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return acceptLanguage;
+    }
+
+    public void setAcceptCharset(String acceptCharset) {
+        this.acceptCharset = acceptCharset;
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return acceptCharset;
     }
 }

--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -40,14 +40,14 @@ public interface Context {
         }
     }
 	
-	/**
-	 * Content type of the request we got.
-	 * Important for content negotiation...
-	 * 
-	 * @return the content type of the incoming request.
-	 * 
-	 */
-	String getRequestContentType();
+    /**
+     * The Content-Type header field indicates the media type of the request body
+     * sent to the recipient. E.g. Content-Type: text/html; charset=ISO-8859-4
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the content type of the incoming request.
+     */
+    String getRequestContentType();
 
 	/**
 	 * Returns the uri as seen by the server.
@@ -350,4 +350,58 @@ public interface Context {
      * @return The validation context
      */
     Validation getValidation();
+
+    /**
+     * Get the content type that is acceptable for the client.
+     * (in this order : {@see Result.TEXT_HTML} > {@see Result.APPLICATION_XML} > {@see Result.APPLICATION_JSON} > {@see Result.TEXT_PLAIN}
+     * level- or quality-parameter are ignored with this method.)
+     * E.g. Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,text/html;level=2;q=0.4
+     * 
+     * The Accept request-header field can be used to specify certain media types which are acceptable
+     * for the response. Accept headers can be used to indicate that the request is specifically
+     * limited to a small set of desired types, as in the case of a request for an in-line image.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return one of the {@see Result} mime types that is acceptable for the client or {@see Result.TEXT_HTML} if not set
+     */
+    String getAcceptContentType();
+
+    /**
+     * Get the encoding that is acceptable for the client.
+     * E.g. Accept-Encoding: compress, gzip
+     * 
+     * The Accept-Encoding request-header field is similar to Accept, but restricts the content-codings
+     * that are acceptable in the response.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the encoding that is acceptable for the client
+     */
+    String getAcceptEncoding();
+
+    /**
+     * Get the language that is acceptable for the client.
+     * E.g. Accept-Language: da, en-gb;q=0.8, en;q=0.7
+     * 
+     * The Accept-Language request-header field is similar to Accept, but restricts the set of
+     * natural languages that are preferred as a response to the request.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the language that is acceptable for the client
+     */
+    String getAcceptLanguage();
+
+    /**
+     * Get the charset that is acceptable for the client.
+     * E.g. Accept-Charset: iso-8859-5, unicode-1-1;q=0.8
+     * 
+     * The Accept-Charset request-header field can be used to indicate what character sets are
+     * acceptable for the response. This field allows clients capable of understanding more
+     * comprehensive or special- purpose character sets to signal that capability to a server which
+     * is capable of representing documents in those character sets.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the charset that is acceptable for the client
+     */
+    String getAcceptCharset();
+
 }

--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -353,7 +353,8 @@ public interface Context {
 
     /**
      * Get the content type that is acceptable for the client.
-     * (in this order : {@see Result.TEXT_HTML} > {@see Result.APPLICATION_XML} > {@see Result.APPLICATION_JSON} > {@see Result.TEXT_PLAIN}
+     * (in this order : {@see Result.TEXT_HTML} > {@see Result.APPLICATION_XML} > 
+     *     {@see Result.APPLICATION_JSON} > {@see Result.TEXT_PLAIN} > {@see Result.APPLICATION_OCTET_STREAM}
      * level- or quality-parameter are ignored with this method.)
      * E.g. Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,text/html;level=2;q=0.4
      * 

--- a/ninja-core/src/main/java/ninja/ContextImpl.java
+++ b/ninja-core/src/main/java/ninja/ContextImpl.java
@@ -309,6 +309,52 @@ public class ContextImpl implements Context {
 	}
 
     @Override
+    public String getAcceptContentType() {
+        String contentType = httpServletRequest.getHeader("accept");
+
+        if (contentType == null) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xhtml") != -1 || contentType.indexOf("text/html") != -1 || contentType.startsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xml") != -1 || contentType.indexOf("text/xml") != -1) {
+            return Result.APPLICATION_XML;
+        }
+
+        if (contentType.indexOf("application/json") != -1 || contentType.indexOf("text/javascript") != -1) {
+            return Result.APPLICATON_JSON;
+        }
+
+        if (contentType.indexOf("text/plain") != -1) {
+            return Result.TEXT_PLAIN;
+        }
+
+        if (contentType.endsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        return Result.TEXT_HTML;
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return httpServletRequest.getHeader("accept-encoding");
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return httpServletRequest.getHeader("accept-language");
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return httpServletRequest.getHeader("accept-charset");
+    }
+
+    @Override
     public Route getRoute() {
         return route;
     }

--- a/ninja-core/src/main/java/ninja/ContextImpl.java
+++ b/ninja-core/src/main/java/ninja/ContextImpl.java
@@ -332,6 +332,10 @@ public class ContextImpl implements Context {
             return Result.TEXT_PLAIN;
         }
 
+        if (contentType.indexOf("application/octet-stream") != -1) {
+            return Result.APPLICATION_OCTET_STREAM;
+        }
+
         if (contentType.endsWith("*/*")) {
             return Result.TEXT_HTML;
         }

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -182,4 +182,24 @@ public class WrappedContext implements Context {
     public String getPathParameterEncoded(String key) {
         return wrapped.getPathParameterEncoded(key);
     }
+
+    @Override
+    public String getAcceptContentType() {
+        return wrapped.getAcceptContentType();
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return wrapped.getAcceptEncoding();
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return wrapped.getAcceptLanguage();
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return wrapped.getAcceptCharset();
+    }
 }

--- a/ninja-core/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-core/src/main/java/ninja/utils/ResultHandler.java
@@ -47,14 +47,9 @@ public class ResultHandler {
             handleRenderable((Renderable) object, context, result);
         } else {
             // if content type is not yet set in result we copy it over from the
-            // request
-            // otherwise we are using TEXT/HTML as fallback...
+            // request accept header
             if (result.getContentType() == null) {
-                if (context.getRequestContentType() != null) {
-                    result.contentType(context.getRequestContentType());
-                } else {
-                    result.contentType(Result.TEXT_HTML);
-                }
+                result.contentType(context.getAcceptContentType());
             }
 
             renderWithTemplateEngine(context, result);

--- a/ninja-core/src/test/java/ninja/ContextImplTest.java
+++ b/ninja-core/src/test/java/ninja/ContextImplTest.java
@@ -3,6 +3,7 @@ package ninja;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -282,6 +283,125 @@ public class ContextImplTest {
 
         assertEquals("/myapp/is/here", context.getRequestPath());
         
+    }
+
+    @Test
+    public void testGetRequestContentType() {
+        String contentType = "text/html";
+        when(httpServletRequest.getContentType()).thenReturn(contentType);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(contentType, context.getRequestContentType());
+
+        contentType = null;
+        when(httpServletRequest.getContentType()).thenReturn(contentType);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertNull(context.getRequestContentType());
+
+        contentType = "text/html; charset=UTF-8";
+        when(httpServletRequest.getContentType()).thenReturn(contentType);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(contentType, context.getRequestContentType());
+    }
+
+    @Test
+    public void testGetAcceptContentType() {
+        when(httpServletRequest.getHeader("accept")).thenReturn(null);
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("totally_unknown");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/json");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.APPLICATON_JSON, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/html, application/json");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/xhtml, application/json");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/plain");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_PLAIN, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/plain, application/json");
+        context.init(httpServletRequest, httpServletResponse);
+        assertEquals(Result.APPLICATON_JSON, context.getAcceptContentType());
+    }
+
+    @Test
+    public void testGetAcceptEncoding() {
+        String encoding = "compress, gzip";
+        when(httpServletRequest.getHeader("accept-encoding")).thenReturn(encoding);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(encoding, context.getAcceptEncoding());
+
+        encoding = null;
+        when(httpServletRequest.getHeader("accept-encoding")).thenReturn(encoding);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertNull(context.getAcceptEncoding());
+
+        encoding = "gzip;q=1.0, identity; q=0.5, *;q=0";
+        when(httpServletRequest.getHeader("accept-encoding")).thenReturn(encoding);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(encoding, context.getAcceptEncoding());
+    }
+
+    @Test
+    public void testGetAcceptLanguage() {
+        String language = "de";
+        when(httpServletRequest.getHeader("accept-language")).thenReturn(language);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(language, context.getAcceptLanguage());
+
+        language = null;
+        when(httpServletRequest.getHeader("accept-language")).thenReturn(language);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertNull(context.getAcceptLanguage());
+
+        language = "da, en-gb;q=0.8, en;q=0.7";
+        when(httpServletRequest.getHeader("accept-language")).thenReturn(language);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(language, context.getAcceptLanguage());
+    }
+
+    @Test
+    public void testGetAcceptCharset() {
+        String charset = "UTF-8";
+        when(httpServletRequest.getHeader("accept-charset")).thenReturn(charset);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(charset, context.getAcceptCharset());
+
+        charset = null;
+        when(httpServletRequest.getHeader("accept-charset")).thenReturn(charset);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertNull(context.getAcceptCharset());
+
+        charset = "iso-8859-5, unicode-1-1;q=0.8";
+        when(httpServletRequest.getHeader("accept-charset")).thenReturn(charset);
+        context.init(httpServletRequest, httpServletResponse);
+
+        assertEquals(charset, context.getAcceptCharset());
     }
 
 }

--- a/ninja-demo-application-app-engine/src/main/java/ninja/Context.java
+++ b/ninja-demo-application-app-engine/src/main/java/ninja/Context.java
@@ -40,13 +40,13 @@ public interface Context {
         }
     }
 	
-	/**
-	 * Content type of the request we got.
-	 * Important for content negotiation...
-	 * 
-	 * @return the content type of the incoming request.
-	 * 
-	 */
+    /**
+     * The Content-Type header field indicates the media type of the request body
+     * sent to the recipient. E.g. Content-Type: text/html; charset=ISO-8859-4
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the content type of the incoming request.
+     */
 	String getRequestContentType();
 
 	/**
@@ -350,4 +350,59 @@ public interface Context {
      * @return The validation context
      */
     Validation getValidation();
+
+    /**
+     * Get the content type that is acceptable for the client.
+     * (in this order : {@see Result.TEXT_HTML} > {@see Result.APPLICATION_XML} > 
+     *     {@see Result.APPLICATION_JSON} > {@see Result.TEXT_PLAIN} > {@see Result.APPLICATION_OCTET_STREAM}
+     * level- or quality-parameter are ignored with this method.)
+     * E.g. Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,text/html;level=2;q=0.4
+     * 
+     * The Accept request-header field can be used to specify certain media types which are acceptable
+     * for the response. Accept headers can be used to indicate that the request is specifically
+     * limited to a small set of desired types, as in the case of a request for an in-line image.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return one of the {@see Result} mime types that is acceptable for the client or {@see Result.TEXT_HTML} if not set
+     */
+    String getAcceptContentType();
+
+    /**
+     * Get the encoding that is acceptable for the client.
+     * E.g. Accept-Encoding: compress, gzip
+     * 
+     * The Accept-Encoding request-header field is similar to Accept, but restricts the content-codings
+     * that are acceptable in the response.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the encoding that is acceptable for the client
+     */
+    String getAcceptEncoding();
+
+    /**
+     * Get the language that is acceptable for the client.
+     * E.g. Accept-Language: da, en-gb;q=0.8, en;q=0.7
+     * 
+     * The Accept-Language request-header field is similar to Accept, but restricts the set of
+     * natural languages that are preferred as a response to the request.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the language that is acceptable for the client
+     */
+    String getAcceptLanguage();
+
+    /**
+     * Get the charset that is acceptable for the client.
+     * E.g. Accept-Charset: iso-8859-5, unicode-1-1;q=0.8
+     * 
+     * The Accept-Charset request-header field can be used to indicate what character sets are
+     * acceptable for the response. This field allows clients capable of understanding more
+     * comprehensive or special- purpose character sets to signal that capability to a server which
+     * is capable of representing documents in those character sets.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the charset that is acceptable for the client
+     */
+    String getAcceptCharset();
+
 }

--- a/ninja-demo-application-app-engine/src/main/java/ninja/ContextImpl.java
+++ b/ninja-demo-application-app-engine/src/main/java/ninja/ContextImpl.java
@@ -309,6 +309,56 @@ public class ContextImpl implements Context {
 	}
 
     @Override
+    public String getAcceptContentType() {
+        String contentType = httpServletRequest.getHeader("accept");
+
+        if (contentType == null) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xhtml") != -1 || contentType.indexOf("text/html") != -1 || contentType.startsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xml") != -1 || contentType.indexOf("text/xml") != -1) {
+            return Result.APPLICATION_XML;
+        }
+
+        if (contentType.indexOf("application/json") != -1 || contentType.indexOf("text/javascript") != -1) {
+            return Result.APPLICATON_JSON;
+        }
+
+        if (contentType.indexOf("text/plain") != -1) {
+            return Result.TEXT_PLAIN;
+        }
+
+        if (contentType.indexOf("application/octet-stream") != -1) {
+            return Result.APPLICATION_OCTET_STREAM;
+        }
+
+        if (contentType.endsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        return Result.TEXT_HTML;
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return httpServletRequest.getHeader("accept-encoding");
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return httpServletRequest.getHeader("accept-language");
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return httpServletRequest.getHeader("accept-charset");
+    }
+
+    @Override
     public Route getRoute() {
         return route;
     }

--- a/ninja-demo-application-app-engine/src/main/java/ninja/WrappedContext.java
+++ b/ninja-demo-application-app-engine/src/main/java/ninja/WrappedContext.java
@@ -182,4 +182,24 @@ public class WrappedContext implements Context {
     public String getPathParameterEncoded(String key) {
         return wrapped.getPathParameterEncoded(key);
     }
+
+    @Override
+    public String getAcceptContentType() {
+        return wrapped.getAcceptContentType();
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return wrapped.getAcceptEncoding();
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return wrapped.getAcceptLanguage();
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return wrapped.getAcceptCharset();
+    }
 }

--- a/ninja-demo-application-app-engine/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-demo-application-app-engine/src/main/java/ninja/utils/ResultHandler.java
@@ -47,14 +47,9 @@ public class ResultHandler {
             handleRenderable((Renderable) object, context, result);
         } else {
             // if content type is not yet set in result we copy it over from the
-            // request
-            // otherwise we are using TEXT/HTML as fallback...
+            // request accept header
             if (result.getContentType() == null) {
-                if (context.getRequestContentType() != null) {
-                    result.contentType(context.getRequestContentType());
-                } else {
-                    result.contentType(Result.TEXT_HTML);
-                }
+                result.contentType(context.getAcceptContentType());
             }
 
             renderWithTemplateEngine(context, result);

--- a/ninja-demo-application-mybatis/src/main/java/ninja/Context.java
+++ b/ninja-demo-application-mybatis/src/main/java/ninja/Context.java
@@ -40,13 +40,13 @@ public interface Context {
         }
     }
 	
-	/**
-	 * Content type of the request we got.
-	 * Important for content negotiation...
-	 * 
-	 * @return the content type of the incoming request.
-	 * 
-	 */
+    /**
+     * The Content-Type header field indicates the media type of the request body
+     * sent to the recipient. E.g. Content-Type: text/html; charset=ISO-8859-4
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the content type of the incoming request.
+     */
 	String getRequestContentType();
 
 	/**
@@ -350,4 +350,59 @@ public interface Context {
      * @return The validation context
      */
     Validation getValidation();
+
+    /**
+     * Get the content type that is acceptable for the client.
+     * (in this order : {@see Result.TEXT_HTML} > {@see Result.APPLICATION_XML} > 
+     *     {@see Result.APPLICATION_JSON} > {@see Result.TEXT_PLAIN} > {@see Result.APPLICATION_OCTET_STREAM}
+     * level- or quality-parameter are ignored with this method.)
+     * E.g. Accept: text/*;q=0.3, text/html;q=0.7, text/html;level=1,text/html;level=2;q=0.4
+     * 
+     * The Accept request-header field can be used to specify certain media types which are acceptable
+     * for the response. Accept headers can be used to indicate that the request is specifically
+     * limited to a small set of desired types, as in the case of a request for an in-line image.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return one of the {@see Result} mime types that is acceptable for the client or {@see Result.TEXT_HTML} if not set
+     */
+    String getAcceptContentType();
+
+    /**
+     * Get the encoding that is acceptable for the client.
+     * E.g. Accept-Encoding: compress, gzip
+     * 
+     * The Accept-Encoding request-header field is similar to Accept, but restricts the content-codings
+     * that are acceptable in the response.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the encoding that is acceptable for the client
+     */
+    String getAcceptEncoding();
+
+    /**
+     * Get the language that is acceptable for the client.
+     * E.g. Accept-Language: da, en-gb;q=0.8, en;q=0.7
+     * 
+     * The Accept-Language request-header field is similar to Accept, but restricts the set of
+     * natural languages that are preferred as a response to the request.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the language that is acceptable for the client
+     */
+    String getAcceptLanguage();
+
+    /**
+     * Get the charset that is acceptable for the client.
+     * E.g. Accept-Charset: iso-8859-5, unicode-1-1;q=0.8
+     * 
+     * The Accept-Charset request-header field can be used to indicate what character sets are
+     * acceptable for the response. This field allows clients capable of understanding more
+     * comprehensive or special- purpose character sets to signal that capability to a server which
+     * is capable of representing documents in those character sets.
+     * {@link www.w3.org/Protocols/rfc2616/rfc2616-sec14.html}
+     * 
+     * @return the charset that is acceptable for the client
+     */
+    String getAcceptCharset();
+
 }

--- a/ninja-demo-application-mybatis/src/main/java/ninja/ContextImpl.java
+++ b/ninja-demo-application-mybatis/src/main/java/ninja/ContextImpl.java
@@ -309,6 +309,56 @@ public class ContextImpl implements Context {
 	}
 
     @Override
+    public String getAcceptContentType() {
+        String contentType = httpServletRequest.getHeader("accept");
+
+        if (contentType == null) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xhtml") != -1 || contentType.indexOf("text/html") != -1 || contentType.startsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        if (contentType.indexOf("application/xml") != -1 || contentType.indexOf("text/xml") != -1) {
+            return Result.APPLICATION_XML;
+        }
+
+        if (contentType.indexOf("application/json") != -1 || contentType.indexOf("text/javascript") != -1) {
+            return Result.APPLICATON_JSON;
+        }
+
+        if (contentType.indexOf("text/plain") != -1) {
+            return Result.TEXT_PLAIN;
+        }
+
+        if (contentType.indexOf("application/octet-stream") != -1) {
+            return Result.APPLICATION_OCTET_STREAM;
+        }
+
+        if (contentType.endsWith("*/*")) {
+            return Result.TEXT_HTML;
+        }
+
+        return Result.TEXT_HTML;
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return httpServletRequest.getHeader("accept-encoding");
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return httpServletRequest.getHeader("accept-language");
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return httpServletRequest.getHeader("accept-charset");
+    }
+
+    @Override
     public Route getRoute() {
         return route;
     }

--- a/ninja-demo-application-mybatis/src/main/java/ninja/WrappedContext.java
+++ b/ninja-demo-application-mybatis/src/main/java/ninja/WrappedContext.java
@@ -182,4 +182,24 @@ public class WrappedContext implements Context {
     public String getPathParameterEncoded(String key) {
         return wrapped.getPathParameterEncoded(key);
     }
+
+    @Override
+    public String getAcceptContentType() {
+        return wrapped.getAcceptContentType();
+    }
+
+    @Override
+    public String getAcceptEncoding() {
+        return wrapped.getAcceptEncoding();
+    }
+
+    @Override
+    public String getAcceptLanguage() {
+        return wrapped.getAcceptLanguage();
+    }
+
+    @Override
+    public String getAcceptCharset() {
+        return wrapped.getAcceptCharset();
+    }
 }

--- a/ninja-demo-application-mybatis/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-demo-application-mybatis/src/main/java/ninja/utils/ResultHandler.java
@@ -47,14 +47,9 @@ public class ResultHandler {
             handleRenderable((Renderable) object, context, result);
         } else {
             // if content type is not yet set in result we copy it over from the
-            // request
-            // otherwise we are using TEXT/HTML as fallback...
+            // request accept header
             if (result.getContentType() == null) {
-                if (context.getRequestContentType() != null) {
-                    result.contentType(context.getRequestContentType());
-                } else {
-                    result.contentType(Result.TEXT_HTML);
-                }
+                result.contentType(context.getAcceptContentType());
             }
 
             renderWithTemplateEngine(context, result);


### PR DESCRIPTION
The Resulthandler uses now the Accept Header to set the response content type
