### PR TITLE
ignore maven-enforcer-plugin in eclipse because its not supported by m2e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,35 @@
 					</configuration>
 				</plugin>
 
+				<!--
+					This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the
+					Maven build itself.
+				-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-enforcer-plugin</artifactId>
+										<versionRange>[1.0,)</versionRange>
+										<goals>
+										  <goal>enforce</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
ignore maven-enforcer-plugin in eclipse because its not supported by m2e and causes noisy warnings in eclipse

btw: had problems with tabs as my editor is tab-free :)
do you relly want tabs because any other project is moving away from tabulators?
