### PR TITLE
Feature/do not process response flag

### DIFF
--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -19,6 +19,7 @@ package ninja;
 import java.util.List;
 import java.util.Map;
 
+import ninja.template.TemplateEngineJsonGson;
 import ninja.utils.DateUtil;
 
 import com.google.common.collect.Lists;
@@ -51,6 +52,7 @@ public class Result {
     // /////////////////////////////////////////////////////////////////////////
     public static final String TEXT_HTML = "text/html";
     public static final String TEXT_PLAIN = "text/plain";
+    public static final String TEXT_XML = "text/xml";
     public static final String APPLICATON_JSON = "application/json";
     public static final String APPLICATION_XML = "application/xml";
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
@@ -91,6 +93,12 @@ public class Result {
     private String template;
 
     /**
+     * See {@link #doNotProcessBody(boolean)}.
+     */
+    private boolean doNotProcessBody;
+
+
+    /**
      * A result. Sets utf-8 as charset and status code by default. 
      * Refer to {@link Result#SC_200_OK}, {@link Result#SC_204_NO_CONTENT} and so on
      * for some short cuts to predefined results. 
@@ -104,7 +112,7 @@ public class Result {
 
         this.headers = Maps.newHashMap();
         this.cookies = Lists.newArrayList();
-
+        doNotProcessBody = false;
     }
 
     public Object getRenderable() {
@@ -304,4 +312,25 @@ public class Result {
         
     } 
 
+    /**
+     * Tells whether the body needs processing by the framework. Normally it does, except {@link #doNotProcessBody()}
+     * has been called *AND* a content type has been set.
+     * 
+     * @return
+     */
+    public boolean mustProcessBody() {
+        return !doNotProcessBody || contentType == null;
+    }
+
+    /**
+     * Normally, Ninja will process the body according to the content type, so it will e.g. use
+     * {@link TemplateEngineJsonGson} if content type is "application/json". However, in some special cases you may want
+     * to produce e.g. the json response manually and Ninja should just write it out without further processing. In this
+     * case, set {@link #bodyIsProcessed} to true. But make sure you also set a content type, otherwise this flag will
+     * be ignored!
+     */
+    public Result doNotProcessBody() {
+        this.doNotProcessBody = true;
+        return this;
+    }
 }

--- a/ninja-core/src/main/java/ninja/Results.java
+++ b/ninja-core/src/main/java/ninja/Results.java
@@ -16,8 +16,6 @@
 
 package ninja;
 
-import ninja.lifecycle.Start;
-import ninja.utils.DateUtil;
 
 /**
  * Convenience methods for the generation of Results.

--- a/ninja-core/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-core/src/main/java/ninja/utils/ResultHandler.java
@@ -53,14 +53,17 @@ public class ResultHandler {
         Object object = result.getRenderable();
         String contentType = result.getContentType();
 
-        if (object == null && contentType == null) {
+        if (!result.mustProcessBody()) {
+            handlePlainText(context, result);
+        }
+
+        else if (object == null && contentType == null) {
             // Just finalize the headers, nothing else
             context.finalizeHeaders(result);
         } else if (object instanceof Renderable) {
             // if the object is a renderable it should do everything itself...:
             // make sure to call context.finalizeHeaders(result) with the
-            // results
-            // you want to set...
+            // results you want to set...
             handleRenderable((Renderable) object, context, result);
         } else {
             // if content type is not yet set in result we copy it over from the
@@ -91,6 +94,7 @@ public class ResultHandler {
     }
 
     private void renderWithTemplateEngine(Context context, Result result) {
+
         // try to get a suitable rendering engine...
         TemplateEngine templateEngine = templateEngineManager
                 .getTemplateEngineForContentType(result.getContentType());
@@ -103,16 +107,8 @@ public class ResultHandler {
 
             if (result.getRenderable() instanceof String) {
                 // Simply write it out
-                try {
-                    result.contentType(Result.TEXT_PLAIN);
-                    ResponseStreams responseStreams = context
-                            .finalizeHeaders(result);
-                    responseStreams.getWriter().write(
-                            (String) result.getRenderable());
-
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                result.contentType(Result.TEXT_PLAIN);
+                handlePlainText(context, result);
 
             } else if (result.getRenderable() instanceof byte[]) {
                 // Simply write it out
@@ -130,6 +126,24 @@ public class ResultHandler {
                         "No template engine found for result content type "
                                 + result.getContentType());
             }
+        }
+    }
+
+    /**
+     * Finalizes headers and writes plain content to response stream without any template engine or other further body
+     * processing being involved.
+     * 
+     * @param context
+     * @param result
+     */
+    private void handlePlainText(Context context, Result result) {
+        try {
+            ResponseStreams responseStreams = context
+                    .finalizeHeaders(result);
+            responseStreams.getWriter().write(
+                    (String) result.getRenderable());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,6 @@
 Version 1.X
 ===========
-
+ * Support manually controlling response body by calling Result#doNotProcess()
  * Support XML payload parsing on Content-Type: application/xml
 
 Version 1.0.6


### PR DESCRIPTION
in some cases the framework user might want to fully control the content of a response body even if the response has a  content type that is normally handled by a certain template engine. To do so, I added a flag to class Result that is evaluated by ResultHandler.
