### PR TITLE
Feature/session cookie http only

### DIFF
--- a/ninja-core/src/main/java/ninja/session/SessionCookieImpl.java
+++ b/ninja-core/src/main/java/ninja/session/SessionCookieImpl.java
@@ -51,6 +51,7 @@ public class SessionCookieImpl implements SessionCookie {
     private final Integer sessionExpireTimeInMs;
     private final Boolean sessionSendOnlyIfChanged;
     private final Boolean sessionTransferredOverHttpsOnly;
+    private final Boolean sessionHttpOnly;
     private final String applicationCookiePrefix;
     private final Map<String, String> data = new HashMap<String, String>();
 
@@ -74,6 +75,8 @@ public class SessionCookieImpl implements SessionCookie {
         
 		this.sessionSendOnlyIfChanged = ninjaProperties.getBooleanWithDefault(NinjaConstant.sessionSendOnlyIfChanged, true);
 		this.sessionTransferredOverHttpsOnly = ninjaProperties.getBooleanWithDefault(NinjaConstant.sessionTransferredOverHttpsOnly, true);
+        this.sessionHttpOnly = ninjaProperties.getBooleanWithDefault(
+                NinjaConstant.sessionHttpOnly, true);
 		
 		this.applicationCookiePrefix = ninjaProperties.getOrDie(NinjaConstant.applicationCookiePrefix);
 	}
@@ -242,6 +245,9 @@ public class SessionCookieImpl implements SessionCookie {
             }
             if (sessionTransferredOverHttpsOnly != null) {
                 cookie.setSecure(sessionTransferredOverHttpsOnly);
+            }
+            if (sessionHttpOnly) {
+                CookieHelper.setHttpOnly(cookie);
             }
 
 			context.getHttpServletResponse().addCookie(cookie);

--- a/ninja-core/src/main/java/ninja/utils/CookieHelper.java
+++ b/ninja-core/src/main/java/ninja/utils/CookieHelper.java
@@ -16,10 +16,10 @@
 
 package ninja.utils;
 
+import javax.servlet.http.Cookie;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.http.Cookie;
 
 public class CookieHelper {
     private static final Logger log = LoggerFactory
@@ -70,6 +70,10 @@ public class CookieHelper {
             HTTP_ONLY_SETTER.setHttpOnly(servletCookie);
         }
         return servletCookie;
+    }
+
+    public static void setHttpOnly(Cookie cookie) {
+        HTTP_ONLY_SETTER.setHttpOnly(cookie);
     }
 
     /**

--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -86,6 +86,16 @@ public interface NinjaConstant {
     final String sessionTransferredOverHttpsOnly = "application.session.transferred_over_https_only";
 
     /**
+     * Used to set the HttpOnly flag at the session cookie. On a supported
+     * browser, an HttpOnly session cookie will be used only when transmitting
+     * HTTP (or HTTPS) requests, thus restricting access from other, non-HTTP
+     * APIs (such as JavaScript). This restriction mitigates but does not
+     * eliminate the threat of session cookie theft via cross-site scripting
+     * (XSS).
+     */
+    final String sessionHttpOnly = "application.session.http_only";
+
+    /**
      * Suffix used for Ninja cookies. Usually results in cookies like
      * "NINJA_SESSION
      */

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -2,6 +2,7 @@ Version 1.0.X
 =============
  
  * Bugfix: explicitly set content type of result keeps untouched by ResultHandler now 
+ * Added HttpOnly option for the session cookie 
  
 Version 1.0.8
 =============

--- a/ninja-core/src/test/java/ninja/utils/NinjaConstantTest.java
+++ b/ninja-core/src/test/java/ninja/utils/NinjaConstantTest.java
@@ -56,6 +56,9 @@ public class NinjaConstantTest {
 
         assertEquals(false, configuration.getBoolean(NinjaConstant.sessionTransferredOverHttpsOnly));
 
+        assertEquals(true,
+                configuration.getBoolean(NinjaConstant.sessionHttpOnly));
+
     }
 
 }

--- a/ninja-core/src/test/resources/conf/all_constants.conf
+++ b/ninja-core/src/test/resources/conf/all_constants.conf
@@ -10,6 +10,4 @@ application.server.name=SERVER_NAME
 application.session.expire_time_in_seconds=9999
 application.session.send_only_if_changed=false
 application.session.transferred_over_https_only=false
-
-
-
+application.session.http_only=true


### PR DESCRIPTION
HttpOnly flag at the session cookie. 
On a supported browser, an HttpOnly session cookie will be used only when transmitting HTTP (or HTTPS) requests, thus restricting access from other, non-HTTP APIs (such as JavaScript). This restriction mitigates but does not eliminate the threat of session cookie theft via cross-site scripting (XSS).
