### PR TITLE
Set content type when it is not explicitly set

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-core/src/main/java/ninja/utils/ResultHandler.java
@@ -121,7 +121,11 @@ public class ResultHandler {
             } else if (result.getRenderable() instanceof byte[]) {
                 // Simply write it out
                 try {
-                    result.contentType(Result.APPLICATION_OCTET_STREAM);
+                    // if content type not explicitly set, application/octet-stream 
+                    // is a good default value:
+                    if (result.getContentType() == null) {
+                        result.contentType(Result.APPLICATION_OCTET_STREAM);
+                    }
                     ResponseStreams responseStreams = context
                             .finalizeHeaders(result);
                     responseStreams.getOutputStream().write(

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version 1.3
+===========
+ * Fix for byte[] get a forced octet stream when content type is already explicitly set (qubic)
+
+
 Version 1.2
 ===========
 

--- a/ninja-core/src/test/java/ninja/utils/ResultHandlerTest.java
+++ b/ninja-core/src/test/java/ninja/utils/ResultHandlerTest.java
@@ -16,6 +16,7 @@
 
 package ninja.utils;
 
+import java.io.OutputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -48,6 +49,9 @@ public class ResultHandlerTest {
     @Mock
     private ResponseStreams responseStreams;
 
+	@Mock
+	private OutputStream outputStream;
+	
     @Mock
     private Writer writer;
 
@@ -61,6 +65,7 @@ public class ResultHandlerTest {
     public void init() throws Exception {
         
         resultHandler = new ResultHandler(templateEngineManager);
+		when(responseStreams.getOutputStream()).thenReturn(outputStream);
         when(responseStreams.getWriter()).thenReturn(writer);
         when(context.finalizeHeaders(any(Result.class))).thenReturn(responseStreams);
         when(templateEngineManager.getTemplateEngineForContentType(
@@ -136,4 +141,14 @@ public class ResultHandlerTest {
         assertEquals(contentType, result.getContentType());
     }
 
+	@Test
+	public void testRenderPictureFromBytes() {
+		final byte[] toRender = new byte[]{1,2,3};
+        final String contentType = "image/png";
+        Result result = Results.ok();
+        result.contentType(contentType);
+        result.render(toRender);
+        resultHandler.handleResult(result, context);
+        assertEquals(contentType, result.getContentType());
+	}
 }


### PR DESCRIPTION
I use rrd4j to generate picture and convert it to bytes array, "application/octet-stream" will make browser to download the picture which is not what i want.
