### PR TITLE
Context attributes and multivalued headers

### DIFF
--- a/ninja-core-test/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-core-test/src/main/java/ninja/utils/FakeContext.java
@@ -62,6 +62,7 @@ public class FakeContext implements Context {
     private ListMultimap<String, String> params = ArrayListMultimap.create();
     private Map<String, String> pathParams = new HashMap<String, String>();
     private ListMultimap<String, String> headers = ArrayListMultimap.create();
+    private Map<String, Object> attributes = new HashMap<String, Object>();
     private Object body;
     private Validation validation = new ValidationImpl();
 
@@ -368,5 +369,20 @@ public class FakeContext implements Context {
     @Override
     public String getMethod() {
         throw new UnsupportedOperationException("Not supported in fake context");
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    @Override
+    public <T> T getAttribute(String name, Class<T> clazz) {
+        return clazz.cast(getAttribute(name));
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        attributes.put(name, value);
     }
 }

--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -484,4 +484,44 @@ public interface Context {
     */
     String getMethod();
 
+    /**
+     * Gets an attribute value previously set by {@link #setAttribute}.
+     * <p>
+     * Attributes are shared state for the duration of the request;
+     * useful to pass values between {@link Filter filters} and
+     * controllers.
+     *
+     * @return the attribute value, or {@code null} if the attribute does
+     *         not exist
+     */
+    Object getAttribute(String name);
+
+    /**
+     * Gets an attribute value previously set by {@link #setAttribute}.
+     * <p>
+     * This is a convenience method, equivalent to:
+     * <pre><code>
+     *     return clazz.cast(getAttribute(name));
+     * </code></pre>
+     * <p>
+     * Attributes are shared state for the duration of the request;
+     * useful to pass values between {@link Filter filters} and
+     * controllers.
+     *
+     * @return the attribute value, or {@code null} if the attribute does
+     *         not exist
+     */
+    <T> T getAttribute(String name, Class<T> clazz);
+
+    /**
+     * Sets an attribute value.
+     * <p>
+     * Attributes are shared state for the duration of the request;
+     * useful to pass values between {@link Filter filters} and
+     * controllers.
+     *
+     * @see #getAttribute(String)
+     * @see #getAttribute(String, Class)
+     */
+    void setAttribute(String name, Object value);
 }

--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -160,14 +160,30 @@ public interface Context {
      * Get the parameter with the given key from the request. The parameter may
      * either be a query parameter, or in the case of form submissions, may be a
      * form parameter.
-     * 
+     * <p>
+     * When the parameter is multivalued, returns the first value.
+     * <p>
      * The parameter is decoded by default.
      * 
      * @param name
      *            The key of the parameter
      * @return The value, or null if no parameter was found.
+     * @see #getParameterValues
      */
     String getParameter(String name);
+
+    /**
+     * Get the parameter with the given key from the request. The parameter may
+     * either be a query parameter, or in the case of form submissions, may be a
+     * form parameter.
+     * <p>
+     * The parameter is decoded by default.
+     *
+     * @param name
+     *            The key of the parameter
+     * @return The values, possibly an empty list.
+     */
+    List<String> getParameterValues(String name);
 
     /**
      * Same like {@link #getParameter(String)}, but returns given defaultValue
@@ -262,18 +278,25 @@ public interface Context {
     Map<String, String[]> getParameters();
 
     /**
-     * Get the request header with the given name
+     * Get the (first) request header with the given name
      * 
      * @return The header value
      */
     String getHeader(String name);
 
     /**
+     * Get all the request headers with the given name.
+     *
+     * @return the header values
+     */
+    List<String> getHeaders(String name);
+
+    /**
      * Get all the headers from the request
      * 
      * @return The headers
      */
-    Map<String, String> getHeaders();
+    Map<String, List<String>> getHeaders();
 
     /**
      * Get the cookie value from the request, if defined

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -61,6 +61,11 @@ public class WrappedContext implements Context {
     }
 
     @Override
+    public List<String> getParameterValues(String name) {
+        return wrapped.getParameterValues(name);
+    }
+
+    @Override
     public String getParameter(String key, String defaultValue) {
         return wrapped.getParameter(key, defaultValue);
     }
@@ -96,7 +101,12 @@ public class WrappedContext implements Context {
     }
 
     @Override
-    public Map<String, String> getHeaders() {
+    public List<String> getHeaders(String name) {
+        return wrapped.getHeaders(name);
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
         return wrapped.getHeaders();
     }
 

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -229,4 +229,19 @@ public class WrappedContext implements Context {
     public String getMethod() {
         return wrapped.getMethod();
     }
+
+    @Override
+    public Object getAttribute(String name) {
+        return wrapped.getAttribute(name);
+    }
+
+    @Override
+    public <T> T getAttribute(String name, Class<T> clazz) {
+        return wrapped.getAttribute(name, clazz);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        wrapped.setAttribute(name, value);
+    }
 }

--- a/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
+++ b/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
@@ -17,6 +17,7 @@
 package ninja.params;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import ninja.Context;
 import ninja.session.FlashCookie;
 import ninja.session.SessionCookie;
@@ -172,6 +173,33 @@ public class ArgumentExtractors {
         @Override
         public Class<String> getExtractedType() {
             return String.class;
+        }
+
+        @Override
+        public String getFieldName() {
+            return key;
+        }
+    }
+
+    public static class AttributeExtractor implements ArgumentExtractor<Object> {
+        private final String key;
+        private final Class<?> attributeType;
+
+        @Inject
+        public AttributeExtractor(Attribute attribute, ArgumentClassHolder attributeType) {
+            this.key = attribute.value();
+            this.attributeType = attributeType.getArgumentClass();
+        }
+
+        @Override
+        public Object extract(Context context) {
+            return context.getAttribute(key, attributeType);
+        }
+
+        @Override
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        public Class getExtractedType() {
+            return attributeType;
         }
 
         @Override

--- a/ninja-core/src/main/java/ninja/params/Attribute.java
+++ b/ninja-core/src/main/java/ninja/params/Attribute.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.params;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Injects an attribute value into a controller method invocation.
+ *
+ * @author Thomas Broyer
+ */
+@WithArgumentExtractor(ArgumentExtractors.AttributeExtractor.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface Attribute {
+    String value();
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version CURRENT
 ==============
 
+ * Headers can be multivalued, added `getParameterValues` for multivalued parameters (tbroyer)
  * Docs: Added documentation for WrappedContext / ArgumentMatchers aka Request scope (ra)
  * Docs: Added twitter account (ra) 
  * Separation of servlet support (module ninja-servlet) from main ninja framework (tbroyer)

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version CURRENT
 ==============
 
+ * Added _attributes_ to `Context`, updated Request scope documentation (tbroyer)
  * Headers can be multivalued, added `getParameterValues` for multivalued parameters (tbroyer)
  * Docs: Added documentation for WrappedContext / ArgumentMatchers aka Request scope (ra)
  * Docs: Added twitter account (ra) 

--- a/ninja-core/src/site/markdown/documentation/request_scope.md
+++ b/ninja-core/src/site/markdown/documentation/request_scope.md
@@ -36,6 +36,9 @@ Then in the controller:
 
 </pre>
 
+or even simpler, you can get the `UserInfo` injected into your controller method's arguments with
+`@Attribute("userinfo") UserInfo userInfo`.
+
 Context attributes are very similar to `ServletRequest`'s attribute, and are implement as such in
 `ninja-servlet`.
 

--- a/ninja-core/src/site/markdown/documentation/request_scope.md
+++ b/ninja-core/src/site/markdown/documentation/request_scope.md
@@ -3,27 +3,60 @@ Request scope facilities
 
 Http is all about the request. Ninja offers some facilities to handle stuff you have to
 do during a request scope. Authentication, and generating objects for a single request are
-common examples. The two major players here are:
+common examples. The three major players here are:
 
+ * Filters that add values as attributes to the context
  * Filters that wrap a context and add / remove stuff from the context.
  * ArgumentExtractors, that allow to inject arbitrary objects into a controller.
+
+Attributes in Contexts
+----------------------
+
+Filters work in a chained manner. At the end you usually call filterChain.next(context) to continue
+the filtering.
+
+This is cool, because it offers you the possibility to inject objects into the context for future
+use by other filters down the chain or the leaf controller.
+
+<pre class="prettyprint">
+
+    //////////////////////////////////////////////////////////////////////////
+    // do some stuff like connecting to your database and verifying the user.
+    //////////////////////////////////////////////////////////////////////////
+    UserInfo userInfo = …; // a complex object, e.g. retrieved from database
+    context.setAttribute("userinfo", userInfo);
+
+</pre>
+
+Then in the controller:
+
+<pre class="prettyprint">
+
+    UserInfo userInfo = context.getAttribute("userinfo", UserInfo.class);
+
+</pre>
+
+Context attributes are very similar to `ServletRequest`'s attribute, and are implement as such in
+`ninja-servlet`.
 
 
 WrappedContext in Filters
 -------------------------
 
-Filters work in a chained manner. At the end you usually call filterChain.next(context) to continue
-the filtering.
-
-This is cool, because it offers you the possibility to replace and partly overwrite the context 
+Filters also offers you the possibility to replace and partly overwrite the context
 with your own context. You can possibly even extend the Context with your own methods and
-functions. A good starting point is class WrappedContext of Ninja.
+functions. A good starting point is the class `WrappedContext` of Ninja.
 
 The following example allows you to inject an arbitrary parameter in the filter chain. This is helpful
 if you want to authorize that user by setting (or not setting) the email as parameter.
 
 
 <pre class="prettyprint">
+
+    //////////////////////////////////////////////////////////////////////////
+    // do some stuff like connecting to your database and verifying the user.
+    //////////////////////////////////////////////////////////////////////////
+    final username = "MyUserName";
 
     public class WrappedContextFilter implements Filter {
 
@@ -32,18 +65,15 @@ if you want to authorize that user by setting (or not setting) the email as para
         
             WrappedContext wrappedContext = new WrappedContext(context) {
             
-                // Overwrite the getParamter function of the context.
+                // Override the getParameter function of the context.
                 // This lets you inject parameters in your controller via @Param("username")
                 // But also have a look at ArgumentExtractors. Maybe they are a cleaner solution
                 // to your problem :)
                 public String getParameter(String key) {
                 
                     if (key.equals("username")) {
-                        //////////////////////////////////////////////////////////////////////////                    
-                        // do some stuff like connecting to your database and verifying the user. 
-                        //////////////////////////////////////////////////////////////////////////
-                        return "MyUserName";
                     
+                        return username;
                     } else {
                     
                         return getParameter(key);
@@ -62,7 +92,7 @@ if you want to authorize that user by setting (or not setting) the email as para
 
 
 
-You can then use a simple @Param("username") to inject the username of your wrapped context into the controller:
+You can then use a simple `@Param("username")` to inject the username of your wrapped context into the controller:
 
 <pre class="prettyprint">
 
@@ -93,11 +123,11 @@ Injecting stuff into your controller via
 </pre>
 
 is really nice, but what about creating your own annotations for custom controller injections? 
-Well. This is pretty simple and can be accomplished by Ninja's ArgumentExtractors. @Param is also
-just an ArgumentExtractor by the way.
+Well. This is pretty simple and can be accomplished by Ninja's `ArgumentExtractors`. `@Param` is also
+just an `ArgumentExtractor` by the way.
 
 Let's say we want to inject a User object into our controller based on e.g. logged in status. 
-First you have to define your own Annotation interface like so:
+First you have to define your own annotation interface like so:
 
 <pre class="prettyprint">
 
@@ -110,8 +140,8 @@ First you have to define your own Annotation interface like so:
     
 </pre>
 
-You can of course also use annotations with values like in @Param. But we want keep things simple for now.
-The next step is to write your own ArgumentExtractor for your User object:
+You can of course also use annotations with values like in `@Param`. But we want keep things simple for now.
+The next step is to write your own `ArgumentExtractor` for your `User` object:
 
 <pre class="prettyprint">
 
@@ -157,7 +187,7 @@ And then you can simply use that extractor as annotation in your controller to i
 </pre>
 
 
-That's almost everything you have to know about ArgumentMatchers. They really facilitate injection of arbitrary objects into
+That's almost everything you have to know about `ArgumentExtractors`. They really facilitate injection of arbitrary objects into
 your controller during a request.
 
  

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -124,6 +124,14 @@ public class ControllerMethodInvokerTest {
     }
 
     @Test
+    public void attributeAnnotatedArgumentShouldBePassed() throws Exception {
+        Dep dep = new Dep("dep");
+        when(context.getAttribute("param1", Dep.class)).thenReturn(dep);
+        create("attribute").invoke(mockController, context);
+        verify(mockController).attribute(dep);
+    }
+
+    @Test
     public void integerParamShouldBeParsedToInteger() throws Exception {
         when(context.getParameter("param1")).thenReturn("20");
         create("integerParam").invoke(mockController, context);
@@ -533,6 +541,7 @@ public class ControllerMethodInvokerTest {
         public Result param(@Param("param1") String param1);
         public Result pathParam(@PathParam("param1") String param1);
         public Result sessionParam(@SessionParam("param1") String param1);
+        public Result attribute(@Attribute("param1") Dep param1);
         public Result integerParam(@Param("param1") Integer param1);
         public Result intParam(@Param("param1") int param1);
         public Result booleanParam(@Param("param1") Boolean param1);

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -511,6 +511,21 @@ public class ContextImpl implements Context.Impl {
     }
     
     
+    @Override
+    public Object getAttribute(String name) {
+        return httpServletRequest.getAttribute(name);
+    }
+
+    @Override
+    public <T> T getAttribute(String name, Class<T> clazz) {
+        return clazz.cast(getAttribute(name));
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        httpServletRequest.setAttribute(name, value);
+    }
+
     /**
      * When a servlet engine gets a content type like:
      * "application/json" it assumes a default encoding of iso-xxxxx.

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -146,6 +148,15 @@ public class ContextImpl implements Context.Impl {
     }
 
     @Override
+    public List<String> getParameterValues(String name) {
+        String[] params = httpServletRequest.getParameterValues(name);
+        if (params == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(params);
+    }
+
+    @Override
     public String getParameter(String key, String defaultValue) {
         String parameter = getParameter(key);
 
@@ -183,12 +194,17 @@ public class ContextImpl implements Context.Impl {
     }
 
     @Override
-    public Map<String, String> getHeaders() {
-        Map<String, String> headers = new HashMap<String, String>();
-        Enumeration<String> enumeration = httpServletRequest.getHeaderNames();
-        while (enumeration.hasMoreElements()) {
-            String name = enumeration.nextElement();
-            headers.put(name, httpServletRequest.getHeader(name));
+    public List<String> getHeaders(String name) {
+        return Collections.list(httpServletRequest.getHeaders(name));
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        Map<String, List<String>> headers = new HashMap<String, List<String>>();
+        Enumeration<String> names = httpServletRequest.getHeaderNames();
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            headers.put(name, Collections.list(httpServletRequest.getHeaders(name)));
         }
         return headers;
     }


### PR DESCRIPTION
- make headers multivalued
- add `getParameterValues`; I find a never-null `List` saner than a never-empty nullable array.
- add `Context` attributes, with `@Attribute` argument extractor.
