### PR TITLE
ninja-core-demo-archetype should use fixed ninja version in pom.xml

### DIFF
--- a/ninja-core-demo-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-core-demo-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.ninjaframework</groupId>
 		<artifactId>ninja</artifactId>
-		<version>1.4-SNAPSHOT</version>
+		<version>1.4</version>
 	</parent>
 
 	<build>
@@ -64,12 +64,12 @@
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
 			<artifactId>ninja-core</artifactId>
-			<version>1.4-SNAPSHOT</version>
+			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
 			<artifactId>ninja-servlet</artifactId>
-			<version>1.4-SNAPSHOT</version>
+			<version>1.4</version>
 		</dependency>
 
 		<dependency>
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
 			<artifactId>ninja-core-test</artifactId>
-			<version>1.4-SNAPSHOT</version>
+			<version>1.4</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
ninja-core-demo-archetype is an awesome tutorial! But it doesn't work because pom.xml depends on ninja 1.4-SNAPSHOT.

Please merge this PR and re-deploy the archetype.

Thanks,
-seratch
