### PR TITLE
access the session-cookie easily in templates

### DIFF
--- a/ninja-core-demo/src/main/java/controllers/ApplicationController.java
+++ b/ninja-core-demo/src/main/java/controllers/ApplicationController.java
@@ -103,8 +103,9 @@ public class ApplicationController {
 
     public Result session(Context context) {
         context.getSessionCookie().put("username", "kevin");
+        //context.getSessionCookie().put("", "");
 
-        return Results.html().render(context.getSessionCookie().getData());
+        return Results.html();//.render(context.getSessionCookie().getData());
 
     }
 

--- a/ninja-core-demo/src/main/java/controllers/ApplicationController.java
+++ b/ninja-core-demo/src/main/java/controllers/ApplicationController.java
@@ -102,10 +102,10 @@ public class ApplicationController {
     }
 
     public Result session(Context context) {
+    	//Sets the username "kevin" in the session-cookie
         context.getSessionCookie().put("username", "kevin");
-        //context.getSessionCookie().put("", "");
 
-        return Results.html();//.render(context.getSessionCookie().getData());
+        return Results.html();
 
     }
 

--- a/ninja-core-demo/src/main/java/views/ApplicationController/session.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/session.ftl.html
@@ -9,7 +9,7 @@
 
 <h2>You now got a session cookie attached to your browsing session.</h2>
 <p>
-And currently the username stored in the session is: <b>${username}</b><br/>
+And currently the username stored in the session is: <b>${session.username}</b><br/>
 They can be easily accessed in your template by calling the key as variable.
 <p>
 <p>

--- a/ninja-core-demo/src/main/java/views/ApplicationController/session.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/session.ftl.html
@@ -9,7 +9,8 @@
 
 <h2>You now got a session cookie attached to your browsing session.</h2>
 <p>
-And currently the username stored in the session is: <b>${username}</b>
+And currently the username stored in the session is: <b>${username}</b><br/>
+They can be easily accessed in your template by calling the key as variable.
 <p>
 <p>
 If you use firebug or any other tool you can spot the session attached to the request.

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -134,7 +134,7 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         // put all entries of the session cookie to the map.
         // You can access the values by their key in the cookie
         if (!context.getSessionCookie().isEmpty()) {
-            map.putAll(context.getSessionCookie().getData());
+            map.put("session", context.getSessionCookie().getData());
         }
 
         // merge messages with this template...

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -130,7 +130,13 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         if (language.isPresent()) {
             map.put("lang", language.get());
         }
-        
+
+        // put all entries of the session cookie to the map.
+        // You can access the values by their key in the cookie
+        if (!context.getSessionCookie().isEmpty()) {
+            map.putAll(context.getSessionCookie().getData());
+        }
+
         // merge messages with this template...
         Map<Object, Object> i18nMap = messages.getAll(context, Optional.of(result));
         map.putAll(i18nMap);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,7 @@
+Version 1.5
+===========
+ * Added an easy way to access the Session-Cookie-Values in every template (pthum)
+
 Version 1.4.2
 =============
 

--- a/ninja-core/src/site/markdown/documentation/html_templating.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating.md
@@ -284,4 +284,5 @@ Implicit variables available in templates
 -----------------------------------------
 
  * ${lang} resolves to the language Ninja uses currently. 
-    
+ * You can access all session-cookie values by their keys. E.g.: If you had set a cookie with the key "username", then you can use ${username} to 
+    resolve the username and display it.

--- a/ninja-core/src/site/markdown/documentation/html_templating.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating.md
@@ -284,5 +284,4 @@ Implicit variables available in templates
 -----------------------------------------
 
  * ${lang} resolves to the language Ninja uses currently. 
- * You can access all session-cookie values by their keys. E.g.: If you had set a cookie with the key "username", then you can use ${username} to 
-    resolve the username and display it.
+ * You can access all session-cookie values by their keys prefixed with the accessor "session.". E.g.: If you had set a cookie with the key "username", then you can use ${session.username} to resolve the username and display it.

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -34,6 +34,7 @@ contributed to Ninja. In some random order:
  * Anatoly Zozlinsky aka zoza (zoza)
  * Thomas Broyer (tbroyer)
  * Seratch
+ * Patrick Thum (pthum)
 
 Do you feel you are missing from that list? Please let us know - this did not happen
 intentionally. You can even add yourself to the list:


### PR DESCRIPTION
Until now, you had to pass e.g. the username manually in every controller-method to render it in a template. Now, the values of the session-cookie will be added to every template and can be accessed by calling the key as variable in the template (this can be useful for an individualized header for logged-in users).

I don't know if this is a good solution. Maybe its better to add a variable to the application.conf and check whether this set to true? Another possibility may be to prefix all keys (like shown here: http://www.java2s.com/Tutorial/Java/0140__Collections/Clonesamapandprefixesthekeysintheclone.htm ). But this could lower the performance... 
