### PR TITLE
Bigfix messages parsing

### DIFF
--- a/ninja-core-demo-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-core-demo-archetype/src/main/resources/archetype-resources/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
 			<artifactId>ninja-servlet</artifactId>
-			<version>1.4.3</version>
+			<version>1.4.4</version>
 		</dependency>
 
 		<dependency>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
 			<artifactId>ninja-core-test</artifactId>
-			<version>1.4.3</version>
+			<version>1.4.4</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/conf/messages.de.properties
+++ b/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/conf/messages.de.properties
@@ -18,4 +18,4 @@ ${symbol_pound} limitations under the License.
 ${symbol_pound}
 
 ${symbol_pound} This file is utf-8
-i18nHello=Hallo - das ist eine internationalisierte Nachricht in der Templating Engine
+hello=Hallo - das ist eine internationalisierte Nachricht in der Templating Engine

--- a/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/conf/messages.properties
+++ b/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/conf/messages.properties
@@ -18,4 +18,4 @@ ${symbol_pound} limitations under the License.
 ${symbol_pound}
 
 ${symbol_pound} This file is utf-8
-i18nHello=Hello - this is an i18n message in the templating engine
+hello=Hello - this is an i18n message in the templating engine

--- a/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/views/I18nController/index.ftl.html
+++ b/ninja-core-demo-archetype/src/main/resources/archetype-resources/src/main/java/views/I18nController/index.ftl.html
@@ -13,7 +13,7 @@
 
 <h2>I18n in the templates</h2>
 <ul>
-	<h1>${symbol_dollar}{i18nHello}</h1>
+	<h1>${symbol_dollar}{i18n("hello")}</h1>
 	
 	<li>Implicit language is: ${symbol_dollar}{lang}</li>
 	

--- a/ninja-core-demo/src/main/java/conf/Routes.java
+++ b/ninja-core-demo/src/main/java/conf/Routes.java
@@ -70,7 +70,11 @@ public class Routes implements ApplicationRoutes {
         router.GET().route("/redirect").with(ApplicationController.class, "redirect");
 
         router.GET().route("/session").with(ApplicationController.class, "session");
-
+        
+        router.GET().route("/flash_success").with(ApplicationController.class, "flashSuccess");
+        router.GET().route("/flash_error").with(ApplicationController.class, "flashError");
+        router.GET().route("/flash_any").with(ApplicationController.class, "flashAny");
+        
         router.GET().route("/htmlEscaping").with(ApplicationController.class, "htmlEscaping");
 
         // /////////////////////////////////////////////////////////////////////

--- a/ninja-core-demo/src/main/java/conf/messages.de.properties
+++ b/ninja-core-demo/src/main/java/conf/messages.de.properties
@@ -15,4 +15,4 @@
 #
 
 # This file is utf-8
-i18nHello=Hallo - das ist eine internationalisierte Nachricht in der Templating Engine
+hello=Hallo - das ist eine internationalisierte Nachricht in der Templating Engine mit placeholder: {0}

--- a/ninja-core-demo/src/main/java/conf/messages.properties
+++ b/ninja-core-demo/src/main/java/conf/messages.properties
@@ -15,4 +15,9 @@
 #
 
 # This file is utf-8
-i18nHello=Hello - this is an i18n message in the templating engine
+hello=Hello - this is an i18n message in the templating engine with placeholder: {0}
+
+# some i18n flash messages => they all contain {0} to make sure message formatting works.
+flashSuccess=This is a flashed success - with placeholder: {0}
+flashError=This is a flashed error - with placeholder: {0}
+flashAny=This is an arbitrary message as flash message - with placeholder: {0}

--- a/ninja-core-demo/src/main/java/controllers/ApplicationController.java
+++ b/ninja-core-demo/src/main/java/controllers/ApplicationController.java
@@ -24,6 +24,7 @@ import ninja.Context;
 import ninja.Result;
 import ninja.Results;
 import ninja.i18n.Lang;
+import ninja.i18n.Messages;
 import ninja.params.Param;
 import ninja.params.PathParam;
 import ninja.validation.Required;
@@ -31,6 +32,7 @@ import ninja.validation.Validation;
 
 import org.slf4j.Logger;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -49,6 +51,9 @@ public class ApplicationController {
 
     @Inject
     Lang lang;
+    
+    @Inject
+    Messages messages;
 
     public Result examples(Context context) {
         logger.info("In example ");
@@ -89,7 +94,8 @@ public class ApplicationController {
                              @Param("email") @Required String email) {
 
         if (validation.hasViolations()) {
-            return Results.json().render(validation.getFieldViolations("email"));
+            return Results.json()
+                    .render(validation.getFieldViolations("email"));
         } else {
             return Results.json().render(email);
         }
@@ -102,10 +108,48 @@ public class ApplicationController {
     }
 
     public Result session(Context context) {
-    	//Sets the username "kevin" in the session-cookie
+        // Sets the username "kevin" in the session-cookie
         context.getSessionCookie().put("username", "kevin");
 
         return Results.html();
+
+    }
+
+    public Result flashSuccess(Context context) {
+        
+        Result result = Results.html();
+        
+        // sets a 18n flash message and adds a timestamp to make sure formatting works
+        Optional<String> flashMessage = messages.get("flashSuccess", context, Optional.of(result), "PLACEHOLDER");
+        if (flashMessage.isPresent()) {
+            context.getFlashCookie().success(flashMessage.get());
+        }
+
+        return result;
+
+    }
+    
+    public Result flashError(Context context) {
+        Result result = Results.html();
+        // sets a 18n flash message and adds a timestamp to make sure formatting works
+        Optional<String> flashMessage = messages.get("flashError", context, Optional.of(result), "PLACEHOLDER");
+        if (flashMessage.isPresent()) {
+            context.getFlashCookie().error(flashMessage.get());
+        }
+
+        return result;
+
+    }
+    
+    public Result flashAny(Context context) {
+        Result result = Results.html();
+        // sets a 18n flash message and adds a timestamp to make sure formatting works
+        Optional<String> flashMessage = messages.get("flashAny", context, Optional.of(result), "PLACEHOLDER");
+        if (flashMessage.isPresent()) {
+            context.getFlashCookie().put("any", flashMessage.get());
+        }
+
+        return result;
 
     }
 
@@ -114,6 +158,7 @@ public class ApplicationController {
         return Results.html();
 
     }
+
     public Result postContactForm(Context context, Contact contact) {
         // contact is parsed into the method
         // and automatically gets rendered via the html

--- a/ninja-core-demo/src/main/java/views/ApplicationController/examples.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/examples.ftl.html
@@ -63,8 +63,11 @@
 	<li>To transmit small bits of information from one request to
 		another Ninja supports so called flash cookies. They transmit eg a
 		error message from one request to another. Usually flash cookies only
-		live for one request: <a href="/TODO">/TODO</a>
+		live for one request.
 	</li>
+	<li>Success message via flash cookie: <a href="/flash_success">/flash_success</a></li>
+	<li>Error message via flash cookie: <a href="/flash_error">/flash_error</a></li>
+	<li>An arbitrary flash message: <a href="/flash_any">/flash_any</a></li>
 </ul>
 
 

--- a/ninja-core-demo/src/main/java/views/ApplicationController/flashAny.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/flashAny.ftl.html
@@ -1,0 +1,23 @@
+<#import "../layout/defaultLayout.ftl.html" as layout> <@layout.myLayout
+"Home page">
+
+<header class="jumbotron subhead">
+    <h1>Flash Cookie support</h1>
+</header>
+
+<hr>
+
+<h2>This page displays a flash cookie.</h2>
+<p>
+<#if flash_any??>
+        An arbitrary flash message: <p class="success">${flash_any}</p>
+</#if>
+<p>
+<p>
+You can use firebug or any other tool you can spot the flash cookie attached to the request.
+</p>
+<p>
+If you move to another page the cookie will go away.
+</p>
+
+</@layout.myLayout>

--- a/ninja-core-demo/src/main/java/views/ApplicationController/flashError.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/flashError.ftl.html
@@ -1,0 +1,23 @@
+<#import "../layout/defaultLayout.ftl.html" as layout> <@layout.myLayout
+"Home page">
+
+<header class="jumbotron subhead">
+    <h1>Flash Cookie support</h1>
+</header>
+
+<hr>
+
+<h2>This page displays a flash cookie.</h2>
+<p>
+<#if flash_error??>
+        Error cookie: <p class="success">${flash_error}</p>
+</#if>
+<p>
+<p>
+You can use firebug or any other tool you can spot the flash cookie attached to the request.
+</p>
+<p>
+If you move to another page the cookie will go away.
+</p>
+
+</@layout.myLayout>

--- a/ninja-core-demo/src/main/java/views/ApplicationController/flashSuccess.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/flashSuccess.ftl.html
@@ -1,0 +1,23 @@
+<#import "../layout/defaultLayout.ftl.html" as layout> <@layout.myLayout
+"Home page">
+
+<header class="jumbotron subhead">
+    <h1>Flash Cookie support</h1>
+</header>
+
+<hr>
+
+<h2>This page displays a flash cookie.</h2>
+<p>
+<#if flash_success??>
+        Success cookie: <p class="success">${flash_success}</p>
+</#if>
+<p>
+<p>
+You can use firebug or any other tool you can spot the flash cookie attached to the request.
+</p>
+<p>
+If you move to another page the cookie will go away.
+</p>
+
+</@layout.myLayout>

--- a/ninja-core-demo/src/main/java/views/ApplicationController/index.ftl.html
+++ b/ninja-core-demo/src/main/java/views/ApplicationController/index.ftl.html
@@ -7,9 +7,7 @@
 	<p>And developing large web applications becomes fun again.</p>
 </div>
 
-<#if flash_success??>
-        <p class="success">${flash_success}</p>
-</#if>
+
 <!-- Example row of columns -->
 <div class="row">
 	<div class="span4">

--- a/ninja-core-demo/src/main/java/views/I18nController/index.ftl.html
+++ b/ninja-core-demo/src/main/java/views/I18nController/index.ftl.html
@@ -10,7 +10,7 @@
 
 <h2>I18n in the templates</h2>
 <ul>
-	<h1>${i18nHello}</h1>
+	<h1>${i18n("hello", "Yea!")}</h1>
 	
 	<li>Implicit language is: ${lang}</li>
 	

--- a/ninja-core-demo/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-core-demo/src/test/java/controllers/ApplicationControllerTest.java
@@ -150,5 +150,40 @@ public class ApplicationControllerTest extends NinjaTest {
 
 
     }
+    
+    @Test
+    public void testFlashSuccessWorks() {
+
+        String response =
+                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_success");
+
+        System.out.println("repinse: " +response);
+        // And assert that stuff is visible on page:
+        assertTrue(response.contains("This is a flashed success - with placeholder: PLACEHOLDER"));
+
+    }
+    
+    @Test
+    public void testFlashErrorWorks() {
+
+        String response =
+                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_error");
+        
+        System.out.println("repinse: " +response);
+        // And assert that stuff is visible on page:
+        assertTrue(response.contains("This is a flashed error - with placeholder: PLACEHOLDER"));
+
+    }
+    
+    @Test
+    public void testFlashAnyWorks() {
+
+        String response =
+                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_any");
+
+        // And assert that stuff is visible on page:
+        assertTrue(response.contains("This is an arbitrary message as flash message - with placeholder: PLACEHOLDER"));
+
+    }
 
 }

--- a/ninja-core-demo/src/test/java/controllers/I18nControllerTest.java
+++ b/ninja-core-demo/src/test/java/controllers/I18nControllerTest.java
@@ -30,8 +30,8 @@ import com.google.common.collect.Maps;
 
 public class I18nControllerTest extends NinjaTest {
     
-    String TEXT_EN = "Hello - this is an i18n message in the templating engine";
-    String TEXT_DE = "Hallo - das ist eine internationalisierte Nachricht in der Templating Engine";
+    String TEXT_EN = "Hello - this is an i18n message in the templating engine with placeholder: Yea!";
+    String TEXT_DE = "Hallo - das ist eine internationalisierte Nachricht in der Templating Engine mit placeholder: Yea!";
 
     @Test
     public void testThatI18nWorksEn() {

--- a/ninja-core/src/main/java/ninja/session/FlashCookie.java
+++ b/ninja-core/src/main/java/ninja/session/FlashCookie.java
@@ -16,6 +16,7 @@
 
 package ninja.session;
 
+import java.text.MessageFormat;
 import java.util.Map;
 
 import ninja.Context;
@@ -44,9 +45,23 @@ public interface FlashCookie {
 
     void now(String key, String value);
 
-    void error(String value, Object... args);
+    /**
+     * Sets the error flash cookie value.
+     * Usually accessible via ${flash_error} in html templating engine.
+     * 
+     * @param value The i18n key used to retrieve value of that message
+     *        OR an already translated message that will be displayed right away.
+     */
+    void error(String value);
 
-    void success(String value, Object... args);
+    /**
+     * Sets the success flash cookie value.
+     * Usually accessible via ${flash_success} in html templating engine.
+     * 
+     * @param value The i18n key used to retrieve value of that message
+     *        OR an already translated message that will be displayed right away.
+     */
+    void success(String value);
 
     void discard(String key);
 

--- a/ninja-core/src/main/java/ninja/session/FlashCookieImpl.java
+++ b/ninja-core/src/main/java/ninja/session/FlashCookieImpl.java
@@ -19,8 +19,8 @@ package ninja.session;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.text.MessageFormat;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -158,13 +158,13 @@ public class FlashCookieImpl implements FlashCookie {
     }
 
     @Override
-    public void error(String value, Object... args) {
-        put("error", String.format(value, args));
+    public void error(String value) {
+        put("error", value);
     }
 
     @Override
-    public void success(String value, Object... args) {
-        put("success", String.format(value, args));
+    public void success(String value) {
+        put("success", value);
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
@@ -1,0 +1,92 @@
+package ninja.template;
+
+import java.util.List;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.i18n.Messages;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+import freemarker.template.SimpleNumber;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+public class TemplateEngineFreemarkerI18nMethod implements
+        TemplateMethodModelEx {
+
+    Messages messages;
+    Context context;
+    Optional<Result> result;
+
+    public TemplateEngineFreemarkerI18nMethod(Messages messages,
+                                              Context context,
+                                              Result result) {
+        this.messages = messages;
+        this.context = context;
+        this.result = Optional.of(result);
+
+    }
+
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+        if (args.size() == 0) {
+
+            throw new TemplateModelException(
+                    "Using i18n without any key is not possible.");
+
+        } else if (args.size() == 1) {
+
+            Optional<String> optionalString = messages
+                    .get(((SimpleScalar) args.get(0)).getAsString(), context,
+                            result);
+
+            if (!optionalString.isPresent()) {
+                throw new TemplateModelException(
+                        "Could not find translated message for: "
+                                + (((SimpleScalar) args.get(0)).getAsString()));
+
+            } else {
+                return new SimpleScalar(optionalString.get());
+            }
+
+        } else if (args.size() > 1) {
+
+            List<String> strings = Lists.newArrayList();
+            
+            for (Object o : args) {
+                
+                // We currently allow only numbers and strings as arguments
+                if (o instanceof SimpleScalar) {
+                    strings.add(((SimpleScalar) o).getAsString());
+                } else if  (o instanceof SimpleNumber) {
+                    strings.add(((SimpleNumber) o).toString());
+                }
+                
+            }
+
+            Optional<String> optionalString = messages.get(strings.get(0),
+                    context, result, strings.subList(1, strings.size())
+                            .toArray());
+
+            if (!optionalString.isPresent()) {
+                throw new TemplateModelException(
+                        "Could not find translated message for: "
+                                + (((SimpleScalar) args.get(0)).getAsString()));
+
+            } else {
+                return new SimpleScalar(optionalString.get());
+            }
+
+        } else {
+
+            throw new TemplateModelException(
+                    "Using i18n without any key is not possible.");
+
+        }
+
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,11 +1,9 @@
 Version X
-=========
-
- * Your changes (author)
-
-Version 1.4.4
 =============
+
  * Added possibility to get the contextpath in templates (pthum)
+ * Fixed bug when translating flash scope i18n (pthum, ra)
+ * Added better i18n facilities to html tempting (ra)
 
 Version 1.4.3
 =============

--- a/ninja-core/src/site/markdown/documentation/html_templating.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating.md
@@ -283,6 +283,14 @@ The message itself is being translated.
 Implicit variables available in templates
 -----------------------------------------
 
+ * ${session.*} You can access all session-cookie values by their keys prefixed with the accessor "session.". E.g.: 
+   If you had set a cookie with the key "username", then you can use ${session.username} to resolve the 
+   username and display it.
+ * ${flash_success} Translated (if possible) flash success message (via success("value")).
+ * ${flash_error} Translated (if possible) flash error message (via error("value")).
+ * ${flash_*} Translated (if possible) flash message with arbitrary key (via put("key", "value")).
  * ${lang} resolves to the language Ninja uses currently. 
- * You can access all session-cookie values by their keys prefixed with the accessor "session.". E.g.: If you had set a cookie with the key "username", then you can use ${session.username} to resolve the username and display it.
- *${contextPath} resolves the context path of the application (empty if running on root)
+ * ${contextPath} resolves the context path of the application (empty if running on root)
+
+ 
+

--- a/ninja-core/src/site/markdown/documentation/internationalization.md
+++ b/ninja-core/src/site/markdown/documentation/internationalization.md
@@ -33,22 +33,21 @@ conf/messages.en.properties might look like:
 
 <pre class="prettyprint">
     # registration.ftl.html
-    i18nCasinoRegistrationTitle=Register
-    i18nCasinoRegistrationEmail=Your email
-    i18nCasinoRegistrationConfirm=Confirm
-    i18nCasinoRegistrationAcceptTermsOfService=Accept terms of service          
-    i18nCasinoRegistrationRegister=Register
+    casinoRegistrationTitle=Register
+    casinoRegistrationEmail=Your email
+    casinoRegistrationConfirm=Confirm
+    casinoRegistrationAcceptTermsOfService=Accept terms of service          
+    casinoRegistrationRegister=Register
 
     # registrationPending.ftl.html
-    i18nRegistrationPleaseVerifyEmailAddress=Please check your email inbox to verify your account.
-    i18nRegistrationPendingError=Error confirming email.
-    i18nRegistrationPendingSuccess=Success confirming email.  
+    registrationPleaseVerifyEmailAddress=Please check your email inbox to verify your account.
+    registrationPendingError=Error confirming email.
+    registrationPendingSuccess=Success confirming email.  
 </pre>
 
-Two important things:
+One important thing:
 
- * Use camelCaseWriting for your messages
- * Start your message ALWAYS with i18n
+ * Use ONLY camelCaseWriting for your messages
 
 
 Getting a message inside your code
@@ -86,7 +85,7 @@ Inside a freemarker template (ftl.html) you can get internationalized messages b
 
     <html>
         <head>
-            <title>${i18nCasinoRegistrationTitle}</title>
+            <title>${i18n("casinoRegistrationTitle")}</title>
         </head>
     <html>
 

--- a/ninja-core/src/site/markdown/documentation/upgrading_to_current_version.md
+++ b/ninja-core/src/site/markdown/documentation/upgrading_to_current_version.md
@@ -1,6 +1,17 @@
 Upgrading to latest Ninja
 =========================
 
+From 1.4 to 1.X
+---------------
+
+Improvements in i18n. You can now use the following snipplet to include i18n into your templates:
+${i18n("myMessageKey")}. Using ${i18nMyMessageKey} will be deprecated soon. Don't use it.
+
+With the new i18n facilities you can now also format your messages with variables of your template:
+
+${i18n("myMessageKey", myVariable)}.
+
+
 From 1.2 to 1.3
 ---------------
 


### PR DESCRIPTION
- fixes an issue with flash cookies and their translation
- adds the much better option to translate messages inside the template via ${i18n(messageKey, parameters...}
