### PR TITLE
Support for skipping rendering of HttpBody via NoHttpBody class

### DIFF
--- a/ninja-core/src/main/java/ninja/Results.java
+++ b/ninja-core/src/main/java/ninja/Results.java
@@ -16,6 +16,8 @@
 
 package ninja;
 
+import ninja.utils.NoHttpBody;
+
 
 /**
  * Convenience methods for the generation of Results.
@@ -53,7 +55,8 @@ public class Results {
     }
 
     public static Result noContent() {
-        return status(Result.SC_204_NO_CONTENT);
+        return status(Result.SC_204_NO_CONTENT)
+                .render(new NoHttpBody());
     }
 
     public static Result internalServerError() {
@@ -63,15 +66,23 @@ public class Results {
     /**
      * A redirect that uses 303 see other.
      * 
+     * The redirect does NOT need a template and does NOT
+     * render a text in the Http body by default. 
+     * 
+     * If you wish to do so please
+     * remove the {@link NoHttpBody} that is set as renderable of
+     * the Result.
+     * 
      * @param url
      *            The url used as redirect target.
      * @return A nicely configured result with status code 303 and the url set
-     *         as Location header.
+     *         as Location header. Renders no Http body by default.
      */
     public static Result redirect(String url) {
 
         Result result = status(Result.SC_303_SEE_OTHER);
         result.addHeader(Result.LOCATION, url);
+        result.render(new NoHttpBody());
 
         return result;
     }
@@ -79,15 +90,23 @@ public class Results {
     /**
      * A redirect that uses 307 see other.
      * 
+     * The redirect does NOT need a template and does NOT
+     * render a text in the Http body by default. 
+     * 
+     * If you wish to do so please
+     * remove the {@link NoHttpBody} that is set as renderable of
+     * the Result.
+     * 
      * @param url
      *            The url used as redirect target.
      * @return A nicely configured result with status code 307 and the url set
-     *         as Location header.
+     *         as Location header. Renders no Http body by default.
      */
     public static Result redirectTemporary(String url) {
 
         Result result = status(Result.SC_307_TEMPORARY_REDIRECT);
         result.addHeader(Result.LOCATION, url);
+        result.render(new NoHttpBody());
 
         return result;
     }

--- a/ninja-core/src/main/java/ninja/utils/NoHttpBody.java
+++ b/ninja-core/src/main/java/ninja/utils/NoHttpBody.java
@@ -1,0 +1,14 @@
+package ninja.utils;
+
+/**
+ * This is a marker class used to handle Results in {@link ResultHandler}.
+ * 
+ * It causes the ResultHandler to render no body, just the header. Useful
+ * when issuing a redirect and no corresponding content should be shown.
+ * 
+ * @author ra
+ *
+ */
+public class NoHttpBody {
+    // intentionally left empty. Just a marker class.
+}

--- a/ninja-core/src/main/java/ninja/utils/ResultHandler.java
+++ b/ninja-core/src/main/java/ninja/utils/ResultHandler.java
@@ -54,13 +54,13 @@ public class ResultHandler {
             return;
         }
         
-        Object object = result.getRenderable();
+        Object objectToBeRendered = result.getRenderable();
 
-        if (object instanceof Renderable) {
+        if (objectToBeRendered instanceof Renderable) {
             // if the object is a renderable it should do everything itself...:
             // make sure to call context.finalizeHeaders(result) with the
             // results you want to set...
-            handleRenderable((Renderable) object, context, result);
+            handleRenderable((Renderable) objectToBeRendered, context, result);
         } else {
             
             // if content type is not yet set in result we copy it over from the
@@ -74,8 +74,18 @@ public class ResultHandler {
             if (!result.getHeaders().containsKey(Result.CACHE_CONTROL)) {
                 result.doNotCacheContent();
             }
-
-            renderWithTemplateEngine(context, result);
+            
+            if (objectToBeRendered instanceof NoHttpBody) {
+                // This indicates that we do not want to render anything in the body.
+                // Can be used e.g. for a 204 No Content response.
+                // and surpasses the rendering engines.
+                context.finalizeHeaders(result);
+                
+            } else {
+                // normal mode of operation: we render the stuff via the
+                // template renderer.
+                renderWithTemplateEngine(context, result);
+            }
         }
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,8 +1,7 @@
 Version X
 =========
 
- * Your changes go here
-
+ * 2013-07-15 Support for skipping rendering of HttpBody via NoHttpBody class (useful in redirects eg) (makotan, pthum, ra)
 
 Version 1.5
 ===========

--- a/ninja-core/src/site/markdown/documentation/upgrading_to_current_version.md
+++ b/ninja-core/src/site/markdown/documentation/upgrading_to_current_version.md
@@ -1,7 +1,17 @@
 Upgrading to latest Ninja
 =========================
 
-From 1.4 to 1.X
+
+Upgrading to 1.X
+----------------
+
+If you are using Results.redirectTemporary(...) / Results.redirect(...) or Results.noContent()
+AND if you are using a http body to indicate something (like a hyperlink text) you have to set
+result.render(null) to remove the NoHttpResult. Otherwise nothing will change for you. You simply
+don't need a html template by default any more.
+
+
+Upgrading to 1.4
 ---------------
 
 Improvements in i18n. You can now use the following snipplet to include i18n into your templates:

--- a/ninja-core/src/test/java/ninja/ResultsTest.java
+++ b/ninja-core/src/test/java/ninja/ResultsTest.java
@@ -18,6 +18,7 @@ package ninja;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import ninja.utils.NoHttpBody;
 
 import org.junit.Test;
 
@@ -68,6 +69,7 @@ public class ResultsTest {
 
         Result result = Results.noContent();
         assertEquals(Result.SC_204_NO_CONTENT, result.getStatusCode());
+        assertTrue(result.getRenderable() instanceof NoHttpBody);
 
     }
 
@@ -87,6 +89,7 @@ public class ResultsTest {
         assertEquals(Result.SC_303_SEE_OTHER, result.getStatusCode());
         assertEquals("http://example.com",
                 result.getHeaders().get(Result.LOCATION));
+        assertTrue(result.getRenderable() instanceof NoHttpBody);
 
     }
 
@@ -97,6 +100,7 @@ public class ResultsTest {
         assertEquals(Result.SC_307_TEMPORARY_REDIRECT, result.getStatusCode());
         assertEquals("http://example.com",
                 result.getHeaders().get(Result.LOCATION));
+        assertTrue(result.getRenderable() instanceof NoHttpBody);
     }
 
     @Test


### PR DESCRIPTION
As discussed in https://github.com/ninjaframework/ninja/pull/101
