### PR TITLE
Exclude type:String from being converted to JSON string again

### DIFF
--- a/ninja-core-demo/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-core-demo/src/test/java/controllers/ApplicationControllerTest.java
@@ -119,7 +119,7 @@ public class ApplicationControllerTest extends NinjaTest {
                         + "validation?email=john@example.com");
 
         // And assert that stuff is visible on page:
-        assertEquals(response, "\"john@example.com\"");
+        assertEquals("john@example.com", response);
 
         response = ninjaTestBrowser.makeRequest(getServerAddress() + "validation");
 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
@@ -33,7 +33,7 @@ import com.google.inject.Singleton;
 public class TemplateEngineJson implements TemplateEngine {
 
     private final Logger logger;
-    
+
     private final ObjectMapper objectMapper;
 
     @Inject
@@ -46,19 +46,21 @@ public class TemplateEngineJson implements TemplateEngine {
     public void invoke(Context context, Result result) {
 
         ResponseStreams responseStreams = context.finalizeHeaders(result);
-        
+        // Strings needs to be bypassed.
         try {
-            
-            OutputStream outputStream  = responseStreams.getOutputStream();
-            objectMapper.writeValue(outputStream, result.getRenderable());
+            OutputStream outputStream = responseStreams.getOutputStream();
+            Object obj = result.getRenderable();
+            if (obj instanceof String) {
+                outputStream.write(((String) obj).getBytes());
+            } else {
+                objectMapper.writeValue(outputStream, obj);
+            }
             outputStream.close();
-            
+
         } catch (IOException e) {
 
             logger.error("Error while rendering json", e);
         }
-        
-
     }
 
     @Override


### PR DESCRIPTION
objectMapper.writeValue(OutputStream, String) will adorn the String with extra quotes. Which is in fact an invalid JSON according to the RFC 4627. I believe we should bypass if the type is String. 
Moreover this will give users flexibility to use any other JSON serializer in application if they need.
