### PR TITLE
Fixed wrong encoding of post parameters with tomcat

### DIFF
--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -94,6 +94,8 @@ public class ContextImpl implements Context.Impl {
         this.httpServletRequest = httpServletRequest;
         this.httpServletResponse = httpServletResponse;
 
+        enforceCorrectEncodingOfRequest();
+
         // init flash scope:
         flashScope.init(this);
 
@@ -360,17 +362,11 @@ public class ContextImpl implements Context.Impl {
 
     @Override
     public InputStream getInputStream() throws IOException {
-
-        enforeCorrectEncodingOfRequest();
-
         return httpServletRequest.getInputStream();
     }
 
     @Override
     public BufferedReader getReader() throws IOException {
-
-        enforeCorrectEncodingOfRequest();
-
         return httpServletRequest.getReader();
     }
 
@@ -575,7 +571,7 @@ public class ContextImpl implements Context.Impl {
      * 
      * Therefore we'll set utf-8 as request encoding if it is not set.
      */
-    private void enforeCorrectEncodingOfRequest() {
+    private void enforceCorrectEncodingOfRequest() {
         
         String charset = NinjaConstant.UTF_8;
         

--- a/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
@@ -638,15 +638,20 @@ public class ContextImplTest {
        public Long count;
     }
 
+    /**
+     * Make sure the correct character encoding is set after init.
+     */
+    @Test
+    public void testInitEnforcingOfCorrectEncoding() throws Exception {
+        context.init(httpServletRequest, httpServletResponse);
+
+        //this proofs that the encoding has been set:
+        verify(httpServletRequest).setCharacterEncoding(NinjaConstant.UTF_8);
+    }
 
     /**
      * Make sure the correct character encoding is set before the
      * reader is returned.
-     *
-     *
-     * Otherwise we might get strange default encodings
-     * from the servlet engine.
-     *
      */
     @Test
     public void testGetReaderEnforcingOfCorrectEncoding() throws Exception {
@@ -663,10 +668,6 @@ public class ContextImplTest {
     /**
      * Make sure the correct character encoding is set before the
      * inputStream is returned.
-     *
-     * Otherwise we might get strange default encodings
-     * from the servlet engine.
-     *
      */
     @Test
     public void testGetInputStreamEnforcingOfCorrectEncoding() throws Exception {


### PR DESCRIPTION
I want to use Ninja web framework 3.0.0 with Apache Tomcat 7.0.50.
But I found a problem: HTML POST parameters are not encoded by UTF-8.

Default encoding of application servers:

|  | GET | POST |
| --- | --- | --- |
| Jetty 9.1.1 | UTF-8 | UTF-8 |
| Tomcat 7.0.50 | ISO-8859-1 or UTF-8(URIEncoding="UTF-8") | ISO-8859-1 |

I think that `HttpServletRequest#setCharacterEncoding("utf-8")` should be invoked in any case.

I tested with below repository.
[mallowlabs/ninja-encoding-test](https://github.com/mallowlabs/ninja-encoding-test)
