### PR TITLE
changed Result.NO_HTTP_CONTENT to Result.NO_HTTP_BODY in changelog.md

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -13,7 +13,7 @@ Version 3.1.4
 
  * 2014-04-06 Fixed bug (#165) that caused that html template caching did 
               not work properly. (Nomi + ra)
- * 2014-03-28 Added support for static Result.NO_HTTP_CONTENT. No need
+ * 2014-03-28 Added support for static Result.NO_HTTP_BODY. No need
               to create new() class all the time. (ra)
 
 Version 3.1.3


### PR DESCRIPTION
This is very minor, but there is no Result.NO_HTTP_CONTENT. Should be Result.NO_HTTP_BODY.
