### PR TITLE
Added a getHostname() method to the context.  

### DIFF
--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -88,6 +88,15 @@ public interface Context {
     String getRequestUri();
 
     /**
+     * Returns the hostname as seen by the server.
+     *
+     * http://example.com/index would return "example.com".
+     *
+     * @return the host name as seen by the server
+     */
+    String getHostname();
+
+    /**
      * Returns the path that Ninja should act upon.
      * 
      * For instance in servlets you could have soemthing like a context prefix.

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -46,6 +46,11 @@ public class WrappedContext implements Context {
     }
 
     @Override
+    public String getHostname() {
+        return wrapped.getHostname();
+    }
+
+    @Override
     public FlashScope getFlashCookie() {
         return wrapped.getFlashCookie();
     }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2014-05-08 Added getHostname() method to context as a wrapper to getting the Host header.
  * 2014-05-08 Fixed issue #173. NinjaJetty was listening on two http ports.
  * 2014-04-27 Added possibility to define custom package for application
               module and routes (avarabyeu)
@@ -9,7 +10,6 @@ Version X.X.X
  * 2014-04-10 Support getInjector() on FluentLenium testcases (ra)
  * 2014-04-07 Logback is now only configured when on classpath. Allows to use
               jul logging on App Engine. (Nomi + ra)
-
 
 Version 3.1.4
 =============

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -32,6 +32,7 @@ contributed to Ninja. In some random order:
  * Mikko Oksa (metacity)
  * Zoran Zaric
  * Andrei Varabyeu (avarabyeu)
+ * Matt Jones (mattjonesorg)
 
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -327,7 +327,9 @@ public class ContextImpl implements Context.Impl {
     }
 
     @Override
-    public String getHostname() { return httpServletRequest.getHeader("host"); }
+    public String getHostname() {
+        return httpServletRequest.getHeader("host");
+    }
 
     public void handleAsync() {
         synchronized (asyncLock) {

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -326,6 +326,9 @@ public class ContextImpl implements Context.Impl {
         return httpServletRequest.getRequestURI();
     }
 
+    @Override
+    public String getHostname() { return httpServletRequest.getHeader("host"); }
+
     public void handleAsync() {
         synchronized (asyncLock) {
             if (asyncStrategy == null) {

--- a/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
@@ -110,6 +110,19 @@ public class ContextImplTest {
     }
 
     @Test
+    public void testGetHostname() {
+
+        //say the httpServletRequest to return a certain value:
+        when(httpServletRequest.getHeader("host")).thenReturn("test.com");
+
+        //init the context from a (mocked) servlet
+        context.init(httpServletRequest, httpServletResponse);
+
+        //make sure this is correct
+        assertEquals("test.com", context.getHostname());
+    }
+
+    @Test
     public void testAddCookieViaResult() {
         Cookie cookie = Cookie.builder("cookie", "yum").setDomain("domain").build();
         context.init(httpServletRequest, httpServletResponse);

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -113,7 +113,9 @@ public class FakeContext implements Context {
     public String getHostname() {
         return hostname;
     }
-    public void setHostname(String hostname) {this.hostname = hostname;}
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
 
     public FakeContext setFlashCookie(FlashScope flashCookie) {
         this.flashScope = flashCookie;

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -55,6 +55,7 @@ public class FakeContext implements Context {
     /** please use the requestPath stuff */
     @Deprecated
     private String requestUri;
+    private String hostname;
     private FlashScope flashScope;
     private Session session;
     private List<Cookie> addedCookies = new ArrayList<Cookie>();
@@ -107,6 +108,12 @@ public class FakeContext implements Context {
     public String getRequestUri() {
         return requestUri;
     }
+
+    @Override
+    public String getHostname() {
+        return hostname;
+    }
+    public void setHostname(String hostname) {this.hostname = hostname;}
 
     public FakeContext setFlashCookie(FlashScope flashCookie) {
         this.flashScope = flashCookie;


### PR DESCRIPTION
This is helpful for supporting multi-tenant applications where each customer has their own hostname.

Today, it is as simple as context.getHeader("Host"), but if the context already has many other wrappers around headers, I thought this would be helpful.
