### PR TITLE
Optional annotation-based route definition and reverse routing improvements

### DIFF
--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -32,6 +32,16 @@ import java.util.regex.Pattern;
  */
 public class Route {
 
+    public static class HttpMethod {
+        public final static String OPTIONS = "OPTIONS";
+        public final static String HEAD = "HEAD";
+        public final static String GET = "GET";
+        public final static String PUT = "PUT";
+        public final static String POST = "POST";
+        public final static String DELETE = "DELETE";
+    }
+
+
     //Matches: {id} AND {id: .*?}
     // group(1) extracts the name of the group (in that case "id").
     // group(3) extracts the regex if defined

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -175,6 +175,10 @@ class RouteBuilderImpl implements RouteBuilder {
         // Calculate filters
         LinkedList<Class<? extends Filter>> filters = new LinkedList<Class<? extends Filter>>();
         if(controller != null) {
+            if (controllerMethod == null) {
+                throw new IllegalStateException(
+                        "Route does not have a controller method");
+            }
             filters.addAll(calculateFiltersForClass(controller));
             FilterWith filterWith = controllerMethod
                     .getAnnotation(FilterWith.class);

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
+import ninja.Route.HttpMethod;
 import ninja.params.ControllerMethodInvoker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,32 +41,32 @@ class RouteBuilderImpl implements RouteBuilder {
     private Result result;
 
     public RouteBuilderImpl GET() {
-        httpMethod = "GET";
+        httpMethod = HttpMethod.GET;
         return this;
     }
 
     public RouteBuilderImpl POST() {
-        httpMethod = "POST";
+        httpMethod = HttpMethod.POST;
         return this;
     }
 
     public RouteBuilderImpl PUT() {
-        httpMethod = "PUT";
+        httpMethod = HttpMethod.PUT;
         return this;
     }
 
     public RouteBuilderImpl DELETE() {
-        httpMethod = "DELETE";
+        httpMethod = HttpMethod.DELETE;
         return this;
     }
 
     public RouteBuilderImpl OPTIONS() {
-        httpMethod = "OPTIONS";
+        httpMethod = HttpMethod.OPTIONS;
         return this;
     }
     
     public RouteBuilderImpl HEAD() {
-        httpMethod = "HEAD";
+        httpMethod = HttpMethod.HEAD;
         return this;
     }
         

--- a/ninja-core/src/main/java/ninja/RouteDef.java
+++ b/ninja-core/src/main/java/ninja/RouteDef.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import ninja.Route.HttpMethod;
+
+/**
+ * An annotation for specifying a Ninja route.
+ *
+ * @author James Moger
+ *
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RouteDef {
+
+    /**
+     * The URI(s) for the route.
+     *
+     * e.g. @RouteDef(uri="/users/{username}") or
+     *
+     * @RouteDef(uri={"/users/{username}", "/accounts/{username}"})
+     *
+     * @return the uris
+     */
+    String[] uri();
+
+    /**
+     * The HTTP method for the route. e.g. "GET"
+     *
+     * @return the http method
+     */
+    String method() default HttpMethod.GET;
+
+    /**
+     * The registration order of the route; a lower number will be registered earlier.
+     *
+     * @return the order of the route
+     */
+    int order() default 1;
+}

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -101,7 +101,15 @@ public interface Router {
     public String getReverseRoute(Class<?> controllerClass,
                                  String controllerMethodName,
                                  Optional<Map<String, Object>> parameterMap);
-        
+
+
+    /**
+     * Build routes for all annotated methods in a controller.
+     *
+     * @param controllerClass
+     */
+    public void register(Class<?> controllerClass);
+
     /**
      * Compile all the routes that have been registered with the router. This
      * should be called once, during initialization, before the application
@@ -136,4 +144,45 @@ public interface Router {
      * @return the routeBuilder for chaining.
      */
     public RouteBuilder METHOD(String method);
+
+    // /////////////////////////////////////////////////////////////////////////
+    // convenience methods for reverse route generation using the specified HTTP
+    // method. This will return the first registered method in the controller
+    // that matches the HTTP method.
+    // /////////////////////////////////////////////////////////////////////////
+
+    public String getReverseGET(Class<?> controllerClass);
+
+    public String getReverseGET(Class<?> controllerClass, Object... parameterMap);
+
+    public String getReverseGET(Class<?> controllerClass, Map<String, Object> parameterMap);
+
+    public String getReverseGET(Class<?> controllerClass, Optional<Map<String, Object>> parameterMap);
+
+    public String getReversePUT(Class<?> controllerClass, Object... parameterMap);
+
+    public String getReversePUT(Class<?> controllerClass, Map<String, Object> parameterMap);
+
+    public String getReversePUT(Class<?> controllerClass, Optional<Map<String, Object>> parameterMap);
+
+    public String getReversePOST(Class<?> controllerClass, Object... parameterMap);
+
+    public String getReversePOST(Class<?> controllerClass, Map<String, Object> parameterMap);
+
+    public String getReversePOST(Class<?> controllerClass, Optional<Map<String, Object>> parameterMap);
+
+    public String getReverseDELETE(Class<?> controllerClass, Object... parameterMap);
+
+    public String getReverseDELETE(Class<?> controllerClass, Map<String, Object> parameterMap);
+
+    public String getReverseDELETE(Class<?> controllerClass, Optional<Map<String, Object>> parameterMap);
+
+    public String getReverseMETHOD(String httpMethod, Class<?> controllerClass);
+
+    public String getReverseMETHOD(String httpMethod, Class<?> controllerClass, Object... parameterMap);
+
+    public String getReverseMETHOD(String httpMethod, Class<?> controllerClass, Map<String, Object> parameterMap);
+
+    public String getReverseMETHOD(String httpMethod, Class<?> controllerClass, Optional<Map<String, Object>> parameterMap);
+
 }

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -16,6 +16,7 @@
 
 package ninja;
 
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Optional;
@@ -107,6 +108,11 @@ public interface Router {
      * starts serving requests.
      */
     public void compileRoutes();
+
+    /**
+     * Returns the list of compiled routes.
+     */
+    public List<Route> getRoutes();
 
     // /////////////////////////////////////////////////////////////////////////
     // convenience methods to use the route in a DSL like way

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -170,6 +170,14 @@ public class RouterImpl implements Router {
     }
 
     @Override
+    public List<Route> getRoutes() {
+        if (routes == null) {
+            throw new IllegalStateException("Routes have not been compiled");
+        }
+        return routes;
+    }
+
+    @Override
     public RouteBuilder GET() {
 
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl().GET();

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -25,6 +25,7 @@ import ninja.Context;
 import ninja.Result;
 import ninja.i18n.Lang;
 import ninja.i18n.Messages;
+import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
 import ninja.utils.ResponseStreams;
 
@@ -80,7 +81,15 @@ public class TemplateEngineFreemarker implements TemplateEngine {
     private final TemplateEngineFreemarkerAssetsAtMethod templateEngineFreemarkerAssetsAtMethod;
     
     private final TemplateEngineFreemarkerWebJarsAtMethod templateEngineFreemarkerWebJarsAtMethod;
-    
+
+    private final TemplateEngineFreemarkerGETRouteMethod templateEngineFreemarkerGETRouteMethod;
+
+    private final TemplateEngineFreemarkerPOSTRouteMethod templateEngineFreemarkerPOSTRouteMethod;
+
+    private final TemplateEngineFreemarkerPUTRouteMethod templateEngineFreemarkerPUTRouteMethod;
+
+    private final TemplateEngineFreemarkerDELETERouteMethod templateEngineFreemarkerDELETERouteMethod;
+
     @Inject
     public TemplateEngineFreemarker(Messages messages,
                                     Lang lang,
@@ -91,6 +100,10 @@ public class TemplateEngineFreemarker implements TemplateEngine {
                                     TemplateEngineFreemarkerReverseRouteMethod templateEngineFreemarkerReverseRouteMethod,
                                     TemplateEngineFreemarkerAssetsAtMethod templateEngineFreemarkerAssetsAtMethod,
                                     TemplateEngineFreemarkerWebJarsAtMethod templateEngineFreemarkerWebJarsAtMethod,
+                                    TemplateEngineFreemarkerGETRouteMethod templateEngineFreemarkerGETRouteMethod,
+                                    TemplateEngineFreemarkerPOSTRouteMethod templateEngineFreemarkerPOSTRouteMethod,
+                                    TemplateEngineFreemarkerPUTRouteMethod templateEngineFreemarkerPUTRouteMethod,
+                                    TemplateEngineFreemarkerDELETERouteMethod templateEngineFreemarkerDELETERouteMethod,
                                     NinjaProperties ninjaProperties) throws Exception {
         this.messages = messages;
         this.lang = lang;
@@ -100,7 +113,11 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         this.templateEngineFreemarkerReverseRouteMethod = templateEngineFreemarkerReverseRouteMethod;
         this.templateEngineFreemarkerAssetsAtMethod = templateEngineFreemarkerAssetsAtMethod;
         this.templateEngineFreemarkerWebJarsAtMethod = templateEngineFreemarkerWebJarsAtMethod;
-        
+        this.templateEngineFreemarkerGETRouteMethod = templateEngineFreemarkerGETRouteMethod;
+        this.templateEngineFreemarkerPOSTRouteMethod = templateEngineFreemarkerPOSTRouteMethod;
+        this.templateEngineFreemarkerPUTRouteMethod = templateEngineFreemarkerPUTRouteMethod;
+        this.templateEngineFreemarkerDELETERouteMethod = templateEngineFreemarkerDELETERouteMethod;
+
         cfg = new Configuration();
         
         // This is important to enable html escaping of apostrophes
@@ -252,6 +269,10 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         map.put("reverseRoute", templateEngineFreemarkerReverseRouteMethod);
         map.put("assetsAt", templateEngineFreemarkerAssetsAtMethod);
         map.put("webJarsAt", templateEngineFreemarkerWebJarsAtMethod);
+        map.put("reverseGET", templateEngineFreemarkerGETRouteMethod);
+        map.put("reversePOST", templateEngineFreemarkerPOSTRouteMethod);
+        map.put("reversePUT", templateEngineFreemarkerPUTRouteMethod);
+        map.put("reverseDELETE", templateEngineFreemarkerDELETERouteMethod);
 
         ///////////////////////////////////////////////////////////////////////
         // Convenience method to translate possible flash scope keys.

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerDELETERouteMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerDELETERouteMethod.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.List;
+
+import ninja.Route.HttpMethod;
+import ninja.Router;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+@Singleton
+public class TemplateEngineFreemarkerDELETERouteMethod
+        extends TemplateEngineFreemarkerMETHODRoute
+        implements TemplateMethodModelEx {
+
+    @Inject
+    public TemplateEngineFreemarkerDELETERouteMethod(Router router) {
+        super(router, HttpMethod.DELETE, 3);
+    }
+
+    @Override
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+       return computeReverseRoute(args);
+
+    }
+}

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerGETRouteMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerGETRouteMethod.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.List;
+
+import ninja.Route.HttpMethod;
+import ninja.Router;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+@Singleton
+public class TemplateEngineFreemarkerGETRouteMethod
+        extends TemplateEngineFreemarkerMETHODRoute
+        implements TemplateMethodModelEx {
+
+    @Inject
+    public TemplateEngineFreemarkerGETRouteMethod(Router router) {
+        super(router, HttpMethod.GET, 1);
+    }
+
+    @Override
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+       return computeReverseRoute(args);
+
+    }
+}

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerMETHODRoute.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerMETHODRoute.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ninja.Router;
+import freemarker.template.SimpleNumber;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+public abstract class TemplateEngineFreemarkerMETHODRoute {
+
+    private final Router router;
+
+    private final String httpMethod;
+
+    private final int minimumArgsCount;
+
+    public TemplateEngineFreemarkerMETHODRoute(Router router, String method, int minArgsCount) {
+        this.router = router;
+        this.httpMethod = method;
+        this.minimumArgsCount = minArgsCount;
+    }
+
+    public TemplateModel computeReverseRoute(List args) throws TemplateModelException {
+
+        if (args.size() < minimumArgsCount) {
+
+            throw new TemplateModelException(
+                    "Please specify the controller and parameters.");
+
+        } else {
+
+            List<String> strings = new ArrayList<>(args.size());
+
+            for (Object o : args) {
+
+                // We currently allow only numbers and strings as arguments
+                if (o instanceof String) {
+                    strings.add((String) o);
+                } if (o instanceof SimpleScalar) {
+                    strings.add(((SimpleScalar) o).getAsString());
+                } else if (o instanceof SimpleNumber) {
+                    strings.add(((SimpleNumber) o).toString());
+                }
+
+            }
+
+            try {
+
+                String reverseRoute;
+                Class<?> clazz = Class.forName(strings.get(0));
+
+                if (strings.size() == 1) {
+                    reverseRoute = router.getReverseMETHOD(httpMethod, clazz);
+                } else {
+                    Object [] parameterMap = strings.subList(1, strings.size()).toArray();
+
+                    if (parameterMap.length % 2 != 0) {
+                        throw new TemplateModelException("Odd parameter count! Always provide key-value pairs for reverse route generation.");
+                    }
+
+                    reverseRoute = router.getReverseMETHOD(httpMethod, clazz, parameterMap);
+                }
+
+                return new SimpleScalar(reverseRoute);
+            } catch (ClassNotFoundException ex) {
+                throw new TemplateModelException("Error. Cannot find class for String: " + strings.get(0));
+            }
+        }
+
+    }
+}

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPOSTRouteMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPOSTRouteMethod.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.List;
+
+import ninja.Route.HttpMethod;
+import ninja.Router;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+@Singleton
+public class TemplateEngineFreemarkerPOSTRouteMethod
+        extends TemplateEngineFreemarkerMETHODRoute
+        implements TemplateMethodModelEx {
+
+    @Inject
+    public TemplateEngineFreemarkerPOSTRouteMethod(Router router) {
+        super(router, HttpMethod.POST, 3);
+    }
+
+    @Override
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+       return computeReverseRoute(args);
+
+    }
+}

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPUTRouteMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPUTRouteMethod.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.List;
+
+import ninja.Route.HttpMethod;
+import ninja.Router;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+@Singleton
+public class TemplateEngineFreemarkerPUTRouteMethod
+        extends TemplateEngineFreemarkerMETHODRoute
+        implements TemplateMethodModelEx {
+
+    @Inject
+    public TemplateEngineFreemarkerPUTRouteMethod(Router router) {
+        super(router, HttpMethod.PUT, 3);
+    }
+
+    @Override
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+       return computeReverseRoute(args);
+
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2014-07-21 Added support for optional annotation-based route registration. (gitblit)
  * 2014-06-06 Fixed testcase that was flaky in GMT-5 timezones. (ra) 
  * 2014-06-05 Fixed dependency problems with scope test and ninja-test-utilities (ra) 
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/basic_concepts.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/basic_concepts.md
@@ -23,6 +23,8 @@ public class Routes implements ApplicationRoutes {
 
         router.GET().route("/").with(ApplicationController.class, "index");
 
+        router.register(UsersController.class);
+
     }
 }
 </pre>
@@ -56,6 +58,28 @@ Controller methods always return a <code>Result</code>.
 a little helper that lets you create results easily. 
 In the case of the application controller the result is a html response.
 
+
+Alternately, you may register your routes using annotations.
+
+<pre class="prettyprint">
+package controllers;
+
+@Singleton
+public class UsersController {       
+
+    @RouteDef("/users")
+    public Result index() {
+        return Results.html();
+
+    }
+
+    @RouteDef("/users/{username}", order=2)
+    public Result getUser(@PathParam("username") String username) {
+        return Results.html();
+
+    }
+}
+</pre>
 
 Now we got one side of the equation - 
 from Ninja to the routes to our controller. But how does Ninja generate the html

--- a/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
@@ -84,10 +84,13 @@ Implicit functions available in templates
 ### reverseRoute(...)
 
 Reverse route allows you to calculate a reverse route inside your templates.
+
+#### Named controller method reverse routing
+
 For instance via <code>${reverseRoute("controllers.ApplicationController", 
 "userDashboard", "email", email, "id", id)}</code>.
 
-First parameter is the controller name, second parameter the method name. All
+First parameter is the controller name, second parameter the *controller method name*. All
 other parameters are optional and used to replace variable parts inside the route with
 appropriate values. 
 
@@ -98,6 +101,21 @@ For a route like
 <code>router.GET().route("/user/{id}/{email}/userDashboard").with(ApplicationController.class, "userDashboard");</code> 
 the result is: <code>/me/user/1000/my@email.com/userDashboard</code>.
 
+#### Http method reverse routing
+
+For instance via <code>${reverseGET("controllers.ApplicationController", "email", email, "id", id)}</code>.
+
+First parameter is the controller name. All other parameters are optional and used to replace variable
+parts inside the route with appropriate values. 
+
+In the example above the user rendered the variable parts
+with <code>Results.html().render("id", 1000).render("email", "my@email.com") </code>.
+
+For a route like 
+<code>router.GET().route("/user/{id}/{email}/userDashboard").with(ApplicationController.class);</code> 
+the result is: <code>/me/user/1000/my@email.com/userDashboard</code>.
+
+**NOTE**: Http method reverse routing will return the first matching route for the controller.
 
 ### assetsAt(...)
 

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -35,6 +35,7 @@ contributed to Ninja. In some random order:
  * Matt Jones (mattjonesorg)
  * Naum Naumovski (Buffer0verflow)
  * Primož Kokol
+ * James Moger (gitblit)
 
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-core/src/test/java/ninja/RouterImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouterImplTest.java
@@ -19,7 +19,11 @@ package ninja;
 import com.google.common.base.Optional;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import ninja.params.PathParam;
+import ninja.Route.HttpMethod;
+import ninja.utils.NinjaMode;
 import ninja.utils.NinjaProperties;
+import ninja.utils.NinjaPropertiesImpl;
 import org.hamcrest.CoreMatchers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.Test;
@@ -59,6 +63,9 @@ public class RouterImplTest {
         // add route:
         router.GET().route("/testroute").with(TestController.class, "index");
         router.GET().route("/user/{email}/{id: .*}").with(TestController.class, "user");
+
+        // add routes mapped by http method annotation:
+        router.register(AnnotatedController.class);
 
         router.compileRoutes();
     }
@@ -125,6 +132,147 @@ public class RouterImplTest {
 
     }
 
+    @Test
+    public void testGetReverseAnnotatedRouteWithNoContextPathWorks() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReverseGET(AnnotatedController.class);
+
+        assertThat(route, CoreMatchers.equalTo("/testroute"));
+
+    }
+
+    @Test
+    public void testGetReverseAnnotatedRouteContextPathWorks() {
+
+        String contextPath = "/myappcontext";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReverseGET(AnnotatedController.class);
+
+        assertThat(route, equalTo("/myappcontext/testroute"));
+
+    }
+
+    @Test
+    public void testGetReverseAnnotatedRouteWithRegexWorks() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReversePUT(AnnotatedController.class,
+                "email", "me@me.com", "id", 10000);
+
+        assertThat(route, equalTo("/user/me@me.com/10000"));
+
+    }
+
+    @Test
+    public void testGetReverseAnnotatedRouteWithRegexAndQueryParametersWorks() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReversePUT(AnnotatedController.class,
+                "email", "me@me.com", "id", 10000, "q", "froglegs");
+
+        assertThat(route, equalTo("/user/me@me.com/10000?q=froglegs"));
+
+    }
+
+    @Test
+    public void testBasicGETAnnotatedRoute() {
+
+        Router router = buildAnnotatedRouter(MockAnnotatedController.class);
+        assertEquals("/get", router.getReverseGET(MockAnnotatedController.class));
+
+    }
+
+    @Test
+    public void testBasicPOSTAnnotatedRoute() {
+
+        Router router = buildAnnotatedRouter(MockAnnotatedController.class);
+        assertEquals("/post", router.getReversePOST(MockAnnotatedController.class));
+
+    }
+
+    @Test
+    public void testBasicPUTAnnotatedRoute() {
+
+        Router router = buildAnnotatedRouter(MockAnnotatedController.class);
+        assertEquals("/put", router.getReversePUT(MockAnnotatedController.class));
+
+    }
+
+    @Test
+    public void testBasicOPTIONSAnnotatedRoute() {
+
+        Router router = buildAnnotatedRouter(MockAnnotatedController.class);
+        assertEquals("/options", router.getReverseMETHOD(HttpMethod.OPTIONS, MockAnnotatedController.class));
+
+    }
+
+    @Test
+    public void testBasicHEADAnnotatedRoute() {
+
+        Router router = buildAnnotatedRouter(MockAnnotatedController.class);
+        assertEquals("/head", router.getReverseMETHOD(HttpMethod.HEAD, MockAnnotatedController.class));
+
+    }
+
+    @Test
+    public void testBestFitRoutes() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        Router router = buildAnnotatedRouter(UsersController.class);
+
+        String index = router.getReverseGET(UsersController.class);
+        String user = router.getReverseGET(UsersController.class, "username", "james");
+
+        assertThat(index, CoreMatchers.equalTo("/users"));
+        assertThat(user, CoreMatchers.equalTo("/users/james"));
+
+    }
+
+    @Test
+    public void testAnnotatedAmbiguousPriority() {
+
+        Router router = buildAnnotatedRouter(AmbiguousOrderController.class);
+        assertEquals(0, router.getRoutes().size());
+    }
+
+    @Test
+    public void testAnnotatedInvalidPriority() {
+
+        Router router = buildAnnotatedRouter(InvalidOrderController.class);
+        assertEquals(0, router.getRoutes().size());
+    }
+
+    @Test
+    public void testDuplicateNames() {
+
+        Router router = buildAnnotatedRouter(DuplicateNamesController.class);
+        assertEquals(0, router.getRoutes().size());
+    }
+
+    @Test
+    public void testInvalidReturnType() {
+
+        Router router = buildAnnotatedRouter(InvalidReturnTypeController.class);
+        assertEquals(0, router.getRoutes().size());
+    }
+
+    @Test
+    public void testNonAnnotatedControllerRegistration() {
+
+        Router router = buildAnnotatedRouter(TestController.class);
+        assertEquals(0, router.getRoutes().size());
+    }
+
     // Just a dummy TestController for mocking...
     public static class TestController {
 
@@ -138,6 +286,135 @@ public class RouterImplTest {
 
             return Results.ok();
 
+        }
+
+    }
+
+    // Just a dummy AnnotatedController for mocking...
+    public static class AnnotatedController {
+
+        @RouteDef(uri="/testroute")
+        public Result index() {
+
+            return Results.ok();
+
+        }
+
+        @RouteDef(uri="/user/{email}/{id: .*}", method=HttpMethod.PUT)
+        public Result user(@PathParam("email") String email,
+                                      @PathParam("id") String id) {
+
+            return Results.ok();
+
+        }
+    }
+
+
+    private Router buildAnnotatedRouter(Class<?> controllerClass) {
+        RouterImpl router = new RouterImpl(injector, new NinjaPropertiesImpl(NinjaMode.dev));
+        router.register(controllerClass);
+        router.compileRoutes();
+        return router;
+    }
+
+    public static class MockAnnotatedController {
+
+        @RouteDef(uri="/options", method=HttpMethod.OPTIONS)
+        public Result options() {
+            return null;
+        }
+
+        @RouteDef(uri="/head", method=HttpMethod.HEAD)
+        public Result head() {
+            return null;
+        }
+
+        @RouteDef(uri="/get", method=HttpMethod.GET)
+        public Result get() {
+            return null;
+        }
+
+        @RouteDef(uri="/put", method=HttpMethod.PUT)
+        public Result put() {
+            return null;
+        }
+
+        @RouteDef(uri="/post", method=HttpMethod.POST)
+        public Result post() {
+            return null;
+        }
+
+        @RouteDef(uri="/delete", method=HttpMethod.DELETE)
+        public Result delete() {
+            return null;
+        }
+
+    }
+
+    public static class UsersController {
+
+        @RouteDef(uri="/users")
+        public Result index() {
+
+            return Results.ok();
+
+        }
+
+        @RouteDef(uri="/users/{username}", order=2)
+        public Result user(@PathParam("username") String username) {
+
+            return Results.ok();
+
+        }
+    }
+
+    public static class AmbiguousOrderController {
+
+        @RouteDef(uri="/get", method=HttpMethod.GET)
+        public Result get() {
+            return null;
+        }
+
+        @RouteDef(uri="/get2", method=HttpMethod.GET)
+        public Result get2() {
+            return null;
+        }
+
+    }
+
+    public static class InvalidOrderController {
+
+        @RouteDef(uri="/get", method=HttpMethod.GET)
+        public Result get() {
+            return null;
+        }
+
+        @RouteDef(uri="/get2", method=HttpMethod.GET, order=0)
+        public Result get2() {
+            return null;
+        }
+
+    }
+
+    public static class DuplicateNamesController {
+
+        @RouteDef(uri="/get", method=HttpMethod.GET)
+        public Result get() {
+            return null;
+        }
+
+        @RouteDef(uri="/get2", method=HttpMethod.GET, order=2)
+        public Result get(String test) {
+            return null;
+        }
+
+    }
+
+    public static class InvalidReturnTypeController {
+
+        @RouteDef(uri="/get", method=HttpMethod.GET)
+        public String get() {
+            return null;
         }
 
     }

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
@@ -23,6 +23,7 @@ import java.util.List;
 import ninja.Configuration;
 import ninja.Context;
 import ninja.Ninja;
+import ninja.Route;
 import ninja.Router;
 import ninja.application.ApplicationRoutes;
 import ninja.lifecycle.LifecycleSupport;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -310,6 +312,35 @@ public class NinjaBootstrap {
             applicationRoutes.init(router);
             router.compileRoutes();
 
+            // log the routing table
+            int maxMethodLen = 0;
+            int maxPathLen = 0;
+            int maxControllerLen = 0;
+            for (Route route : router.getRoutes()) {
+            	if (route.getControllerClass() != null) {
+            		maxMethodLen = Math.max(maxMethodLen, route.getHttpMethod().length());
+            		maxPathLen = Math.max(maxPathLen, route.getUri().length());
+            		int controllerLen = route.getControllerClass().getName().length()
+            				+ route.getControllerMethod().getName().length();
+            		maxControllerLen = Math.max(maxControllerLen, controllerLen);
+            	}
+            }
+
+            int borderLen = 10 + maxMethodLen + maxPathLen + maxControllerLen;
+            String border = Strings.padEnd("", borderLen, '-');
+            logger.info(border);
+            logger.info("Registered routes");
+            logger.info(border);
+            for (Route route : router.getRoutes()) {
+            	if (route.getControllerClass() != null) {
+            		logger.info("{} {}  =>  {}.{}()",
+            			Strings.padEnd(route.getHttpMethod(), maxMethodLen, ' '),
+            			Strings.padEnd(route.getUri(), maxPathLen, ' '),
+            			route.getControllerClass().getName(),
+            			route.getControllerMethod().getName());
+            	}
+            }
+            logger.info(border);
         }
     
     }


### PR DESCRIPTION
While I think the Ninja framework has great potential, I am not a fan of the fragility of the routing mechanism.  I agree with the concept of the single-file Routes registration approach, but in practice the dependence of a _named_ method is a major weakness.  Perhaps this can be improved with Java 8, but not likely all aspects of routing will be improved by that change.

This pull request gives developers the choice of how to register their routes:
1. single-file route definitions using discrete HTTP method / named controller method registration (`GET()...with(UsersController.class, "index")`)
2. annotation-based route definitions within the controller (`register(UsersController.class)`)

``` java
public class UsersController {

    @RouteDef(uri="/users")
    public Result index() {
        ...
    }

    @RouteDef(uri="/users/{username}", order=2)
    public Result getUser(@PathParam("username") String username) {
        ...
    }

    @RouteDef(uri="/users/{username}", method=HttpMethod.PUT)
    public Result updateUser(@PathParam("username") String username) {
        ...
    }
}
```

Additionally, this pull request implements _best-fit_ reverse routing methods for the requested HTTP method where **best-fit** is defined as the matching route that has the fewest query parameters.  This allows the most common use cases for reverse route generation to work without specifying the controller method  name.

``` java
// returns /users
String indexRoute = router.getReverseGET(UsersController.class);
// returns /users/james
String userRoute = router.getReverseGET(UsersController.class, "username", "james");
```

This pull request also fixes a potential null pointer exception which could occur during reverse route generation for a route that failed registration.

I can split this PR into multiple PRs, if that is your preference.
