### PR TITLE
Add integrated Metrics support

### DIFF
--- a/ninja-annotations/src/main/java/ninja/metrics/Metered.java
+++ b/ninja-annotations/src/main/java/ninja/metrics/Metered.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a controller method to be Metered for metrics collection.
+ *
+ * If no name is specified, the controller classname and method name are used.
+ *
+ * @author James Moger
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Metered {
+
+    String value() default "";
+
+}

--- a/ninja-annotations/src/main/java/ninja/metrics/Timed.java
+++ b/ninja-annotations/src/main/java/ninja/metrics/Timed.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a controller method to be Timed for metrics collection.
+ *
+ * If no name is specified, the controller classname and method name are used.
+ *
+ * @author James Moger
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Timed {
+
+    String value() default "";
+
+}

--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -61,6 +61,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
         </plugins>
 
         <extensions>

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X
 =========
 
+* 2014-10-18 Added a Metrics module with reporters for Graphite, Ganglia, InfluxDB, and Librato (gitblit & ra)
 * 2014-10-10 Stability improvement for Jpa blog archetype - setup works now in a predictable manner for testcases ra).
 * 2014-10-09 Removed localized lookup in Freemarker templates. Not needed as Ninja does i18n already (ra).
 * 2014-10-07 Added support for multiple variable parts *with regex* in routes (bazi)

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -171,6 +171,40 @@ Add the following settings to your `application.conf`.
     metrics.ganglia.address = ganglia.example.com
     metrics.ganglia.port = 8649
 
+### Reporting Metrics to InfluxDB
+
+Ninja Metrics supports reporting to [InfluxDB](http://influxdb.com).
+
+Add the following dependency to your application `pom.xml`.
+
+    <dependency>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja-metrics-influxdb</artifactId>
+        <version>${ninja.version}</version>
+    </dependency>
+
+Bind the InfluxDB integration in your `Module.java`.
+
+<pre class="prettyprint">
+@Singleton
+public class Module extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(NinjaInfluxDB.class);
+  }
+}
+</pre>
+
+Add the following settings to your `application.conf`.
+
+    metrics.influxdb.enabled = true
+    metrics.influxdb.address = localhost
+    metrics.influxdb.port = 8086
+    metrics.influxdb.database = mydb
+    metrics.influxdb.username = root
+    metrics.influxdb.password = root
+
 ### Reporting Metrics to Librato
 
 [Librato](http://metrics.librato.com) is a cloud-based metrics database and dashboard service.

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -1,0 +1,94 @@
+Metrics
+==============
+
+Ninja provides optional integration with [Metrics](http://metrics.dropwizard.io/) for measuring the responsiveness of your application.
+
+Setup
+------------------
+
+### Add the Ninja-Metrics dependency
+
+    <dependency>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja-metrics</artifactId>
+        <version>${ninja.version}</version>
+    </dependency>
+
+
+### Install the `MetricsModule` in your `conf.Module` class.
+
+<pre class="prettyprint">
+@Singleton
+public class Module extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        install(new MetricsModule());
+
+    }
+}
+</pre>
+
+### Subclass InstrumentedNinja in your `conf.Ninja` class.
+
+<pre class="prettyprint">
+package conf;
+
+import ninja.metrics.InstrumentedNinja;
+
+public class Ninja extends InstrumentedNinja {
+
+}
+
+</pre>
+
+### Collecting Route Metrics
+
+Now you are ready to start annotating your controllers.
+
+You have three choices in the collection of route metrics:
+
+- *Do nothing*
+- *Metered*
+A meter measures the rate of events over time (e.g., “requests per second”). In addition to the mean rate, meters also track 1-, 5-, and 15-minute moving averages.
+- *Timed*
+A timer measures both the rate that a particular piece of code is called and the distribution of its duration.
+
+1. Start by sprinkling `@Metered` or `@Timed` on some of your controller methods.
+2. Start up VisualVM (and install the MBeans plugin) or JConsole.
+3. Browse your app and refresh the collected metrics.
+
+<pre class="prettyprint">
+package controllers;
+
+@Singleton
+public class AppController {
+
+    @Timed
+    public Result index() {
+
+        return Results.html();
+    }
+
+}
+</pre>
+
+### Collecting Cache Metrics
+
+If you want to instrument your NinjaCache, Ninja-Metrics supports instrumenting both the EhCache and the Memcached implementations.
+
+In your `application.conf` file specify:
+
+    cache.implementation = ninja.metrics.InstrumentedEhCache
+
+or
+
+    cache.implementation = ninja.metrics.InstrumentedMemcached
+
+Reporting
+------------------
+
+By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx=false* in your `application.conf` file.
+
+You can view the collected metrics using VisualVM (with the MBeans plugin installed) or using JConsole.

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -30,7 +30,7 @@ public class Module extends AbstractModule {
 }
 </pre>
 
-### Subclass InstrumentedNinja in your `conf.Ninja` class.
+### Subclass InstrumentedNinja in your `conf.Ninja` class. (optional)
 
 <pre class="prettyprint">
 package conf;
@@ -86,9 +86,32 @@ or
 
     cache.implementation = ninja.metrics.InstrumentedMemcached
 
-Reporting
-------------------
+### Collecting Additional Metrics
 
-By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx=false* in your `application.conf` file.
+#### JVM Metrics
+
+You may optionally enable JVM-level details reporting by setting *metrics.jvm.enabled=true* in your `application.conf` file.
+
+    metrics.jvm.enabled = true
+
+#### Logback Metrics
+
+You may optionally enable reporting of Logback log-level counts by setting *metrics.logback.enabled=true* in your `application.conf` file.
+
+    metrics.logback.enabled = true
+
+### Reporting Metrics via JMX for VisualVM/JConsole
+
+### Exposing Metrics via JMX for VisualVM/JConsole
+
+By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx.enable=false* in your `application.conf` file.
 
 You can view the collected metrics using VisualVM (with the MBeans plugin installed) or using JConsole.
+
+
+### Reporting Metrics to 3rd party services
+
+It is also possible to collect & report your Metrics data to several cloud-based services such as:
+
+- [Librato](http://www.librato.com)
+- [DataDog](http://www.datadoghq.com)

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -102,12 +102,28 @@ You may optionally enable reporting of Logback log-level counts by setting *metr
 
 ### Reporting Metrics via JMX for VisualVM/JConsole
 
-### Exposing Metrics via JMX for VisualVM/JConsole
+By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx.enabled=false* in your `application.conf` file.
 
-By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx.enable=false* in your `application.conf` file.
+    metrics.jmx.enabled = true
 
 You can view the collected metrics using VisualVM (with the MBeans plugin installed) or using JConsole.
 
+### Reporting Metrics to Graphite
+
+Ninja Metrics supports reporting to Graphite.
+
+    metrics.graphite.enabled = true
+    metrics.graphite.address = graphite.example.com
+    metrics.graphite.port = 2003
+    metrics.graphite.pickled = false
+
+### Reporting Metrics to Ganglia
+
+Ninja Metrics supports reporting to Ganglia.
+
+    metrics.ganglia.enabled = true
+    metrics.ganglia.address = ganglia.example.com
+    metrics.ganglia.port = 8649
 
 ### Reporting Metrics to 3rd party services
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -141,6 +141,7 @@ Add the following settings to your `application.conf`.
     metrics.graphite.address = graphite.example.com
     metrics.graphite.port = 2003
     metrics.graphite.pickled = false
+    metrics.graphite.period = 60s
 
 ### Reporting Metrics to Ganglia
 
@@ -172,6 +173,7 @@ Add the following settings to your `application.conf`.
     metrics.ganglia.enabled = true
     metrics.ganglia.address = ganglia.example.com
     metrics.ganglia.port = 8649
+    metrics.ganglia.period = 60s
 
 ### Reporting Metrics to InfluxDB
 
@@ -206,6 +208,7 @@ Add the following settings to your `application.conf`.
     metrics.influxdb.database = mydb
     metrics.influxdb.username = root
     metrics.influxdb.password = root
+    metrics.influxdb.period = 60s
 
 ### Reporting Metrics to Librato
 
@@ -237,3 +240,4 @@ Add the following settings to your `application.conf`.
     metrics.librato.enabled = true
     metrics.librato.username = person@example.com
     metrics.librato.apikey = 12345cafebabe
+    metrics.librato.period = 60s

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -102,11 +102,11 @@ You may optionally enable reporting of Logback log-level counts by setting *metr
 
     metrics.logback.enabled = true
 
-### Reporting Metrics via JMX for VisualVM/JConsole
+### Reporting Metrics via MBeans for VisualVM, JConsole, or JMX
 
-By default, Ninja Metrics will expose your metrics over JMX. You may disable this behavior by setting *metrics.jmx.enabled=false* in your `application.conf` file.
+If you want to expose your metrics to VisualVM, JConsole, or JMX you must enable the MBeans reporter in your `application.conf` file.
 
-    metrics.jmx.enabled = true
+    metrics.mbeans.enabled = true
 
 You can view the collected metrics using VisualVM (with the MBeans plugin installed) or using JConsole.
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -43,19 +43,21 @@ public class Ninja extends InstrumentedNinja {
 
 </pre>
 
-### Collecting Route Metrics
+### Collecting Metrics
 
-Now you are ready to start annotating your controllers.
+Now you are ready to start annotating your controllers or any other methods.
 
-You have three choices in the collection of route metrics:
+You have several choices in the collection of metrics:
 
 - *Do nothing*
+- *Counted*
+A counter increments (and optionally decrements) when a method is executed.
 - *Metered*
 A meter measures the rate of events over time (e.g., “requests per second”). In addition to the mean rate, meters also track 1-, 5-, and 15-minute moving averages.
 - *Timed*
 A timer measures both the rate that a particular piece of code is called and the distribution of its duration.
 
-1. Start by sprinkling `@Metered` or `@Timed` on some of your controller methods.
+1. Start by sprinkling `@Counted`, `@Metered`, or `@Timed` on some of your controller methods.
 2. Start up VisualVM (and install the MBeans plugin) or JConsole.
 3. Browse your app and refresh the collected metrics.
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -110,7 +110,30 @@ You can view the collected metrics using VisualVM (with the MBeans plugin instal
 
 ### Reporting Metrics to Graphite
 
-Ninja Metrics supports reporting to Graphite.
+Ninja Metrics supports reporting to [Graphite](https://github.com/graphite-project).
+
+Add the following dependency to your application `pom.xml`.
+
+    <dependency>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja-metrics-graphite</artifactId>
+        <version>${ninja.version}</version>
+    </dependency>
+
+Bind the Graphite integration in your `Module.java`.
+
+<pre class="prettyprint">
+@Singleton
+public class Module extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(NinjaGraphite.class);
+  }
+}
+</pre>
+
+Add the following settings to your `application.conf`.
 
     metrics.graphite.enabled = true
     metrics.graphite.address = graphite.example.com
@@ -119,15 +142,62 @@ Ninja Metrics supports reporting to Graphite.
 
 ### Reporting Metrics to Ganglia
 
-Ninja Metrics supports reporting to Ganglia.
+Ninja Metrics supports reporting to [Ganglia](http://ganglia.info).
+
+Add the following dependency to your application `pom.xml`.
+
+    <dependency>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja-metrics-ganglia</artifactId>
+        <version>${ninja.version}</version>
+    </dependency>
+
+Bind the Ganglia integration in your `Module.java`.
+
+<pre class="prettyprint">
+@Singleton
+public class Module extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(NinjaGanglia.class);
+  }
+}
+</pre>
+
+Add the following settings to your `application.conf`.
 
     metrics.ganglia.enabled = true
     metrics.ganglia.address = ganglia.example.com
     metrics.ganglia.port = 8649
 
-### Reporting Metrics to 3rd party services
+### Reporting Metrics to Librato
 
-It is also possible to collect & report your Metrics data to several cloud-based services such as:
+[Librato](http://metrics.librato.com) is a cloud-based metrics database and dashboard service.
 
-- [Librato](http://www.librato.com)
-- [DataDog](http://www.datadoghq.com)
+Add the following dependency to your application `pom.xml`.
+
+    <dependency>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja-metrics-librato</artifactId>
+        <version>${ninja.version}</version>
+    </dependency>
+
+Bind the Librato integration in your `Module.java`.
+
+<pre class="prettyprint">
+@Singleton
+public class Module extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(NinjaLibrato.class);
+  }
+}
+</pre>
+
+Add the following settings to your `application.conf`.
+
+    metrics.librato.enabled = true
+    metrics.librato.username = person@example.com
+    metrics.librato.apikey = 12345cafebabe

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -73,6 +73,7 @@
                 <item name="Sessions" href="./documentation/basic_concepts/sessions.html"/>
                 <item name="Flash scope" href="./documentation/basic_concepts/flash_scope.html"/>
                 <item name="Error handling" href="./documentation/basic_concepts/error_handling.html"/>
+                <item name="Metrics" href="./documentation/basic_concepts/metrics.html"/>
             </item>
 
             <item name="Configuration and modes" href="./documentation/configuration_and_modes.html"/>

--- a/ninja-maven-plugin/pom.xml
+++ b/ninja-maven-plugin/pom.xml
@@ -76,13 +76,9 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
-
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ninja-metrics-ganglia/pom.xml
+++ b/ninja-metrics-ganglia/pom.xml
@@ -11,7 +11,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>ninja-metrics</artifactId>
+	<artifactId>ninja-metrics-ganglia</artifactId>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -21,10 +21,6 @@
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>
-	
-	<properties>
-	   <metrics.version>3.1.0</metrics.version>
-	</properties>
 
 	<build>
 		<resources>
@@ -54,26 +50,14 @@
 
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
-			<artifactId>ninja-core</artifactId>
+			<artifactId>ninja-metrics</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
+			<artifactId>metrics-ganglia</artifactId>
 			<version>${metrics.version}</version>
 		</dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jvm</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
 
 		<!-- Testing -->
 		<dependency>

--- a/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
+++ b/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
@@ -26,6 +26,7 @@ import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
 import ninja.metrics.MetricsService;
 import ninja.utils.NinjaProperties;
+import ninja.utils.TimeUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,9 @@ public class NinjaGanglia {
                     .getOrDie("metrics.ganglia.address");
             final int port = ninjaProperties.getIntegerWithDefault(
                     "metrics.ganglia.port", 8649);
+            final String period = ninjaProperties.getWithDefault(
+                    "metrics.ganglia.period", "60s");
+            final int delay = TimeUtil.parseDuration(period);
 
             try {
                 GMetric ganglia = new GMetric(address, port,
@@ -78,9 +82,11 @@ public class NinjaGanglia {
                         .convertDurationsTo(TimeUnit.MILLISECONDS)
                         .build(ganglia);
 
-                reporter.start(1, TimeUnit.MINUTES);
+                reporter.start(delay, TimeUnit.SECONDS);
 
-                log.info("Started Ganglia Metrics reporter for '{}'", hostname);
+                log.info(
+                        "Started Ganglia Metrics reporter for '{}', updating every {}",
+                        hostname, period);
 
             } catch (IOException e) {
                 log.error("Failed to start Ganglia reporter!", e);

--- a/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
+++ b/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics.ganglia;
+
+import info.ganglia.gmetric4j.gmetric.GMetric;
+import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import ninja.lifecycle.Dispose;
+import ninja.lifecycle.Start;
+import ninja.metrics.MetricsService;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.ganglia.GangliaReporter;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Integration of Ninja Metrics with Ganglia.
+ *
+ * @author James Moger
+ */
+@Singleton
+public class NinjaGanglia {
+
+    private final Logger log = LoggerFactory.getLogger(NinjaGanglia.class);
+
+    private final NinjaProperties ninjaProperties;
+
+    private final MetricsService metricsService;
+
+    private GangliaReporter reporter;
+
+    @Inject
+    public NinjaGanglia(NinjaProperties ninjaProperties,
+                        MetricsService metricsService) {
+        this.ninjaProperties = ninjaProperties;
+        this.metricsService = metricsService;
+    }
+
+    @Start(order = 90)
+    public void start() {
+
+        if (ninjaProperties.getBooleanWithDefault("metrics.ganglia.enabled",
+                false)) {
+
+            final String hostname = metricsService.getHostname();
+            final String address = ninjaProperties
+                    .getOrDie("metrics.ganglia.address");
+            final int port = ninjaProperties.getIntegerWithDefault(
+                    "metrics.ganglia.port", 8649);
+
+            try {
+                GMetric ganglia = new GMetric(address, port,
+                        UDPAddressingMode.MULTICAST, 1);
+                reporter = GangliaReporter
+                        .forRegistry(metricsService.getMetricRegistry())
+                        .convertRatesTo(TimeUnit.SECONDS)
+                        .convertDurationsTo(TimeUnit.MILLISECONDS)
+                        .build(ganglia);
+
+                reporter.start(1, TimeUnit.MINUTES);
+
+                log.info("Started Ganglia Metrics reporter for '{}'", hostname);
+
+            } catch (IOException e) {
+                log.error("Failed to start Ganglia reporter!", e);
+            }
+
+        }
+    }
+
+    @Dispose(order = 10)
+    public void stop() {
+
+        if (reporter != null) {
+
+            reporter.stop();
+
+            log.debug("Stopped Ganglia Metrics reporter");
+        }
+
+    }
+}

--- a/ninja-metrics-graphite/pom.xml
+++ b/ninja-metrics-graphite/pom.xml
@@ -11,7 +11,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>ninja-metrics</artifactId>
+	<artifactId>ninja-metrics-graphite</artifactId>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -21,10 +21,6 @@
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>
-	
-	<properties>
-	   <metrics.version>3.1.0</metrics.version>
-	</properties>
 
 	<build>
 		<resources>
@@ -54,26 +50,14 @@
 
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
-			<artifactId>ninja-core</artifactId>
+			<artifactId>ninja-metrics</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
+			<artifactId>metrics-graphite</artifactId>
 			<version>${metrics.version}</version>
 		</dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jvm</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
 
 		<!-- Testing -->
 		<dependency>

--- a/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
+++ b/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
@@ -23,6 +23,7 @@ import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
 import ninja.metrics.MetricsService;
 import ninja.utils.NinjaProperties;
+import ninja.utils.TimeUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +72,9 @@ public class NinjaGraphite {
                     "metrics.graphite.port", 2003);
             final boolean isPickled = ninjaProperties.getBooleanWithDefault(
                     "metrics.graphite.pickled", false);
+            final String period = ninjaProperties.getWithDefault(
+                    "metrics.graphite.period", "60s");
+            final int delay = TimeUtil.parseDuration(period);
             final InetSocketAddress graphiteAddress = new InetSocketAddress(
                     address, port);
 
@@ -86,9 +90,12 @@ public class NinjaGraphite {
                     .prefixedWith(hostname).convertRatesTo(TimeUnit.SECONDS)
                     .convertDurationsTo(TimeUnit.MILLISECONDS)
                     .filter(MetricFilter.ALL).build(sender);
-            reporter.start(1, TimeUnit.MINUTES);
 
-            log.info("Started Graphite Metrics reporter for '{}'", hostname);
+            reporter.start(delay, TimeUnit.SECONDS);
+
+            log.info(
+                    "Started Graphite Metrics reporter for '{}', updating every {}",
+                    hostname, period);
 
         }
     }

--- a/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
+++ b/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics.graphite;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import ninja.lifecycle.Dispose;
+import ninja.lifecycle.Start;
+import ninja.metrics.MetricsService;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.GraphiteSender;
+import com.codahale.metrics.graphite.PickledGraphite;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Integration of Ninja Metrics with Graphite.
+ *
+ * @author James Moger
+ */
+@Singleton
+public class NinjaGraphite {
+
+    private final Logger log = LoggerFactory.getLogger(NinjaGraphite.class);
+
+    private final NinjaProperties ninjaProperties;
+
+    private final MetricsService metricsService;
+
+    private GraphiteReporter reporter;
+
+    @Inject
+    public NinjaGraphite(NinjaProperties ninjaProperties,
+                         MetricsService metricsService) {
+        this.ninjaProperties = ninjaProperties;
+        this.metricsService = metricsService;
+    }
+
+    @Start(order = 90)
+    public void start() {
+
+        if (ninjaProperties.getBooleanWithDefault("metrics.graphite.enabled",
+                false)) {
+
+            final String hostname = metricsService.getHostname();
+            final String address = ninjaProperties
+                    .getOrDie("metrics.graphite.address");
+            final int port = ninjaProperties.getIntegerWithDefault(
+                    "metrics.graphite.port", 2003);
+            final boolean isPickled = ninjaProperties.getBooleanWithDefault(
+                    "metrics.graphite.pickled", false);
+            final InetSocketAddress graphiteAddress = new InetSocketAddress(
+                    address, port);
+
+            final GraphiteSender sender;
+            if (isPickled) {
+                sender = new PickledGraphite(graphiteAddress);
+            } else {
+                sender = new Graphite(graphiteAddress);
+            }
+
+            reporter = GraphiteReporter
+                    .forRegistry(metricsService.getMetricRegistry())
+                    .prefixedWith(hostname).convertRatesTo(TimeUnit.SECONDS)
+                    .convertDurationsTo(TimeUnit.MILLISECONDS)
+                    .filter(MetricFilter.ALL).build(sender);
+            reporter.start(1, TimeUnit.MINUTES);
+
+            log.info("Started Graphite Metrics reporter for '{}'", hostname);
+
+        }
+    }
+
+    @Dispose(order = 10)
+    public void stop() {
+
+        if (reporter != null) {
+
+            reporter.stop();
+
+            log.debug("Stopped Graphite Metrics reporter");
+        }
+
+    }
+}

--- a/ninja-metrics-influxdb/pom.xml
+++ b/ninja-metrics-influxdb/pom.xml
@@ -1,0 +1,74 @@
+<!-- Copyright (C) 2012-2014 the original author or authors. Licensed under 
+	the Apache License, Version 2.0 (the "License"); you may not use this file 
+	except in compliance with the License. You may obtain a copy of the License 
+	at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
+	law or agreed to in writing, software distributed under the License is distributed 
+	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+	express or implied. See the License for the specific language governing permissions 
+	and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>ninja-metrics-influxdb</artifactId>
+	<packaging>jar</packaging>
+
+	<parent>
+		<groupId>org.ninjaframework</groupId>
+		<artifactId>ninja</artifactId>
+		<version>3.3.4-SNAPSHOT</version>
+	</parent>
+
+	<url>http://www.ninjaframework.org</url>
+	
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**/*</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/*</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.ninjaframework</groupId>
+			<artifactId>ninja-metrics</artifactId>
+		</dependency>
+
+<dependency>
+	<groupId>net.alchim31</groupId>
+	<artifactId>metrics-influxdb</artifactId>
+	<version>0.4.0</version>
+</dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
+++ b/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics.influxdb;
+
+import java.util.concurrent.TimeUnit;
+
+import metrics_influxdb.Influxdb;
+import metrics_influxdb.InfluxdbReporter;
+import ninja.lifecycle.Dispose;
+import ninja.lifecycle.Start;
+import ninja.metrics.MetricsService;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricFilter;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Integration of Ninja Metrics with InfluxDB.
+ *
+ * @author James Moger
+ */
+@Singleton
+public class NinjaInfluxDB {
+
+    private final Logger log = LoggerFactory.getLogger(NinjaInfluxDB.class);
+
+    private final NinjaProperties ninjaProperties;
+
+    private final MetricsService metricsService;
+
+    private InfluxdbReporter reporter;
+
+    @Inject
+    public NinjaInfluxDB(NinjaProperties ninjaProperties,
+                         MetricsService metricsService) {
+        this.ninjaProperties = ninjaProperties;
+        this.metricsService = metricsService;
+    }
+
+    @Start(order = 90)
+    public void start() {
+
+        if (ninjaProperties.getBooleanWithDefault("metrics.influxdb.enabled",
+                false)) {
+
+            final String hostname = metricsService.getHostname();
+            final String address = ninjaProperties
+                    .getOrDie("metrics.influxdb.address");
+            final int port = ninjaProperties.getIntegerWithDefault(
+                    "metrics.influxdb.port", 8086);
+            final String database = ninjaProperties
+                    .getOrDie("metrics.influxdb.database");
+            final String username = ninjaProperties
+                    .getOrDie("metrics.influxdb.username");
+            final String password = ninjaProperties
+                    .getOrDie("metrics.influxdb.password");
+
+            try {
+
+                Influxdb influxdb = new Influxdb(address, port, database,
+                        username, password);
+                final InfluxdbReporter reporter = InfluxdbReporter
+                        .forRegistry(metricsService.getMetricRegistry())
+                        .prefixedWith(hostname)
+                        .convertRatesTo(TimeUnit.SECONDS)
+                        .convertDurationsTo(TimeUnit.MILLISECONDS)
+                        .filter(MetricFilter.ALL).build(influxdb);
+                reporter.start(10, TimeUnit.SECONDS);
+
+                log.info("Started InfluxDB Metrics reporter for '{}'", hostname);
+
+            } catch (Exception e) {
+                log.error("Failed to start InfluxDB reporter!", e);
+            }
+        }
+    }
+
+    @Dispose(order = 10)
+    public void stop() {
+
+        if (reporter != null) {
+
+            reporter.stop();
+
+            log.debug("Stopped InfluxDB Metrics reporter");
+        }
+
+    }
+}

--- a/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
+++ b/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
@@ -24,6 +24,7 @@ import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
 import ninja.metrics.MetricsService;
 import ninja.utils.NinjaProperties;
+import ninja.utils.TimeUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +73,9 @@ public class NinjaInfluxDB {
                     .getOrDie("metrics.influxdb.username");
             final String password = ninjaProperties
                     .getOrDie("metrics.influxdb.password");
+            final String period = ninjaProperties.getWithDefault(
+                    "metrics.influxdb.period", "60s");
+            final int delay = TimeUtil.parseDuration(period);
 
             try {
 
@@ -83,9 +87,12 @@ public class NinjaInfluxDB {
                         .convertRatesTo(TimeUnit.SECONDS)
                         .convertDurationsTo(TimeUnit.MILLISECONDS)
                         .filter(MetricFilter.ALL).build(influxdb);
-                reporter.start(10, TimeUnit.SECONDS);
 
-                log.info("Started InfluxDB Metrics reporter for '{}'", hostname);
+                reporter.start(delay, TimeUnit.SECONDS);
+
+                log.info(
+                        "Started InfluxDB Metrics reporter for '{}', updating every {}",
+                        hostname, period);
 
             } catch (Exception e) {
                 log.error("Failed to start InfluxDB reporter!", e);

--- a/ninja-metrics-librato/pom.xml
+++ b/ninja-metrics-librato/pom.xml
@@ -11,7 +11,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>ninja-metrics</artifactId>
+	<artifactId>ninja-metrics-librato</artifactId>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -22,10 +22,6 @@
 
 	<url>http://www.ninjaframework.org</url>
 	
-	<properties>
-	   <metrics.version>3.1.0</metrics.version>
-	</properties>
-
 	<build>
 		<resources>
 			<resource>
@@ -54,25 +50,13 @@
 
 		<dependency>
 			<groupId>org.ninjaframework</groupId>
-			<artifactId>ninja-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
-			<version>${metrics.version}</version>
+			<artifactId>ninja-metrics</artifactId>
 		</dependency>
 
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jvm</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>${metrics.version}</version>
+            <groupId>com.librato.metrics</groupId>
+            <artifactId>metrics-librato</artifactId>
+            <version>4.0.1.4</version>
         </dependency>
 
 		<!-- Testing -->

--- a/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
+++ b/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics.librato;
+
+import java.util.concurrent.TimeUnit;
+
+import ninja.lifecycle.Dispose;
+import ninja.lifecycle.Start;
+import ninja.metrics.MetricsService;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.librato.metrics.LibratoReporter;
+
+/**
+ * Integration of Ninja Metrics with Librato.
+ *
+ * @author James Moger
+ */
+@Singleton
+public class NinjaLibrato {
+
+    private final Logger logger = LoggerFactory.getLogger(NinjaLibrato.class);
+
+    private final NinjaProperties ninjaProperties;
+
+    private final MetricsService metricsService;
+
+    @Inject
+    public NinjaLibrato(NinjaProperties ninjaProperties,
+                        MetricsService metricsService) {
+        this.ninjaProperties = ninjaProperties;
+        this.metricsService = metricsService;
+    }
+
+    @Start(order = 90)
+    public void startService() {
+
+        if (ninjaProperties.getBooleanWithDefault("metrics.librato.enabled",
+                false)) {
+
+            final String hostname = metricsService.getHostname();
+            final String username = ninjaProperties
+                    .getOrDie("metrics.librato.username");
+            final String apiKey = ninjaProperties
+                    .getOrDie("metrics.librato.apikey");
+
+            LibratoReporter.enable(LibratoReporter.builder(
+                    metricsService.getMetricRegistry(), username, apiKey,
+                    hostname), 10, TimeUnit.SECONDS);
+
+            logger.info("Started Librato Metrics reporter for '{}'", hostname);
+
+        }
+
+    }
+
+    @Dispose(order = 90)
+    public void stopService() {
+    }
+}

--- a/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
+++ b/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
@@ -22,6 +22,7 @@ import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
 import ninja.metrics.MetricsService;
 import ninja.utils.NinjaProperties;
+import ninja.utils.TimeUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,7 @@ import com.librato.metrics.LibratoReporter;
 @Singleton
 public class NinjaLibrato {
 
-    private final Logger logger = LoggerFactory.getLogger(NinjaLibrato.class);
+    private final Logger log = LoggerFactory.getLogger(NinjaLibrato.class);
 
     private final NinjaProperties ninjaProperties;
 
@@ -62,12 +63,17 @@ public class NinjaLibrato {
                     .getOrDie("metrics.librato.username");
             final String apiKey = ninjaProperties
                     .getOrDie("metrics.librato.apikey");
+            final String period = ninjaProperties.getWithDefault(
+                    "metrics.librato.period", "60s");
+            final int delay = TimeUtil.parseDuration(period);
 
             LibratoReporter.enable(LibratoReporter.builder(
                     metricsService.getMetricRegistry(), username, apiKey,
-                    hostname), 10, TimeUnit.SECONDS);
+                    hostname), delay, TimeUnit.SECONDS);
 
-            logger.info("Started Librato Metrics reporter for '{}'", hostname);
+            log.info(
+                    "Started Librato Metrics reporter for '{}', updating every {}",
+                    hostname, period);
 
         }
 

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -75,6 +75,18 @@
             <version>${metrics.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-ganglia</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+
 		<!-- Testing -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -1,0 +1,58 @@
+<!-- Copyright (C) 2012-2014 the original author or authors. Licensed under 
+	the Apache License, Version 2.0 (the "License"); you may not use this file 
+	except in compliance with the License. You may obtain a copy of the License 
+	at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
+	law or agreed to in writing, software distributed under the License is distributed 
+	on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+	express or implied. See the License for the specific language governing permissions 
+	and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>ninja-metrics</artifactId>
+	<packaging>jar</packaging>
+
+	<parent>
+		<groupId>org.ninjaframework</groupId>
+		<artifactId>ninja</artifactId>
+		<version>3.3.2-SNAPSHOT</version>
+	</parent>
+
+	<url>http://www.ninjaframework.org</url>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**/*</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/*</include>
+				</includes>
+			</resource>
+		</resources>
+	</build>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.ninjaframework</groupId>
+			<artifactId>ninja-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.dropwizard.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -21,6 +21,10 @@
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>
+	
+	<properties>
+	   <metrics.version>3.1.0</metrics.version>
+	</properties>
 
 	<build>
 		<resources>
@@ -38,13 +42,13 @@
 				</includes>
 			</resource>
 		</resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 
 	<dependencies>
 
@@ -56,19 +60,31 @@
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
-			<version>3.1.0</version>
+			<version>${metrics.version}</version>
 		</dependency>
-        
-        <!-- Testing -->
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-logback</artifactId>
+            <version>${metrics.version}</version>
         </dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -38,7 +38,13 @@
 				</includes>
 			</resource>
 		</resources>
-	</build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 	<dependencies>
 

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.ninjaframework</groupId>
 		<artifactId>ninja</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>3.3.4-SNAPSHOT</version>
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -52,7 +52,17 @@
 			<artifactId>metrics-core</artifactId>
 			<version>3.1.0</version>
 		</dependency>
+        
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/ninja-metrics/src/main/java/ninja/metrics/Counted.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/Counted.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a controller method to be Counted for metrics
+ * collection.
+ *
+ * A counter increments on method execution and optionally decrements at execution completion.
+ *
+ * If no name is specified, the controller classname and method name are used.
+ *
+ * @author James Moger
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Counted {
+
+    String value() default "";
+
+    /**
+     * Determines the behavior of the counter.
+     * <p/>
+     * if false (default), the counter will continuously increment and will
+     * indicate the number of times this method has been executed.
+     * <p/>
+     * if true, the counter will be incremented before the method is executed
+     * and will be decremented when method execution has completed - regardless
+     * of thrown exceptions.
+     * <p/>
+     * This is useful for determining the realtime execution status of a method.
+     */
+    boolean active() default false;
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/CountedInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/CountedInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/**
+ *
+ * @author James Moger
+ */
+public class CountedInterceptor implements MethodInterceptor {
+
+    final Provider<MetricsService> metricsServiceProvider;
+
+    @Inject
+    public CountedInterceptor(Provider<MetricsService> metricsServiceProvider) {
+        this.metricsServiceProvider = metricsServiceProvider;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+
+        Counted counted = invocation.getMethod().getAnnotation(Counted.class);
+        String counterName = counted.value();
+
+        if (counterName.isEmpty()) {
+            counterName = MetricRegistry.name(invocation.getThis().getClass()
+                    .getSuperclass(), invocation.getMethod().getName());
+        }
+
+        Counter counter = metricsServiceProvider.get().getMetricRegistry()
+                .counter(counterName);
+
+        counter.inc();
+
+        try {
+            return invocation.proceed();
+        } finally {
+            if (counted.active()) {
+                counter.dec();
+            }
+        }
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
@@ -47,7 +47,7 @@ abstract class InstrumentedCache implements Cache {
         init();
     }
 
-    public void init() {
+    private void init() {
         MetricRegistry registry = metricsService
             .getMetricRegistry(MetricsService.METRICS_REGISTRY_CACHE);
 
@@ -55,14 +55,8 @@ abstract class InstrumentedCache implements Cache {
         missCounter = getCounter(registry, "miss");
     }
 
-    protected Timer getTimer(MetricRegistry registry, String name) {
-        return registry.timer(MetricRegistry.name(underlyingCache.getClass(),
-                name));
-    }
-
-    protected Counter getCounter(MetricRegistry registry, String name) {
-        return registry.counter(MetricRegistry.name(underlyingCache.getClass(),
-                name));
+    private Counter getCounter(MetricRegistry registry, String name) {
+        return registry.counter(MetricRegistry.name(underlyingCache.getClass(), name));
     }
 
     @Override

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
@@ -23,6 +23,7 @@ import ninja.cache.Cache;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 
 /**
@@ -31,19 +32,21 @@ import com.google.inject.Inject;
  * @author James Moger
  *
  */
-abstract class InstrumentedCache implements Cache {
+public class InstrumentedCache implements Cache {
 
     private final Cache underlyingCache;
 
-    @Inject
     private MetricsService metricsService;
 
     private Counter hitCounter;
 
     private Counter missCounter;
 
-    public InstrumentedCache(Cache cache) {
+    InstrumentedCache(
+            Cache cache,
+            MetricsService metricsService) {
         this.underlyingCache = cache;
+        this.metricsService = metricsService;
         init();
     }
 
@@ -56,7 +59,10 @@ abstract class InstrumentedCache implements Cache {
     }
 
     private Counter getCounter(MetricRegistry registry, String name) {
-        return registry.counter(MetricRegistry.name(underlyingCache.getClass(), name));
+        return registry.counter(
+                MetricRegistry.name(
+                        underlyingCache.getClass(), 
+                        name));
     }
 
     @Override

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.util.Map;
+
+import ninja.cache.Cache;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Inject;
+
+/**
+ * Instruments the configured Ninja Cache instance for Metrics collection.
+ *
+ * @author James Moger
+ *
+ */
+abstract class InstrumentedCache implements Cache {
+
+    private final Cache underlyingCache;
+
+    @Inject
+    private MetricsService metricsService;
+
+    private Timer addTimer;
+
+    private Timer safeAddTimer;
+
+    private Timer setTimer;
+
+    private Timer safeSetTimer;
+
+    private Timer replaceTimer;
+
+    private Timer safeReplaceTimer;
+
+    private Timer getTimer;
+
+    private Timer getManyTimer;
+
+    private Timer incrTimer;
+
+    private Timer decrTimer;
+
+    private Timer clearTimer;
+
+    private Timer deleteTimer;
+
+    private Timer safeDeleteTimer;
+
+    private Counter hitCounter;
+
+    private Counter missCounter;
+
+    public InstrumentedCache(Cache cache) {
+        this.underlyingCache = cache;
+    }
+
+    public void init() {
+        MetricRegistry registry = metricsService
+                .getMetricRegistry(MetricsService.METRICS_REGISTRY_CACHE);
+
+        addTimer = getTimer(registry, "add");
+        safeAddTimer = getTimer(registry, "safeAdd");
+        setTimer = getTimer(registry, "set");
+        safeSetTimer = getTimer(registry, "safeSet");
+        replaceTimer = getTimer(registry, "replace");
+        safeReplaceTimer = getTimer(registry, "safeReplace");
+        getTimer = getTimer(registry, "get");
+        getManyTimer = getTimer(registry, "getMany");
+        incrTimer = getTimer(registry, "incr");
+        decrTimer = getTimer(registry, "decr");
+        clearTimer = getTimer(registry, "clear");
+        deleteTimer = getTimer(registry, "delete");
+        safeDeleteTimer = getTimer(registry, "safeDelete");
+
+        hitCounter = getCounter(registry, "hits");
+        missCounter = getCounter(registry, "miss");
+    }
+
+    protected Timer getTimer(MetricRegistry registry, String name) {
+        return registry.timer(MetricRegistry.name(underlyingCache.getClass(),
+                name));
+    }
+
+    protected Counter getCounter(MetricRegistry registry, String name) {
+        return registry.counter(MetricRegistry.name(underlyingCache.getClass(),
+                name));
+    }
+
+    @Override
+    public void add(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = addTimer.time();
+        try {
+            underlyingCache.add(key, value, expiration);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public boolean safeAdd(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = safeAddTimer.time();
+        try {
+            boolean result = underlyingCache.safeAdd(key, value, expiration);
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public void set(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = setTimer.time();
+        try {
+            underlyingCache.set(key, value, expiration);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public boolean safeSet(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = safeSetTimer.time();
+        try {
+            boolean result = underlyingCache.safeSet(key, value, expiration);
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public void replace(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = replaceTimer.time();
+        try {
+            underlyingCache.replace(key, value, expiration);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public boolean safeReplace(String key, Object value, int expiration) {
+        init();
+        final Timer.Context ctx = safeReplaceTimer.time();
+        try {
+            return underlyingCache.safeReplace(key, value, expiration);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public Object get(String key) {
+        init();
+        final Timer.Context ctx = getTimer.time();
+        try {
+            Object result = underlyingCache.get(key);
+            if (result == null) {
+                missCounter.inc();
+            } else {
+                hitCounter.inc();
+            }
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public Map<String, Object> get(String[] keys) {
+        init();
+        final Timer.Context ctx = getManyTimer.time();
+        try {
+            Map<String, Object> result = underlyingCache.get(keys);
+            if (result == null || result.isEmpty()) {
+                missCounter.inc(keys.length);
+            } else {
+                hitCounter.inc(result.size());
+                missCounter.inc(keys.length - result.size());
+            }
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public long incr(String key, int by) {
+        init();
+        final Timer.Context ctx = incrTimer.time();
+        try {
+            long result = underlyingCache.incr(key, by);
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public long decr(String key, int by) {
+        init();
+        final Timer.Context ctx = decrTimer.time();
+        try {
+            long result = underlyingCache.decr(key, by);
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public void clear() {
+        init();
+        final Timer.Context ctx = clearTimer.time();
+        try {
+            underlyingCache.clear();
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        init();
+        final Timer.Context ctx = deleteTimer.time();
+        try {
+            underlyingCache.delete(key);
+        } finally {
+            ctx.stop();
+        }
+    }
+
+    @Override
+    public boolean safeDelete(String key) {
+        init();
+        final Timer.Context ctx = safeDeleteTimer.time();
+        try {
+            boolean result = underlyingCache.safeDelete(key);
+            return result;
+        } finally {
+            ctx.stop();
+        }
+    }
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
@@ -22,9 +22,6 @@ import ninja.cache.Cache;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.common.base.Preconditions;
-import com.google.inject.Inject;
 
 /**
  * Instruments the configured Ninja Cache instance for Metrics collection.
@@ -42,67 +39,57 @@ public class InstrumentedCache implements Cache {
 
     private Counter missCounter;
 
-    InstrumentedCache(
-            Cache cache,
-            MetricsService metricsService) {
+    InstrumentedCache(Cache cache, MetricsService metricsService) {
         this.underlyingCache = cache;
         this.metricsService = metricsService;
         init();
     }
 
     private void init() {
-        MetricRegistry registry = metricsService
-            .getMetricRegistry(MetricsService.METRICS_REGISTRY_CACHE);
+        MetricRegistry registry = metricsService.getMetricRegistry();
 
-        hitCounter = getCounter(registry, "hits");
-        missCounter = getCounter(registry, "miss");
-    }
-
-    private Counter getCounter(MetricRegistry registry, String name) {
-        return registry.counter(
-                MetricRegistry.name(
-                        underlyingCache.getClass(), 
-                        name));
+        hitCounter = registry.counter("ninja.cache.hits");
+        missCounter = registry.counter("ninja.cache.miss");
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.add")
     public void add(String key, Object value, int expiration) {
         underlyingCache.add(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.safeAdd")
     public boolean safeAdd(String key, Object value, int expiration) {
         return underlyingCache.safeAdd(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.set")
     public void set(String key, Object value, int expiration) {
         underlyingCache.set(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.safeSet")
     public boolean safeSet(String key, Object value, int expiration) {
         return underlyingCache.safeSet(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.replace")
     public void replace(String key, Object value, int expiration) {
         underlyingCache.replace(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.safeReplace")
     public boolean safeReplace(String key, Object value, int expiration) {
         return underlyingCache.safeReplace(key, value, expiration);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.get")
     public Object get(String key) {
         Object result = underlyingCache.get(key);
         if (result == null) {
@@ -114,7 +101,7 @@ public class InstrumentedCache implements Cache {
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.getMany")
     public Map<String, Object> get(String[] keys) {
         Map<String, Object> result = underlyingCache.get(keys);
         if (result == null || result.isEmpty()) {
@@ -127,32 +114,32 @@ public class InstrumentedCache implements Cache {
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.incr")
     public long incr(String key, int by) {
         return underlyingCache.incr(key, by);
 
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.decr")
     public long decr(String key, int by) {
         return underlyingCache.decr(key, by);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.clear")
     public void clear() {
         underlyingCache.clear();
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.delete")
     public void delete(String key) {
         underlyingCache.delete(key);
     }
 
     @Override
-    @Timed
+    @Timed("ninja.cache.safeDelete")
     public boolean safeDelete(String key) {
         return underlyingCache.safeDelete(key);
     }

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedCache.java
@@ -38,57 +38,18 @@ abstract class InstrumentedCache implements Cache {
     @Inject
     private MetricsService metricsService;
 
-    private Timer addTimer;
-
-    private Timer safeAddTimer;
-
-    private Timer setTimer;
-
-    private Timer safeSetTimer;
-
-    private Timer replaceTimer;
-
-    private Timer safeReplaceTimer;
-
-    private Timer getTimer;
-
-    private Timer getManyTimer;
-
-    private Timer incrTimer;
-
-    private Timer decrTimer;
-
-    private Timer clearTimer;
-
-    private Timer deleteTimer;
-
-    private Timer safeDeleteTimer;
-
     private Counter hitCounter;
 
     private Counter missCounter;
 
     public InstrumentedCache(Cache cache) {
         this.underlyingCache = cache;
+        init();
     }
 
     public void init() {
         MetricRegistry registry = metricsService
-                .getMetricRegistry(MetricsService.METRICS_REGISTRY_CACHE);
-
-        addTimer = getTimer(registry, "add");
-        safeAddTimer = getTimer(registry, "safeAdd");
-        setTimer = getTimer(registry, "set");
-        safeSetTimer = getTimer(registry, "safeSet");
-        replaceTimer = getTimer(registry, "replace");
-        safeReplaceTimer = getTimer(registry, "safeReplace");
-        getTimer = getTimer(registry, "get");
-        getManyTimer = getTimer(registry, "getMany");
-        incrTimer = getTimer(registry, "incr");
-        decrTimer = getTimer(registry, "decr");
-        clearTimer = getTimer(registry, "clear");
-        deleteTimer = getTimer(registry, "delete");
-        safeDeleteTimer = getTimer(registry, "safeDelete");
+            .getMetricRegistry(MetricsService.METRICS_REGISTRY_CACHE);
 
         hitCounter = getCounter(registry, "hits");
         missCounter = getCounter(registry, "miss");
@@ -105,163 +66,94 @@ abstract class InstrumentedCache implements Cache {
     }
 
     @Override
+    @Timed
     public void add(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = addTimer.time();
-        try {
-            underlyingCache.add(key, value, expiration);
-        } finally {
-            ctx.stop();
-        }
+        underlyingCache.add(key, value, expiration);
     }
 
     @Override
+    @Timed
     public boolean safeAdd(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = safeAddTimer.time();
-        try {
-            boolean result = underlyingCache.safeAdd(key, value, expiration);
-            return result;
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.safeAdd(key, value, expiration);
     }
 
     @Override
+    @Timed
     public void set(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = setTimer.time();
-        try {
-            underlyingCache.set(key, value, expiration);
-        } finally {
-            ctx.stop();
-        }
+        underlyingCache.set(key, value, expiration);
     }
 
     @Override
+    @Timed
     public boolean safeSet(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = safeSetTimer.time();
-        try {
-            boolean result = underlyingCache.safeSet(key, value, expiration);
-            return result;
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.safeSet(key, value, expiration);
     }
 
     @Override
+    @Timed
     public void replace(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = replaceTimer.time();
-        try {
-            underlyingCache.replace(key, value, expiration);
-        } finally {
-            ctx.stop();
-        }
+        underlyingCache.replace(key, value, expiration);
     }
 
     @Override
+    @Timed
     public boolean safeReplace(String key, Object value, int expiration) {
-        init();
-        final Timer.Context ctx = safeReplaceTimer.time();
-        try {
-            return underlyingCache.safeReplace(key, value, expiration);
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.safeReplace(key, value, expiration);
     }
 
     @Override
+    @Timed
     public Object get(String key) {
-        init();
-        final Timer.Context ctx = getTimer.time();
-        try {
-            Object result = underlyingCache.get(key);
-            if (result == null) {
-                missCounter.inc();
-            } else {
-                hitCounter.inc();
-            }
-            return result;
-        } finally {
-            ctx.stop();
+        Object result = underlyingCache.get(key);
+        if (result == null) {
+            missCounter.inc();
+        } else {
+            hitCounter.inc();
         }
+        return result;
     }
 
     @Override
+    @Timed
     public Map<String, Object> get(String[] keys) {
-        init();
-        final Timer.Context ctx = getManyTimer.time();
-        try {
-            Map<String, Object> result = underlyingCache.get(keys);
-            if (result == null || result.isEmpty()) {
-                missCounter.inc(keys.length);
-            } else {
-                hitCounter.inc(result.size());
-                missCounter.inc(keys.length - result.size());
-            }
-            return result;
-        } finally {
-            ctx.stop();
+        Map<String, Object> result = underlyingCache.get(keys);
+        if (result == null || result.isEmpty()) {
+            missCounter.inc(keys.length);
+        } else {
+            hitCounter.inc(result.size());
+            missCounter.inc(keys.length - result.size());
         }
+        return result;
     }
 
     @Override
+    @Timed
     public long incr(String key, int by) {
-        init();
-        final Timer.Context ctx = incrTimer.time();
-        try {
-            long result = underlyingCache.incr(key, by);
-            return result;
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.incr(key, by);
+
     }
 
     @Override
+    @Timed
     public long decr(String key, int by) {
-        init();
-        final Timer.Context ctx = decrTimer.time();
-        try {
-            long result = underlyingCache.decr(key, by);
-            return result;
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.decr(key, by);
     }
 
     @Override
+    @Timed
     public void clear() {
-        init();
-        final Timer.Context ctx = clearTimer.time();
-        try {
-            underlyingCache.clear();
-        } finally {
-            ctx.stop();
-        }
+        underlyingCache.clear();
     }
 
     @Override
+    @Timed
     public void delete(String key) {
-        init();
-        final Timer.Context ctx = deleteTimer.time();
-        try {
-            underlyingCache.delete(key);
-        } finally {
-            ctx.stop();
-        }
+        underlyingCache.delete(key);
     }
 
     @Override
+    @Timed
     public boolean safeDelete(String key) {
-        init();
-        final Timer.Context ctx = safeDeleteTimer.time();
-        try {
-            boolean result = underlyingCache.safeDelete(key);
-            return result;
-        } finally {
-            ctx.stop();
-        }
+        return underlyingCache.safeDelete(key);
     }
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
@@ -23,8 +23,10 @@ import com.google.inject.Inject;
 public class InstrumentedEhCache extends InstrumentedCache {
 
     @Inject
-    public InstrumentedEhCache(CacheEhCacheImpl cache) {
-        super(cache);
+    public InstrumentedEhCache(
+            CacheEhCacheImpl cache,
+            MetricsService metricsService) {
+        super(cache, metricsService);
     }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ninja.metrics;
 
 import ninja.cache.CacheEhCacheImpl;

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedEhCache.java
@@ -1,0 +1,14 @@
+package ninja.metrics;
+
+import ninja.cache.CacheEhCacheImpl;
+
+import com.google.inject.Inject;
+
+public class InstrumentedEhCache extends InstrumentedCache {
+
+    @Inject
+    public InstrumentedEhCache(CacheEhCacheImpl cache) {
+        super(cache);
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ninja.metrics;
 
 import ninja.cache.CacheMemcachedImpl;

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
@@ -23,8 +23,10 @@ import com.google.inject.Inject;
 public class InstrumentedMemcached extends InstrumentedCache {
 
     @Inject
-    public InstrumentedMemcached(CacheMemcachedImpl cache) {
-        super(cache);
+    public InstrumentedMemcached(
+            CacheMemcachedImpl cache,
+            MetricsService metricsService) {
+        super(cache, metricsService);
     }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedMemcached.java
@@ -1,0 +1,14 @@
+package ninja.metrics;
+
+import ninja.cache.CacheMemcachedImpl;
+
+import com.google.inject.Inject;
+
+public class InstrumentedMemcached extends InstrumentedCache {
+
+    @Inject
+    public InstrumentedMemcached(CacheMemcachedImpl cache) {
+        super(cache);
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
@@ -55,20 +55,19 @@ public class InstrumentedNinja extends NinjaDefault {
     public void onFrameworkStart() {
 
         MetricRegistry metrics = metricsService
-                .getMetricRegistry(MetricsService.METRICS_REGISTRY_REQUESTS);
+            .getMetricRegistry(MetricsService.METRICS_REGISTRY_REQUESTS);
 
         allRequestsMeter = metrics.meter(MetricsService.METER_ALL_REQUESTS);
-        activeRequests = metrics
-                .counter(MetricsService.COUNTER_ACTIVE_REQUESTS);
+        activeRequests = metrics.counter(MetricsService.COUNTER_ACTIVE_REQUESTS);
         badRequests = metrics.meter(MetricsService.METER_BAD_REQUESTS);
-        internalServerErrors = metrics
-                .meter(MetricsService.METER_INTERNAL_SERVER_ERRORS);
+        internalServerErrors = metrics.meter(MetricsService.METER_INTERNAL_SERVER_ERRORS);
         routesNotFound = metrics.meter(MetricsService.METER_ROUTES_NOT_FOUND);
 
         super.onFrameworkStart();
     }
 
     @Override
+    @Timed
     public void onRouteRequest(Context.Impl context) {
 
         activeRequests.inc();

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
@@ -24,9 +24,7 @@ import ninja.exceptions.BadRequestException;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.inject.Inject;
 
 /**
@@ -54,8 +52,7 @@ public class InstrumentedNinja extends NinjaDefault {
     @Override
     public void onFrameworkStart() {
 
-        MetricRegistry metrics = metricsService
-            .getMetricRegistry(MetricsService.METRICS_REGISTRY_REQUESTS);
+        MetricRegistry metrics = metricsService.getMetricRegistry();
 
         allRequestsMeter = metrics.meter(MetricsService.METER_ALL_REQUESTS);
         activeRequests = metrics.counter(MetricsService.COUNTER_ACTIVE_REQUESTS);

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
@@ -83,17 +83,6 @@ public class InstrumentedNinja extends NinjaDefault {
 
             allRequestsMeter.mark();
 
-            Timer.Context metricsContext = null;
-
-            Metric routeMetric = metricsService.getRouteMetric(route);
-            if (routeMetric != null) {
-                if (routeMetric instanceof Timer) {
-                    metricsContext = ((Timer) routeMetric).time();
-                } else if (routeMetric instanceof Meter) {
-                    ((Meter) routeMetric).mark();
-                }
-            }
-
             try {
 
                 Result result = route.getFilterChain().next(context);
@@ -114,14 +103,6 @@ public class InstrumentedNinja extends NinjaDefault {
 
                 Result result = onException(context, exception);
                 renderErrorResultAndCatchAndLogExceptions(result, context);
-
-            } finally {
-
-                if (metricsContext != null) {
-
-                    metricsContext.stop();
-
-                }
 
             }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/InstrumentedNinja.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import ninja.Context;
+import ninja.NinjaDefault;
+import ninja.Result;
+import ninja.Route;
+import ninja.exceptions.BadRequestException;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Inject;
+
+/**
+ * An implementation of DefaultNinja instrumented for collecting request
+ * metrics.
+ *
+ * @author James Moger
+ *
+ */
+public class InstrumentedNinja extends NinjaDefault {
+
+    @Inject
+    protected MetricsService metricsService;
+
+    protected Meter allRequestsMeter;
+
+    protected Counter activeRequests;
+
+    protected Meter badRequests;
+
+    protected Meter internalServerErrors;
+
+    protected Meter routesNotFound;
+
+    @Override
+    public void onFrameworkStart() {
+
+        MetricRegistry metrics = metricsService
+                .getMetricRegistry(MetricsService.METRICS_REGISTRY_REQUESTS);
+
+        allRequestsMeter = metrics.meter(MetricsService.METER_ALL_REQUESTS);
+        activeRequests = metrics
+                .counter(MetricsService.COUNTER_ACTIVE_REQUESTS);
+        badRequests = metrics.meter(MetricsService.METER_BAD_REQUESTS);
+        internalServerErrors = metrics
+                .meter(MetricsService.METER_INTERNAL_SERVER_ERRORS);
+        routesNotFound = metrics.meter(MetricsService.METER_ROUTES_NOT_FOUND);
+
+        super.onFrameworkStart();
+    }
+
+    @Override
+    public void onRouteRequest(Context.Impl context) {
+
+        activeRequests.inc();
+
+        String httpMethod = context.getMethod();
+
+        Route route = router.getRouteFor(httpMethod, context.getRequestPath());
+
+        context.setRoute(route);
+
+        if (route != null) {
+
+            allRequestsMeter.mark();
+
+            Timer.Context metricsContext = null;
+
+            Metric routeMetric = metricsService.getRouteMetric(route);
+            if (routeMetric != null) {
+                if (routeMetric instanceof Timer) {
+                    metricsContext = ((Timer) routeMetric).time();
+                } else if (routeMetric instanceof Meter) {
+                    ((Meter) routeMetric).mark();
+                }
+            }
+
+            try {
+
+                Result result = route.getFilterChain().next(context);
+
+                resultHandler.handleResult(result, context);
+
+            } catch (Exception exception) {
+
+                if (exception instanceof BadRequestException) {
+
+                    badRequests.mark();
+
+                } else {
+
+                    internalServerErrors.mark();
+
+                }
+
+                Result result = onException(context, exception);
+                renderErrorResultAndCatchAndLogExceptions(result, context);
+
+            } finally {
+
+                if (metricsContext != null) {
+
+                    metricsContext.stop();
+
+                }
+
+            }
+
+        } else {
+            // throw a 404 "not found" because we did not find the route
+            routesNotFound.mark();
+
+            Result result = getNotFoundResult(context);
+            renderErrorResultAndCatchAndLogExceptions(result, context);
+        }
+
+        activeRequests.dec();
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/Metered.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/Metered.java
@@ -32,6 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author James Moger
  */
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Metered {

--- a/ninja-metrics/src/main/java/ninja/metrics/Metered.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/Metered.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a controller method to be Metered for metrics
+ * collection.
+ *
+ * A meter measures the rate of events over time (e.g., “requests per second”).
+ * In addition to the mean rate, meters also track 1-, 5-, and 15-minute moving averages.
+ *
+ * If no name is specified, the controller classname and method name are used.
+ *
+ * @author James Moger
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Metered {
+
+    String value() default "";
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
@@ -16,41 +16,41 @@
 
 package ninja.metrics;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.inject.Provider;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Provider;
+
 
 public class MeteredInterceptor implements MethodInterceptor {
-    
+
     final private Provider<MetricsService> metricsServiceProvider;
 
     public MeteredInterceptor(Provider<MetricsService> metricsServiceProvider) {
         this.metricsServiceProvider = metricsServiceProvider;
-    }        
-            
+    }
+
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
-        
+
         String timerName = invocation.getMethod().getAnnotation(Metered.class).value();
         if (timerName.isEmpty()) {
             timerName = MetricRegistry.name(invocation.getThis().getClass().getSuperclass(), invocation.getMethod().getName());
         }
-        
-        Meter meter 
+
+        Meter meter
             = metricsServiceProvider
                 .get()
-                .getMetricRegistry(MetricsService.METRICS_REGISTRY_APP)
+                .getMetricRegistry()
                 .meter(timerName);
         meter.mark();
-        
+
         try {
             return invocation.proceed();
         } finally {
-        
+
         }
     }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 ra.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.metrics;
+
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Provider;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+
+public class MeteredInterceptor implements MethodInterceptor {
+    
+    final private Provider<MetricsService> metricsServiceProvider;
+
+    public MeteredInterceptor(Provider<MetricsService> metricsServiceProvider) {
+        this.metricsServiceProvider = metricsServiceProvider;
+    }        
+            
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        
+        String timerName = invocation.getMethod().getAnnotation(Metered.class).value();
+        if (timerName.isEmpty()) {
+            timerName = MetricRegistry.name(invocation.getThis().getClass().getSuperclass(), invocation.getMethod().getName());
+        }
+        
+        Meter meter 
+            = metricsServiceProvider
+                .get()
+                .getMetricRegistry(MetricsService.METRICS_REGISTRY_APP)
+                .meter(timerName);
+        meter.mark();
+        
+        try {
+            return invocation.proceed();
+        } finally {
+        
+        }
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MeteredInterceptor.java
@@ -1,11 +1,11 @@
-/*
- * Copyright 2014 ra.
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ninja.metrics;
 
+package ninja.metrics;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+
+/**
+ * Ninja Module for Metrics
+ *
+ * @author James Moger
+ */
+public class MetricsModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        MetricRegistry appMetrics = new MetricRegistry();
+        bind(MetricRegistry.class).toInstance(appMetrics);
+
+        bind(MetricsService.class).to(MetricsServiceImpl.class);
+
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
@@ -18,6 +18,9 @@ package ninja.metrics;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
+import static com.google.inject.matcher.Matchers.annotatedWith;
+import static com.google.inject.matcher.Matchers.any;
+import ninja.jpa.UnitOfWork;
 
 /**
  * Ninja Module for Metrics
@@ -33,6 +36,23 @@ public class MetricsModule extends AbstractModule {
         bind(MetricRegistry.class).toInstance(appMetrics);
 
         bind(MetricsService.class).to(MetricsServiceImpl.class);
+        
+        TimedInterceptor timedInterceptor 
+            = new TimedInterceptor(getProvider(MetricsService.class));
+        bindInterceptor(
+            any(),
+            annotatedWith(Timed.class),
+            timedInterceptor);
+            
+                        
+        MeteredInterceptor meteredInterceptor 
+            = new MeteredInterceptor(getProvider(MetricsService.class));                      
+        bindInterceptor(
+            any(),
+            annotatedWith(Metered.class),
+            meteredInterceptor);
+                        
+                        
 
     }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
 import static com.google.inject.matcher.Matchers.annotatedWith;
 import static com.google.inject.matcher.Matchers.any;
-import ninja.jpa.UnitOfWork;
 
 /**
  * Ninja Module for Metrics

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
@@ -16,10 +16,11 @@
 
 package ninja.metrics;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.inject.AbstractModule;
 import static com.google.inject.matcher.Matchers.annotatedWith;
 import static com.google.inject.matcher.Matchers.any;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
 
 /**
  * Ninja Module for Metrics
@@ -35,20 +36,28 @@ public class MetricsModule extends AbstractModule {
         bind(MetricRegistry.class).toInstance(appMetrics);
 
         bind(MetricsService.class).to(MetricsServiceImpl.class);
-        
-        TimedInterceptor timedInterceptor 
+
+        TimedInterceptor timedInterceptor
             = new TimedInterceptor(getProvider(MetricsService.class));
         bindInterceptor(
             any(),
             annotatedWith(Timed.class),
-            timedInterceptor);   
-                        
-        MeteredInterceptor meteredInterceptor 
-            = new MeteredInterceptor(getProvider(MetricsService.class));                      
+            timedInterceptor);
+
+        MeteredInterceptor meteredInterceptor
+            = new MeteredInterceptor(getProvider(MetricsService.class));
         bindInterceptor(
             any(),
             annotatedWith(Metered.class),
             meteredInterceptor);
+
+        CountedInterceptor countedInterceptor
+            = new CountedInterceptor(getProvider(MetricsService.class));
+        bindInterceptor(
+            any(),
+            annotatedWith(Counted.class),
+            countedInterceptor);
+
     }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsModule.java
@@ -42,8 +42,7 @@ public class MetricsModule extends AbstractModule {
         bindInterceptor(
             any(),
             annotatedWith(Timed.class),
-            timedInterceptor);
-            
+            timedInterceptor);   
                         
         MeteredInterceptor meteredInterceptor 
             = new MeteredInterceptor(getProvider(MetricsService.class));                      
@@ -51,9 +50,6 @@ public class MetricsModule extends AbstractModule {
             any(),
             annotatedWith(Metered.class),
             meteredInterceptor);
-                        
-                        
-
     }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import ninja.Route;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Responsible for managing the Ninja Metrics module.
+ *
+ * @author James Moger
+ */
+public interface MetricsService {
+
+    String METRICS_REGISTRY_APP = "ninja.app";
+
+    String METRICS_REGISTRY_REQUESTS = "ninja.requests";
+
+    String METRICS_REGISTRY_CACHE = "ninja.cache";
+
+    String METER_ALL_REQUESTS = "ninja.allRequests";
+
+    String COUNTER_ACTIVE_REQUESTS = "ninja.activeRequests";
+
+    String METER_BAD_REQUESTS = "ninja.badRequests";
+
+    String METER_INTERNAL_SERVER_ERRORS = "ninja.internalServerErrors";
+
+    String METER_ROUTES_NOT_FOUND = "ninja.routesNotFound";
+
+    /**
+     * Start the Ninja Metrics service.
+     */
+    void start();
+
+    /**
+     * Stops the Ninja Metrics service.
+     */
+    void stop();
+
+    /**
+     * Return all collected metrics in a single metrics registry.
+     *
+     * @return the aggregate metrics registry
+     */
+    MetricRegistry getAllMetrics();
+
+    /**
+     * Returns the specified metric registry.
+     *
+     * @param name
+     * @return the specified metric registry
+     */
+    MetricRegistry getMetricRegistry(String name);
+
+    /**
+     * Returns the metric for this specific route. This will be null if the
+     * controller method was not annotated with @Timed or @Metered.
+     *
+     * @param route
+     * @return a metric or null
+     */
+    Metric getRouteMetric(Route route);
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
@@ -54,12 +54,12 @@ public interface MetricsService {
      */
     void stop();
 
-    /**
-     * Return all collected metrics in a single metrics registry.
-     *
-     * @return the aggregate metrics registry
-     */
-    MetricRegistry getAllMetrics();
+//    /**
+//     * Return all collected metrics in a single metrics registry.
+//     *
+//     * @return the aggregate metrics registry
+//     */
+//    MetricRegistry getAllMetrics();
 
     /**
      * Returns the specified metric registry.
@@ -69,13 +69,13 @@ public interface MetricsService {
      */
     MetricRegistry getMetricRegistry(String name);
 
-    /**
-     * Returns the metric for this specific route. This will be null if the
-     * controller method was not annotated with @Timed or @Metered.
-     *
-     * @param route
-     * @return a metric or null
-     */
-    Metric getRouteMetric(Route route);
+//    /**
+//     * Returns the metric for this specific route. This will be null if the
+//     * controller method was not annotated with @Timed or @Metered.
+//     *
+//     * @param route
+//     * @return a metric or null
+//     */
+//    Metric getRouteMetric(Route route);
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
@@ -29,19 +29,12 @@ import com.codahale.metrics.MetricRegistry;
 public interface MetricsService {
 
     String METRICS_REGISTRY_APP = "ninja.app";
-
     String METRICS_REGISTRY_REQUESTS = "ninja.requests";
-
     String METRICS_REGISTRY_CACHE = "ninja.cache";
-
     String METER_ALL_REQUESTS = "ninja.allRequests";
-
     String COUNTER_ACTIVE_REQUESTS = "ninja.activeRequests";
-
     String METER_BAD_REQUESTS = "ninja.badRequests";
-
     String METER_INTERNAL_SERVER_ERRORS = "ninja.internalServerErrors";
-
     String METER_ROUTES_NOT_FOUND = "ninja.routesNotFound";
 
     /**
@@ -54,13 +47,6 @@ public interface MetricsService {
      */
     void stop();
 
-//    /**
-//     * Return all collected metrics in a single metrics registry.
-//     *
-//     * @return the aggregate metrics registry
-//     */
-//    MetricRegistry getAllMetrics();
-
     /**
      * Returns the specified metric registry.
      *
@@ -68,14 +54,5 @@ public interface MetricsService {
      * @return the specified metric registry
      */
     MetricRegistry getMetricRegistry(String name);
-
-//    /**
-//     * Returns the metric for this specific route. This will be null if the
-//     * controller method was not annotated with @Timed or @Metered.
-//     *
-//     * @param route
-//     * @return a metric or null
-//     */
-//    Metric getRouteMetric(Route route);
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
@@ -16,9 +16,6 @@
 
 package ninja.metrics;
 
-import ninja.Route;
-
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 
 /**
@@ -28,14 +25,11 @@ import com.codahale.metrics.MetricRegistry;
  */
 public interface MetricsService {
 
-    String METRICS_REGISTRY_APP = "ninja.app";
-    String METRICS_REGISTRY_REQUESTS = "ninja.requests";
-    String METRICS_REGISTRY_CACHE = "ninja.cache";
-    String METER_ALL_REQUESTS = "ninja.allRequests";
-    String COUNTER_ACTIVE_REQUESTS = "ninja.activeRequests";
-    String METER_BAD_REQUESTS = "ninja.badRequests";
-    String METER_INTERNAL_SERVER_ERRORS = "ninja.internalServerErrors";
-    String METER_ROUTES_NOT_FOUND = "ninja.routesNotFound";
+    String METER_ALL_REQUESTS = "ninja.requests.allRequests";
+    String COUNTER_ACTIVE_REQUESTS = "ninja.requests.activeRequests";
+    String METER_BAD_REQUESTS = "ninja.requests.badRequests";
+    String METER_INTERNAL_SERVER_ERRORS = "ninja.requests.internalServerErrors";
+    String METER_ROUTES_NOT_FOUND = "ninja.requests.routesNotFound";
 
     /**
      * Start the Ninja Metrics service.
@@ -48,11 +42,10 @@ public interface MetricsService {
     void stop();
 
     /**
-     * Returns the specified metric registry.
+     * Returns the metric registry.
      *
-     * @param name
-     * @return the specified metric registry
+     * @return the metric registry
      */
-    MetricRegistry getMetricRegistry(String name);
+    MetricRegistry getMetricRegistry();
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsService.java
@@ -48,4 +48,10 @@ public interface MetricsService {
      */
     MetricRegistry getMetricRegistry();
 
+    /**
+     * Returns the hostname of the server.
+     *
+     * @return the hostname
+     */
+    String getHostname();
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -106,9 +106,9 @@ public class MetricsServiceImpl implements MetricsService {
         }
 
         /*
-         * JMX
+         * MBeans for VisualVM, JConsole, or JMX
          */
-        if (ninjaProps.getBooleanWithDefault("metrics.jmx.enabled", true)) {
+        if (ninjaProps.getBooleanWithDefault("metrics.mbeans.enabled", true)) {
 
             JmxReporter reporter = JmxReporter.forRegistry(metricRegistry)
                     .inDomain(applicationName).build();
@@ -117,7 +117,7 @@ public class MetricsServiceImpl implements MetricsService {
 
             reporters.add(reporter);
 
-            log.debug("Started Ninja Metrics JMX reporter");
+            log.debug("Started Ninja Metrics MBeans reporter");
 
         }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -45,17 +45,14 @@ import com.google.inject.Singleton;
 public class MetricsServiceImpl implements MetricsService {
 
     private final Logger log = LoggerFactory.getLogger(MetricsService.class);
-    private final Router router;
     private final Map<String, MetricRegistry> metricRegistries;
     private final NinjaProperties ninjaProps;
     private final List<JmxReporter> jmxReporters;
 
     @Inject
-    public MetricsServiceImpl(Router router,
-                              MetricRegistry appMetrics,
+    public MetricsServiceImpl(MetricRegistry appMetrics,
                               NinjaProperties ninjaProps) {
 
-        this.router = router;
         this.ninjaProps = ninjaProps;
 
         this.metricRegistries = new ConcurrentHashMap<>();
@@ -77,11 +74,8 @@ public class MetricsServiceImpl implements MetricsService {
             jmxReporters.add(createJmxReporter(METRICS_REGISTRY_CACHE));
 
             for (JmxReporter reporter : jmxReporters) {
-
                 reporter.start();
-
             }
-
         }
 
         reporterCount += jmxReporters.size();
@@ -92,38 +86,6 @@ public class MetricsServiceImpl implements MetricsService {
             log.debug("Started Ninja Metrics reporters in {} ms", time);
 
         }
-
-//        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
-//        int timedRoutes = 0;
-//        int meteredRoutes = 0;
-//        for (Route route : router.getRoutes()) {
-//            if (route.getControllerMethod() == null) {
-//                // can occur in unit tests, not in real life
-//                continue;
-//            }
-//
-//            if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
-//                String name = getName(route);
-//                routeRequestRegistry.timer(name);
-//                timedRoutes++;
-//                log.debug("Registered @Timed route {}", name);
-//            } else if (route.getControllerMethod().isAnnotationPresent(
-//                    Metered.class)) {
-//                String name = getName(route);
-//                routeRequestRegistry.meter(name);
-//                meteredRoutes++;
-//                log.debug("Registered @Metered route {}", name);
-//            }
-//        }
-//
-//        if (timedRoutes > 0) {
-//            log.info("Ninja Metrics registered {} @Timed routes.", timedRoutes);
-//        }
-//
-//        if (meteredRoutes > 0) {
-//            log.info("Ninja Metrics registered {} @Metered routes.",
-//                    meteredRoutes);
-//        }
 
         log.info("Ninja Metrics is ready for collection.");
     }
@@ -150,39 +112,8 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     protected JmxReporter createJmxReporter(String name) {
-        return JmxReporter.forRegistry(getMetricRegistry(name)).inDomain(name)
-                .build();
+        return JmxReporter.forRegistry(getMetricRegistry(name)).inDomain(name).build();
     }
-
-//    protected String getName(Route route) {
-//        String name = null;
-//        if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
-//            Timed timed = route.getControllerMethod()
-//                    .getAnnotation(Timed.class);
-//            name = timed.value();
-//        } else if (route.getControllerMethod().isAnnotationPresent(
-//                Metered.class)) {
-//            Metered metered = route.getControllerMethod().getAnnotation(
-//                    Metered.class);
-//            name = metered.value();
-//        }
-//
-//        if (name == null || name.isEmpty()) {
-//            name = MetricRegistry.name(route.getControllerClass(), route
-//                    .getControllerMethod().getName());
-//        }
-//
-//        return name;
-//    }
-
-//    @Override
-//    public MetricRegistry getAllMetrics() {
-//        MetricRegistry allMetrics = new MetricRegistry();
-//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_APP));
-//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_REQUESTS));
-//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_CACHE));
-//        return allMetrics;
-//    }
 
     @Override
     public MetricRegistry getMetricRegistry(String name) {
@@ -192,16 +123,5 @@ public class MetricsServiceImpl implements MetricsService {
 
         return metricRegistries.get(name);
     }
-
-//    @Override
-//    public Metric getRouteMetric(Route route) {
-//        if (route.getControllerMethod() == null) {
-//            return null;
-//        }
-//
-//        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
-//        String name = getName(route);
-//        return routeRequestRegistry.getMetrics().get(name);
-//    }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -16,18 +16,13 @@
 
 package ninja.metrics;
 
-import info.ganglia.gmetric4j.gmetric.GMetric;
-import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
@@ -41,14 +36,8 @@ import ch.qos.logback.classic.LoggerContext;
 
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.ganglia.GangliaReporter;
-import com.codahale.metrics.graphite.Graphite;
-import com.codahale.metrics.graphite.GraphiteReporter;
-import com.codahale.metrics.graphite.GraphiteSender;
-import com.codahale.metrics.graphite.PickledGraphite;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
@@ -85,7 +74,6 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public void start() {
 
-        String hostname = determineHostname();
         String applicationName = ninjaProps.getWithDefault(
                 NinjaConstant.applicationName, "Ninja");
 
@@ -133,64 +121,6 @@ public class MetricsServiceImpl implements MetricsService {
 
         }
 
-        /*
-         * Graphite
-         */
-        if (ninjaProps.getBooleanWithDefault("metrics.graphite.enabled", false)) {
-
-            String address = ninjaProps.getWithDefault("metrics.graphite.address", "graphite.example.com");
-            int port = ninjaProps.getIntegerWithDefault("metrics.graphite.port", 2003);
-            boolean isPickled = ninjaProps.getBooleanWithDefault("metrics.graphite.pickled", false);
-            InetSocketAddress graphiteAddress = new InetSocketAddress(address, port);
-
-            final GraphiteSender sender;
-            if (isPickled) {
-                sender = new PickledGraphite(graphiteAddress);
-            } else {
-                sender = new Graphite(graphiteAddress);
-            }
-
-            final GraphiteReporter reporter = GraphiteReporter.forRegistry(metricRegistry)
-                                                              .prefixedWith(hostname)
-                                                              .convertRatesTo(TimeUnit.SECONDS)
-                                                              .convertDurationsTo(TimeUnit.MILLISECONDS)
-                                                              .filter(MetricFilter.ALL)
-                                                              .build(sender);
-            reporter.start(1, TimeUnit.MINUTES);
-
-            reporters.add(reporter);
-
-            log.debug("Started Ninja Metrics Graphite reporter");
-
-        }
-
-        /*
-         * Ganglia
-         */
-        if (ninjaProps.getBooleanWithDefault("metrics.ganglia.enabled", false)) {
-
-            String address = ninjaProps.getWithDefault("metrics.ganglia.address", "ganglia.example.com");
-            int port = ninjaProps.getIntegerWithDefault("metrics.ganglia.port", 8649);
-
-            try {
-                GMetric ganglia = new GMetric(address, port, UDPAddressingMode.MULTICAST, 1);
-                final GangliaReporter reporter = GangliaReporter.forRegistry(metricRegistry)
-                        .convertRatesTo(TimeUnit.SECONDS)
-                        .convertDurationsTo(TimeUnit.MILLISECONDS)
-                        .build(ganglia);
-
-                reporters.add(reporter);
-
-                reporter.start(1, TimeUnit.MINUTES);
-
-                log.debug("Started Ninja Metrics Ganglia reporter");
-
-            } catch (IOException e) {
-                log.error("Failed to create Ganglia reporter!", e);
-            }
-
-        }
-
         log.info("Ninja Metrics is ready for collection.");
 
     }
@@ -231,7 +161,8 @@ public class MetricsServiceImpl implements MetricsService {
         }
     }
 
-    private String determineHostname() {
+    @Override
+    public String getHostname() {
         // try InetAddress.LocalHost first;
         // NOTE -- InetAddress.getLocalHost().getHostName() will not work in
         // certain environments.

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -117,10 +117,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     @Override
     public MetricRegistry getMetricRegistry(String name) {
-        if (!metricRegistries.containsKey(name)) {
-            metricRegistries.put(name, new MetricRegistry());
-        }
-
+        metricRegistries.putIfAbsent(name, new MetricRegistry());
         return metricRegistries.get(name);
     }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -47,7 +47,7 @@ public class MetricsServiceImpl implements MetricsService {
                               NinjaProperties ninjaProps) {
 
         this.ninjaProps = ninjaProps;
-        this.metricRegistry = new MetricRegistry();
+        this.metricRegistry = appMetrics;
 
     }
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -93,37 +93,37 @@ public class MetricsServiceImpl implements MetricsService {
 
         }
 
-        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
-        int timedRoutes = 0;
-        int meteredRoutes = 0;
-        for (Route route : router.getRoutes()) {
-            if (route.getControllerMethod() == null) {
-                // can occur in unit tests, not in real life
-                continue;
-            }
-
-            if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
-                String name = getName(route);
-                routeRequestRegistry.timer(name);
-                timedRoutes++;
-                log.debug("Registered @Timed route {}", name);
-            } else if (route.getControllerMethod().isAnnotationPresent(
-                    Metered.class)) {
-                String name = getName(route);
-                routeRequestRegistry.meter(name);
-                meteredRoutes++;
-                log.debug("Registered @Metered route {}", name);
-            }
-        }
-
-        if (timedRoutes > 0) {
-            log.info("Ninja Metrics registered {} @Timed routes.", timedRoutes);
-        }
-
-        if (meteredRoutes > 0) {
-            log.info("Ninja Metrics registered {} @Metered routes.",
-                    meteredRoutes);
-        }
+//        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
+//        int timedRoutes = 0;
+//        int meteredRoutes = 0;
+//        for (Route route : router.getRoutes()) {
+//            if (route.getControllerMethod() == null) {
+//                // can occur in unit tests, not in real life
+//                continue;
+//            }
+//
+//            if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
+//                String name = getName(route);
+//                routeRequestRegistry.timer(name);
+//                timedRoutes++;
+//                log.debug("Registered @Timed route {}", name);
+//            } else if (route.getControllerMethod().isAnnotationPresent(
+//                    Metered.class)) {
+//                String name = getName(route);
+//                routeRequestRegistry.meter(name);
+//                meteredRoutes++;
+//                log.debug("Registered @Metered route {}", name);
+//            }
+//        }
+//
+//        if (timedRoutes > 0) {
+//            log.info("Ninja Metrics registered {} @Timed routes.", timedRoutes);
+//        }
+//
+//        if (meteredRoutes > 0) {
+//            log.info("Ninja Metrics registered {} @Metered routes.",
+//                    meteredRoutes);
+//        }
 
         log.info("Ninja Metrics is ready for collection.");
     }
@@ -154,35 +154,35 @@ public class MetricsServiceImpl implements MetricsService {
                 .build();
     }
 
-    protected String getName(Route route) {
-        String name = null;
-        if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
-            Timed timed = route.getControllerMethod()
-                    .getAnnotation(Timed.class);
-            name = timed.value();
-        } else if (route.getControllerMethod().isAnnotationPresent(
-                Metered.class)) {
-            Metered metered = route.getControllerMethod().getAnnotation(
-                    Metered.class);
-            name = metered.value();
-        }
+//    protected String getName(Route route) {
+//        String name = null;
+//        if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
+//            Timed timed = route.getControllerMethod()
+//                    .getAnnotation(Timed.class);
+//            name = timed.value();
+//        } else if (route.getControllerMethod().isAnnotationPresent(
+//                Metered.class)) {
+//            Metered metered = route.getControllerMethod().getAnnotation(
+//                    Metered.class);
+//            name = metered.value();
+//        }
+//
+//        if (name == null || name.isEmpty()) {
+//            name = MetricRegistry.name(route.getControllerClass(), route
+//                    .getControllerMethod().getName());
+//        }
+//
+//        return name;
+//    }
 
-        if (name == null || name.isEmpty()) {
-            name = MetricRegistry.name(route.getControllerClass(), route
-                    .getControllerMethod().getName());
-        }
-
-        return name;
-    }
-
-    @Override
-    public MetricRegistry getAllMetrics() {
-        MetricRegistry allMetrics = new MetricRegistry();
-        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_APP));
-        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_REQUESTS));
-        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_CACHE));
-        return allMetrics;
-    }
+//    @Override
+//    public MetricRegistry getAllMetrics() {
+//        MetricRegistry allMetrics = new MetricRegistry();
+//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_APP));
+//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_REQUESTS));
+//        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_CACHE));
+//        return allMetrics;
+//    }
 
     @Override
     public MetricRegistry getMetricRegistry(String name) {
@@ -193,15 +193,15 @@ public class MetricsServiceImpl implements MetricsService {
         return metricRegistries.get(name);
     }
 
-    @Override
-    public Metric getRouteMetric(Route route) {
-        if (route.getControllerMethod() == null) {
-            return null;
-        }
-
-        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
-        String name = getName(route);
-        return routeRequestRegistry.getMetrics().get(name);
-    }
+//    @Override
+//    public Metric getRouteMetric(Route route) {
+//        if (route.getControllerMethod() == null) {
+//            return null;
+//        }
+//
+//        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
+//        String name = getName(route);
+//        return routeRequestRegistry.getMetrics().get(name);
+//    }
 
 }

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -45,7 +45,7 @@ import com.google.inject.Singleton;
 public class MetricsServiceImpl implements MetricsService {
 
     private final Logger log = LoggerFactory.getLogger(MetricsService.class);
-    private final Map<String, MetricRegistry> metricRegistries;
+    private final ConcurrentHashMap<String, MetricRegistry> metricRegistries;
     private final NinjaProperties ninjaProps;
     private final List<JmxReporter> jmxReporters;
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import ninja.Route;
+import ninja.Router;
+import ninja.lifecycle.Dispose;
+import ninja.lifecycle.Start;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Implementation of the metrics service.
+ *
+ * @author James Moger
+ */
+@Singleton
+public class MetricsServiceImpl implements MetricsService {
+
+    private final Logger log = LoggerFactory.getLogger(MetricsService.class);
+    private final Router router;
+    private final Map<String, MetricRegistry> metricRegistries;
+    private final NinjaProperties ninjaProps;
+    private final List<JmxReporter> jmxReporters;
+
+    @Inject
+    public MetricsServiceImpl(Router router,
+                              MetricRegistry appMetrics,
+                              NinjaProperties ninjaProps) {
+
+        this.router = router;
+        this.ninjaProps = ninjaProps;
+
+        this.metricRegistries = new ConcurrentHashMap<>();
+        this.metricRegistries.put(METRICS_REGISTRY_APP, appMetrics);
+
+        this.jmxReporters = new ArrayList<>();
+    }
+
+    @Start(order = 10)
+    @Override
+    public void start() {
+        long startTime = System.currentTimeMillis();
+
+        int reporterCount = 0;
+        if (ninjaProps.getBooleanWithDefault("metrics.jmx", true)) {
+
+            jmxReporters.add(createJmxReporter(METRICS_REGISTRY_APP));
+            jmxReporters.add(createJmxReporter(METRICS_REGISTRY_REQUESTS));
+            jmxReporters.add(createJmxReporter(METRICS_REGISTRY_CACHE));
+
+            for (JmxReporter reporter : jmxReporters) {
+
+                reporter.start();
+
+            }
+
+        }
+
+        reporterCount += jmxReporters.size();
+
+        if (reporterCount > 0) {
+
+            long time = System.currentTimeMillis() - startTime;
+            log.debug("Started Ninja Metrics reporters in {} ms", time);
+
+        }
+
+        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
+        int timedRoutes = 0;
+        int meteredRoutes = 0;
+        for (Route route : router.getRoutes()) {
+            if (route.getControllerMethod() == null) {
+                // can occur in unit tests, not in real life
+                continue;
+            }
+
+            if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
+                String name = getName(route);
+                routeRequestRegistry.timer(name);
+                timedRoutes++;
+                log.debug("Registered @Timed route {}", name);
+            } else if (route.getControllerMethod().isAnnotationPresent(
+                    Metered.class)) {
+                String name = getName(route);
+                routeRequestRegistry.meter(name);
+                meteredRoutes++;
+                log.debug("Registered @Metered route {}", name);
+            }
+        }
+
+        if (timedRoutes > 0) {
+            log.info("Ninja Metrics registered {} @Timed routes.", timedRoutes);
+        }
+
+        if (meteredRoutes > 0) {
+            log.info("Ninja Metrics registered {} @Metered routes.",
+                    meteredRoutes);
+        }
+
+        log.info("Ninja Metrics is ready for collection.");
+    }
+
+    @Dispose(order = 10)
+    @Override
+    public void stop() {
+        long start = System.currentTimeMillis();
+
+        if (!jmxReporters.isEmpty()) {
+
+            log.debug("Stopping Ninja Metrics reporters...");
+
+            for (JmxReporter reporter : jmxReporters) {
+                reporter.stop();
+            }
+
+            long time = System.currentTimeMillis() - start;
+            log.debug("Ninja Metrics reporters stopped in {} ms", time);
+
+        }
+
+        log.info("Ninja Metrics stopped.");
+    }
+
+    protected JmxReporter createJmxReporter(String name) {
+        return JmxReporter.forRegistry(getMetricRegistry(name)).inDomain(name)
+                .build();
+    }
+
+    protected String getName(Route route) {
+        String name = null;
+        if (route.getControllerMethod().isAnnotationPresent(Timed.class)) {
+            Timed timed = route.getControllerMethod()
+                    .getAnnotation(Timed.class);
+            name = timed.value();
+        } else if (route.getControllerMethod().isAnnotationPresent(
+                Metered.class)) {
+            Metered metered = route.getControllerMethod().getAnnotation(
+                    Metered.class);
+            name = metered.value();
+        }
+
+        if (name == null || name.isEmpty()) {
+            name = MetricRegistry.name(route.getControllerClass(), route
+                    .getControllerMethod().getName());
+        }
+
+        return name;
+    }
+
+    @Override
+    public MetricRegistry getAllMetrics() {
+        MetricRegistry allMetrics = new MetricRegistry();
+        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_APP));
+        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_REQUESTS));
+        allMetrics.registerAll(getMetricRegistry(METRICS_REGISTRY_CACHE));
+        return allMetrics;
+    }
+
+    @Override
+    public MetricRegistry getMetricRegistry(String name) {
+        if (!metricRegistries.containsKey(name)) {
+            metricRegistries.put(name, new MetricRegistry());
+        }
+
+        return metricRegistries.get(name);
+    }
+
+    @Override
+    public Metric getRouteMetric(Route route) {
+        if (route.getControllerMethod() == null) {
+            return null;
+        }
+
+        MetricRegistry routeRequestRegistry = getMetricRegistry(METRICS_REGISTRY_REQUESTS);
+        String name = getName(route);
+        return routeRequestRegistry.getMetrics().get(name);
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/Timed.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/Timed.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a controller method to be Timed for metrics
+ * collection.
+ *
+ * A timer measures both the rate that a particular piece of code is called
+ * and the distribution of its duration.
+ *
+ * If no name is specified, the controller classname and method name are used.
+ *
+ * @author James Moger
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Timed {
+
+    String value() default "";
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 ra.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ *
+ * @author ra
+ */
+public class TimedInterceptor implements MethodInterceptor {
+    
+    final Provider<MetricsService> metricsServiceProvider;
+    
+    @Inject
+    public TimedInterceptor(Provider<MetricsService> metricsServiceProvider) {
+        this.metricsServiceProvider = metricsServiceProvider;
+    }        
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        
+        String timerName = invocation.getMethod().getAnnotation(Timed.class).value();
+        
+
+        if (timerName.isEmpty()) {
+            timerName = MetricRegistry.name(invocation.getThis().getClass().getSuperclass(), invocation.getMethod().getName());
+        }
+
+        Timer.Context timerContext 
+            = metricsServiceProvider
+                .get()
+                .getMetricRegistry(MetricsService.METRICS_REGISTRY_APP)
+                .timer(timerName)
+                .time();
+
+        try {
+            return invocation.proceed();
+        } finally {
+            timerContext.stop();
+        }
+    }
+
+}

--- a/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
@@ -16,39 +16,40 @@
 
 package ninja.metrics;
 
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
 
 /**
  *
  * @author ra
  */
 public class TimedInterceptor implements MethodInterceptor {
-    
+
     final Provider<MetricsService> metricsServiceProvider;
-    
+
     @Inject
     public TimedInterceptor(Provider<MetricsService> metricsServiceProvider) {
         this.metricsServiceProvider = metricsServiceProvider;
-    }        
+    }
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
-        
+
         String timerName = invocation.getMethod().getAnnotation(Timed.class).value();
 
         if (timerName.isEmpty()) {
             timerName = MetricRegistry.name(invocation.getThis().getClass().getSuperclass(), invocation.getMethod().getName());
         }
 
-        Timer.Context timerContext 
+        Timer.Context timerContext
             = metricsServiceProvider
                 .get()
-                .getMetricRegistry(MetricsService.METRICS_REGISTRY_APP)
+                .getMetricRegistry()
                 .timer(timerName)
                 .time();
 

--- a/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/TimedInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 ra.
+ * Copyright (C) 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package ninja.metrics;
 
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.inject.Inject;
@@ -40,7 +40,6 @@ public class TimedInterceptor implements MethodInterceptor {
     public Object invoke(MethodInvocation invocation) throws Throwable {
         
         String timerName = invocation.getMethod().getAnnotation(Timed.class).value();
-        
 
         if (timerName.isEmpty()) {
             timerName = MetricRegistry.name(invocation.getThis().getClass().getSuperclass(), invocation.getMethod().getName());

--- a/ninja-metrics/src/test/java/ninja/metrics/InstrumentedCacheTest.java
+++ b/ninja-metrics/src/test/java/ninja/metrics/InstrumentedCacheTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.metrics;
+
+import ninja.metrics.*;
+import java.util.Map;
+
+import ninja.cache.Cache;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+
+public class InstrumentedCacheTest {
+    
+    @Mock
+    Cache Cache;
+    
+    @Mock
+    
+    
+    @InjectMocks
+    InstrumentedCache instrumentedCache;
+
+    public void teatAddKeyValueExpiration() {
+    
+    
+    }
+  
+}

--- a/ninja-metrics/src/test/java/ninja/metrics/MetricsServiceImplTest.java
+++ b/ninja-metrics/src/test/java/ninja/metrics/MetricsServiceImplTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 ra.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import ninja.utils.NinjaProperties;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.mockito.Mock;
+
+public class MetricsServiceImplTest {
+    
+    @Mock
+    NinjaProperties ninjaProperties;
+    
+    MetricsServiceImpl metricsServiceImpl;
+    
+    @Mock
+    MetricRegistry metricRegistry;
+
+    @Before
+    public void before() {
+        metricsServiceImpl = new MetricsServiceImpl(metricRegistry, ninjaProperties);
+    }
+    
+    @Test
+    public void testSomeMethod() {
+    }
+    
+}

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -149,6 +149,11 @@
         
         <dependency>
             <groupId>org.ninjaframework</groupId>
+            <artifactId>ninja-metrics</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-standalone</artifactId>
         </dependency>
 

--- a/ninja-servlet-integration-test/src/main/java/conf/Module.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Module.java
@@ -16,6 +16,8 @@
 
 package conf;
 
+import ninja.metrics.MetricsModule;
+
 import com.google.inject.AbstractModule;
 
 import etc.GreetingService;
@@ -37,6 +39,8 @@ public class Module extends AbstractModule {
         bind(GreetingService.class).to(GreetingServiceImpl.class).asEagerSingleton();
         // Bind the UDP ping controller so it starts up on server start
         // bind(UdpPingController.class);
+
+        install(new MetricsModule());
 
     }
 

--- a/ninja-servlet-integration-test/src/main/java/conf/Ninja.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Ninja.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conf;
+
+import ninja.metrics.InstrumentedNinja;
+
+/**
+ * Collection Metrics data on the routes of this Ninja app.
+ *
+ * @author James Moger
+ *
+ */
+public class Ninja extends InstrumentedNinja {
+
+}

--- a/ninja-servlet-integration-test/src/main/java/conf/application.conf
+++ b/ninja-servlet-integration-test/src/main/java/conf/application.conf
@@ -28,3 +28,5 @@ testproperty=without special mode we use this one... juchuuuu!!!!
 %test.testproperty=test testproperty!!!!
 %dev.testproperty=dev testing
 application.secret = z3TVP9wYlkO3a5FWD6t3dCRpp59mmSghDalgJWaYUC5Pd29xQXYALSCyyEaezgRH
+
+cache.implementation = ninja.metrics.InstrumentedEhCache

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -31,6 +31,7 @@ import ninja.Router;
 import ninja.cache.NinjaCache;
 import ninja.i18n.Lang;
 import ninja.i18n.Messages;
+import ninja.metrics.Timed;
 import ninja.params.Param;
 import ninja.params.PathParam;
 import ninja.servlet.util.Request;
@@ -77,6 +78,7 @@ public class ApplicationController {
     @Inject 
     NinjaProperties ninjaProperties;
 
+    @Timed
     public Result index(@Request HttpServletRequest httpServletRequest,
                            @Response HttpServletResponse httpServletResponse,
                            Context context) {
@@ -95,11 +97,13 @@ public class ApplicationController {
 
     }
 
+    @Timed
     public Result testPage() {
         return Results.html();
 
     }
 
+    @Timed
     public Result userDashboard(@PathParam("email") String email,
                                 @PathParam("id") Integer id,
                                 Context context) {
@@ -119,6 +123,7 @@ public class ApplicationController {
         return Results.html().render(map);
     }
 
+    @Timed
     public Result validation(Validation validation,
                              @Param("email") @Required String email) {
 
@@ -130,12 +135,14 @@ public class ApplicationController {
         }
     }
 
+    @Timed
     public Result redirect(Context context) {
         // Redirects back to the main page simply call redirect
         return Results.redirect("/");
 
     }
 
+    @Timed
     public Result session(Session session) {
         // Sets the username "kevin" in the session-cookie
         session.put("username", "kevin");
@@ -144,6 +151,7 @@ public class ApplicationController {
 
     }
 
+    @Timed
     public Result flashSuccess(FlashScope flashScope, Context context) {
         
         Result result = Results.html();
@@ -157,7 +165,8 @@ public class ApplicationController {
         return result;
 
     }
-    
+
+    @Timed    
     public Result flashError(Context context, FlashScope flashScope) {
         Result result = Results.html();
         // sets a 18n flash message and adds a timestamp to make sure formatting works
@@ -169,7 +178,8 @@ public class ApplicationController {
         return result;
 
     }
-    
+
+    @Timed    
     public Result flashAny(Context context, FlashScope flashScope) {
         Result result = Results.html();
         // sets a 18n flash message and adds a timestamp to make sure formatting works
@@ -182,12 +192,14 @@ public class ApplicationController {
 
     }
 
+    @Timed
     public Result postForm(Context context, FormObject formObject) {
         // formObject is parsed into the method
         // and rendered as json
         return Results.json().render(formObject);
     }
 
+    @Timed
     public Result directObjectTemplateRendering() {
         // Uses Results.html().render(Object) to directly 
         // render an object with a Freemarker template
@@ -199,6 +211,7 @@ public class ApplicationController {
         return Results.html().render(testObject);
     }
 
+    @Timed
     public Result htmlEscaping(Context context) {
 
         // just an example of html escaping in action.
@@ -210,7 +223,7 @@ public class ApplicationController {
 
     }
     
-    
+    @Timed    
     public Result testCaching() {
         
         // Simple integration test to check if ehcache works:
@@ -233,16 +246,19 @@ public class ApplicationController {
 
     }
 
+    @Timed
     public Result testJsonP() {
         return Results.jsonp().render("object", "value");
     }
     
+    @Timed
     public Result badRequest() {
     
         throw new BadRequestException("Just a test to make sure 400 bad request works :)");
         
     }
-    
+
+    @Timed    
     public Result testReverseRouting() {
     
         return Results.html()
@@ -250,7 +266,8 @@ public class ApplicationController {
                 .render("id", "100000");
         
     }
-    
+
+    @Timed    
     public Result testGetContextPathWorks(Context context) {
     
         return Results.html()

--- a/ninja-servlet/pom.xml
+++ b/ninja-servlet/pom.xml
@@ -59,4 +59,13 @@
 
 
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ninja-standalone/pom.xml
+++ b/ninja-standalone/pom.xml
@@ -61,4 +61,13 @@
         </dependency>
         
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ninja-test-utilities/pom.xml
+++ b/ninja-test-utilities/pom.xml
@@ -111,5 +111,15 @@
 
 
     </dependencies>
+    
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <modules>
         <module>ninja-core</module>
         <module>ninja-metrics</module>
+        <module>ninja-metrics-graphite</module>
+        <module>ninja-metrics-ganglia</module>
+        <module>ninja-metrics-librato</module>
         <module>ninja-servlet</module>
         <module>ninja-standalone</module>
         <module>ninja-test-utilities</module>
@@ -58,6 +61,7 @@
         <jetty.version>9.2.1.v20140609</jetty.version>
         <hibernate.version>4.3.5.Final</hibernate.version>
         <jackson.version>2.4.1</jackson.version>
+        <metrics.version>3.1.0</metrics.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>ninja-core</module>
+        <module>ninja-metrics</module>
         <module>ninja-servlet</module>
         <module>ninja-standalone</module>
         <module>ninja-test-utilities</module>
@@ -303,6 +304,12 @@
                 <version>${project.version}</version>
             </dependency>
             
+            <dependency>
+                <groupId>org.ninjaframework</groupId>
+                <artifactId>ninja-metrics</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.ninjaframework</groupId>
                 <artifactId>ninja-servlet</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>ninja-metrics-graphite</module>
         <module>ninja-metrics-ganglia</module>
         <module>ninja-metrics-librato</module>
+        <module>ninja-metrics-influxdb</module>
         <module>ninja-servlet</module>
         <module>ninja-standalone</module>
         <module>ninja-test-utilities</module>


### PR DESCRIPTION
This is a basic integration of [Metrics](http://metrics.codahale.com) support.  It currently collects and exposes Route and JVM metrics over JMX (install MBean plugin in VisualVM).  Individual controller methods may be annotated with `@Timed` for the integration to collect and report metrics.

This PR will create a merge conflict with #195 since they both implement a `getRoutes()` method for the Router.  Assuming one or the other is merged, I will rebase.
