### PR TITLE
Throw IllegalStateException when a registered controller method does not exist

### DIFF
--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -175,6 +175,10 @@ class RouteBuilderImpl implements RouteBuilder {
         // Calculate filters
         LinkedList<Class<? extends Filter>> filters = new LinkedList<Class<? extends Filter>>();
         if(controller != null) {
+            if (controllerMethod == null) {
+                throw new IllegalStateException(
+                        String.format("Route '%s' does not have a controller method", uri));
+            }
             filters.addAll(calculateFiltersForClass(controller));
             FilterWith filterWith = controllerMethod
                     .getAnnotation(FilterWith.class);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2014-07-22 Throw IllegalStateException when a registered controller method does not exist (gitblit)
  * 2014-06-06 Fixed testcase that was flaky in GMT-5 timezones. (ra) 
  * 2014-06-05 Fixed dependency problems with scope test and ninja-test-utilities (ra) 
 

--- a/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
@@ -312,6 +312,19 @@ public class RouteBuilderImplTest {
         assertEquals(result.getTemplate(), template);
     }
 
+    @Test
+    public void testFailedControllerRegistration() {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/failure").with(MockController.class, "DoesNotExist");
+
+        try {	
+            Route route = routeBuilder.buildRoute(injector);
+            assertTrue(route == null);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalStateException);
+        }
+    }
+
     private Route buildRoute(RouteBuilderImpl builder) {
         builder.with(MockController.class, "execute");
         return builder.buildRoute(injector);


### PR DESCRIPTION
It is possible to register a controller method that does not exist.  This is logged but it will trigger a non-informative NPE when building the route.  Instead we should throw an IllegalStateException with a more informative message.
