### PR TITLE
Add type support for primitive & object types: byte, short, char, enum, & arrays

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
+++ b/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
@@ -16,14 +16,16 @@
 
 package ninja.params;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
 import ninja.Context;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.validation.Validation;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 
 /**
  * Built in argument extractors
@@ -150,6 +152,83 @@ public class ArgumentExtractors {
         @Override
         public Class<String> getExtractedType() {
             return String.class;
+        }
+
+        @Override
+        public String getFieldName() {
+            return key;
+        }
+    }
+
+    public static class ParamsExtractor implements ArgumentExtractor<String[]> {
+        private final String key;
+
+        public ParamsExtractor(Params param) {
+            this.key = param.value();
+        }
+
+        @Override
+        public String[] extract(Context context) {
+            List<String> values = context.getParameterValues(key);
+            if (values == null || values.isEmpty()) {
+                return null;
+            }
+            return values.toArray(new String[values.size()]);
+        }
+
+        @Override
+        public Class<String[]> getExtractedType() {
+            return String[].class;
+        }
+
+        @Override
+        public String getFieldName() {
+            return key;
+        }
+    }
+
+    public static class HeaderExtractor implements ArgumentExtractor<String> {
+        private final String key;
+
+        public HeaderExtractor(Header header) {
+            this.key = header.value();
+        }
+
+        @Override
+        public String extract(Context context) {
+            return context.getHeader(key);
+        }
+
+        @Override
+        public Class<String> getExtractedType() {
+            return String.class;
+        }
+
+        @Override
+        public String getFieldName() {
+            return key;
+        }
+    }
+
+    public static class HeadersExtractor implements ArgumentExtractor<String[]> {
+        private final String key;
+
+        public HeadersExtractor(Headers headers) {
+            this.key = headers.value();
+        }
+
+        @Override
+        public String[] extract(Context context) {
+            List<String> values = context.getHeaders(key);
+            if (values == null || values.isEmpty()) {
+                return null;
+            }
+            return values.toArray(new String[values.size()]);
+        }
+
+        @Override
+        public Class<String[]> getExtractedType() {
+            return String[].class;
         }
 
         @Override

--- a/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
+++ b/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import ninja.Context;
 import ninja.RoutingException;
+import ninja.params.ParamParsers.ArrayParamParser;
 import ninja.validation.Validator;
 import ninja.validation.WithValidator;
 
@@ -177,7 +178,7 @@ public class ControllerMethodInvoker {
         if (!boxedParamType.isAssignableFrom(extractor.getExtractedType())) {
             if (extractor.getFieldName() != null) {
                 if (String.class.isAssignableFrom(extractor.getExtractedType())) {
-                    // Look up a parser
+                    // Look up a parser for a single-valued parameter
                     ParamParser<?> parser = ParamParsers.getParamParser(paramType);
                     if (parser == null) {
                         throw new RoutingException("Can't find parameter parser for type "
@@ -185,7 +186,18 @@ public class ControllerMethodInvoker {
                                 + extractor.getFieldName());
                     } else {
                         extractor =
-                                new ParsingArgumentExtractor((ArgumentExtractor) extractor, parser);
+                                new ParsingArgumentExtractor(extractor, parser);
+                    }
+                } else if (String[].class.isAssignableFrom(extractor.getExtractedType())) {
+                    // Look up a parser for a multi-valued parameter
+                    ArrayParamParser<?> parser = ParamParsers.getArrayParser(paramType);
+                    if (parser == null) {
+                        throw new RoutingException("Can't find parameter array parser for type "
+                                + extractor.getExtractedType() + " on field "
+                                + extractor.getFieldName());
+                    } else {
+                        extractor =
+                                new ParsingArrayExtractor(extractor, parser);
                     }
 
                 } else {
@@ -275,6 +287,12 @@ public class ControllerMethodInvoker {
             return Float.class;
         } else if (typeToBox == double.class) {
             return Double.class;
+        } else if (typeToBox == byte.class) {
+            return Byte.class;
+        } else if (typeToBox == short.class) {
+            return Short.class;
+        } else if (typeToBox == char.class) {
+            return Character.class;
         }
         throw new IllegalArgumentException("Don't know how to box type of " + typeToBox);
     }

--- a/ninja-core/src/main/java/ninja/params/Header.java
+++ b/ninja-core/src/main/java/ninja/params/Header.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.params;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Just an idea to inject a header right into the methods...
+ *
+ * This equals context.getHeader(...)
+ *
+ * @author James Moger
+ *
+ */
+@WithArgumentExtractor(ArgumentExtractors.HeaderExtractor.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface Header {
+    String value();
+}

--- a/ninja-core/src/main/java/ninja/params/Headers.java
+++ b/ninja-core/src/main/java/ninja/params/Headers.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.params;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Injects a multi-valued header right into the methods...
+ *
+ * This equals context.getHeaders(...)
+ *
+ * @author James Moger
+ *
+ */
+@WithArgumentExtractor(ArgumentExtractors.HeadersExtractor.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface Headers {
+    String value();
+}

--- a/ninja-core/src/main/java/ninja/params/ParamParsers.java
+++ b/ninja-core/src/main/java/ninja/params/ParamParsers.java
@@ -16,13 +16,17 @@
 
 package ninja.params;
 
-import com.google.common.collect.ImmutableMap;
+import java.lang.reflect.Array;
+import java.util.Map;
+
 import ninja.validation.ConstraintViolation;
+import ninja.validation.IsEnum;
 import ninja.validation.IsFloat;
 import ninja.validation.IsInteger;
 import ninja.validation.Validation;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 /**
  * Built in parsers for parameters
@@ -42,10 +46,76 @@ public class ParamParsers {
                     .put(float.class, new PrimitiveFloatParamParser())
                     .put(Double.class, new DoubleParamParser())
                     .put(double.class, new PrimitiveDoubleParamParser())
+                    .put(String.class, new StringParamParser())
+                    .put(Byte.class, new ByteParamParser())
+                    .put(byte.class, new PrimitiveByteParamParser())
+                    .put(Short.class, new ShortParamParser())
+                    .put(short.class, new PrimitiveShortParamParser())
+                    .put(Character.class, new CharacterParamParser())
+                    .put(char.class, new PrimitiveCharacterParamParser())
                     .build();
 
+    private static final Map<Class<? extends Enum<?>>, ParamParser<?>> ENUM_PARSERS = Maps.newHashMap();
+
     public static ParamParser<?> getParamParser(Class<?> targetType) {
+
+        if (targetType.isArray()) {
+            // check for array of registered types
+            Class<?> componentType = targetType.getComponentType();
+            ParamParser<?> componentParser = getParamParser(componentType);
+
+            if (componentParser != null) {
+                // return CSV parser
+                return new CsvParamParser(targetType, componentParser);
+            }
+        }
+
+        if (ENUM_PARSERS.containsKey(targetType)) {
+            return ENUM_PARSERS.get(targetType);
+        }
+
         return PARAM_PARSERS.get(targetType);
+    }
+
+    public static <E extends Enum<E>> void unregisterEnum(final Class<E> enumClass) {
+        ENUM_PARSERS.remove(enumClass);
+    }
+
+    public static <E extends Enum<E>> void registerEnum(final Class<E> enumClass) {
+        registerEnum(enumClass, true);
+    }
+
+    public static <E extends Enum<E>> void registerEnum(final Class<E> enumClass, final boolean caseSensitive) {
+        EnumParamParser<E> parser = new EnumParamParser<E>() {
+
+            @Override
+            public Class<E> getParsedType() {
+                return enumClass;
+            }
+
+            @Override
+            protected boolean isCaseSensitive() {
+                return caseSensitive;
+            }
+
+        };
+
+        ENUM_PARSERS.put(enumClass, parser);
+    }
+
+    public static ArrayParamParser<?> getArrayParser(Class<?> targetType) {
+        if (targetType.isArray()) {
+            // check for array of registered types
+            Class<?> componentType = targetType.getComponentType();
+            ParamParser<?> componentParser = getParamParser(componentType);
+
+            if (componentParser != null) {
+                // return multi-valued parameter parser
+                return new ArrayParamParser(targetType, componentParser);
+            }
+        }
+
+        return null;
     }
 
     public static class PrimitiveIntegerParamParser implements ParamParser<Integer> {
@@ -255,4 +325,268 @@ public class ParamParsers {
             return Double.class;
         }
     }
+
+    public static class StringParamParser implements ParamParser<String> {
+        @Override
+        public String parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                return parameterValue;
+            }
+        }
+
+        @Override
+        public Class<String> getParsedType() {
+            return String.class;
+        }
+    }
+
+    public static class ByteParamParser implements ParamParser<Byte> {
+        @Override
+        public Byte parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                try {
+                    return Byte.parseByte(parameterValue);
+                } catch (NumberFormatException e) {
+                    validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                            IsInteger.KEY, field, IsInteger.MESSAGE, parameterValue));
+                    return null;
+                }
+            }
+        }
+
+        @Override
+        public Class<Byte> getParsedType() {
+            return Byte.class;
+        }
+    }
+
+    public static class PrimitiveByteParamParser implements ParamParser<Byte> {
+        @Override
+        public Byte parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return 0;
+            } else {
+                try {
+                    return Byte.parseByte(parameterValue);
+                } catch (NumberFormatException e) {
+                    validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                            IsInteger.KEY, field, IsInteger.MESSAGE, parameterValue));
+                    return 0;
+                }
+            }
+        }
+
+        @Override
+        public Class<Byte> getParsedType() {
+            return Byte.class;
+        }
+    }
+
+    public static class ShortParamParser implements ParamParser<Short> {
+        @Override
+        public Short parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                try {
+                    return Short.parseShort(parameterValue);
+                } catch (NumberFormatException e) {
+                    validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                            IsInteger.KEY, field, IsInteger.MESSAGE, parameterValue));
+                    return null;
+                }
+            }
+        }
+
+        @Override
+        public Class<Short> getParsedType() {
+            return Short.class;
+        }
+    }
+
+    public static class PrimitiveShortParamParser implements ParamParser<Short> {
+        @Override
+        public Short parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return 0;
+            } else {
+                try {
+                    return Short.parseShort(parameterValue);
+                } catch (NumberFormatException e) {
+                    validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                            IsInteger.KEY, field, IsInteger.MESSAGE, parameterValue));
+                    return 0;
+                }
+            }
+        }
+
+        @Override
+        public Class<Short> getParsedType() {
+            return Short.class;
+        }
+    }
+
+    public static class CharacterParamParser implements ParamParser<Character> {
+        @Override
+        public Character parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || parameterValue.isEmpty() || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                return parameterValue.charAt(0);
+            }
+        }
+
+        @Override
+        public Class<Character> getParsedType() {
+            return Character.class;
+        }
+    }
+
+    public static class PrimitiveCharacterParamParser implements ParamParser<Character> {
+        @Override
+        public Character parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || parameterValue.isEmpty() || validation.hasFieldViolation(field)) {
+                return '\0';
+            } else {
+                return parameterValue.charAt(0);
+            }
+        }
+
+        @Override
+        public Class<Character> getParsedType() {
+            return Character.class;
+        }
+    }
+
+    /**
+     * Converts a parameter to an Enum value by (case-insensitive) value matching.
+     *
+     * @param <E>
+     */
+    public static abstract class EnumParamParser<E extends Enum<E>> implements ParamParser<E> {
+        @Override
+        public E parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                final boolean caseSensitive = isCaseSensitive();
+
+                E[] values = getParsedType().getEnumConstants();
+                for (E value : values) {
+                    if (caseSensitive) {
+                        if (value.name().equals(parameterValue)) {
+                            return value;
+                        }
+                    } else {
+                        if (value.name().equalsIgnoreCase(parameterValue)) {
+                            return value;
+                        }
+                    }
+                }
+
+                validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                        IsEnum.KEY, field, IsEnum.MESSAGE, new Object[] {parameterValue, getParsedType().getName()}));
+
+                return null;
+            }
+        }
+
+        @Override
+        public abstract Class<E> getParsedType();
+
+        /**
+         * Determines if the enum parser is case-sensitive.
+         */
+        protected abstract boolean isCaseSensitive();
+    }
+
+    /**
+     * Parses a single string value as a CSV array of registered types.
+     */
+    public static class CsvParamParser<T> implements ParamParser<T[]> {
+
+        private final Class<T[]> arrayType;
+        private final ParamParser<T> itemParser;
+
+        public CsvParamParser(Class<T[]> arrayType, ParamParser<T> parser) {
+            this.arrayType = arrayType;
+            this.itemParser = parser;
+        }
+
+        @Override
+        public T[] parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || parameterValue.isEmpty() || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                // split the string value as a csv
+                String [] values = parameterValue.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+
+                // parse the individual values as the target item type
+                Class<T> itemType = (Class<T>) arrayType.getComponentType();
+                T[] array = (T[]) Array.newInstance(itemType, values.length);
+                for (int i = 0; i < values.length; i++) {
+                    T t = itemParser.parseParameter(field, values[i], validation);
+                    Array.set(array, i, t);
+                }
+
+                if (validation.hasFieldViolation(field)) {
+                    return null;
+                }
+
+                return array;
+            }
+        }
+
+        @Override
+        public Class<T[]> getParsedType() {
+            return arrayType;
+        }
+    }
+
+    /**
+     * Parses a multi-valued parameter as an array of registered types.
+     */
+    public static class ArrayParamParser<T> {
+
+        private final Class<T[]> arrayType;
+        private final ParamParser<T> itemParser;
+
+        public ArrayParamParser(Class<T[]> arrayType, ParamParser<T> parser) {
+            this.arrayType = arrayType;
+            this.itemParser = parser;
+        }
+
+        public T[] parseParameter(String field, String[] parameterValues, Validation validation) {
+            if (parameterValues == null || validation.hasFieldViolation(field)) {
+                return null;
+            } else {
+                // parse the individual values as the target item type
+                Class<T> itemType = getItemType();
+                T[] array = (T[]) Array.newInstance(itemType, parameterValues.length);
+                for (int i = 0; i < parameterValues.length; i++) {
+                    T t = itemParser.parseParameter(field, parameterValues[i], validation);
+                    Array.set(array, i, t);
+                }
+
+                if (validation.hasFieldViolation(field)) {
+                    return null;
+                }
+
+                return array;
+            }
+        }
+
+        public Class<T[]> getArrayType() {
+            return arrayType;
+        }
+
+        public Class<T> getItemType() {
+            return (Class<T>) arrayType.getComponentType();
+        }
+    }
+
 }

--- a/ninja-core/src/main/java/ninja/params/Params.java
+++ b/ninja-core/src/main/java/ninja/params/Params.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.params;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Injects a multi-valued parameter right into the methods...
+ *
+ * This equals context.getParameterValues(...)
+ *
+ * @author James Moger
+ *
+ */
+@WithArgumentExtractor(ArgumentExtractors.ParamsExtractor.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface Params {
+    String value();
+}

--- a/ninja-core/src/main/java/ninja/params/ParsingArrayExtractor.java
+++ b/ninja-core/src/main/java/ninja/params/ParsingArrayExtractor.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.params;
+
+import ninja.Context;
+import ninja.params.ParamParsers.ArrayParamParser;
+
+/**
+ * Argument extractor that parses the String[] argument into a X[]
+ */
+public class ParsingArrayExtractor<X> implements ArgumentExtractor<X> {
+    private final ArgumentExtractor<? extends String[]> wrapped;
+    private final ArrayParamParser<?> parser;
+
+    public ParsingArrayExtractor(ArgumentExtractor<? extends String[]> wrapped, ArrayParamParser<?> parser) {
+        this.wrapped = wrapped;
+        this.parser = parser;
+    }
+
+    @Override
+    public X extract(Context context) {
+        return (X) parser.parseParameter(wrapped.getFieldName(), wrapped.extract(context),
+                context.getValidation());
+    }
+
+    @Override
+    public Class<X> getExtractedType() {
+        return (Class<X>) parser.getArrayType();
+    }
+
+    @Override
+    public String getFieldName() {
+        return wrapped.getFieldName();
+    }
+}

--- a/ninja-core/src/main/java/ninja/validation/IsEnum.java
+++ b/ninja-core/src/main/java/ninja/validation/IsEnum.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that the field is a valid enum constant. Only needed if you want
+ * to customise the validation messages.
+ *
+ * @author James Moger
+ */
+@WithValidator(Validators.EnumValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface IsEnum {
+    /**
+     * The key for the violation message
+     *
+     * @return The key of the violation message
+     */
+    String key() default KEY;
+
+    /**
+     * Default message if the key isn't found
+     *
+     * @return The default message
+     */
+    String message() default MESSAGE;
+
+    /**
+     * The key for formatting the field
+     *
+     * @return The key
+     */
+    String fieldKey() default "";
+
+    /**
+     * The enum class.
+     */
+    Class<? extends Enum<?>> enumClass();
+
+    /**
+     * The flag to determine if validation is case-sensitive.
+     *
+     * @return The case-sensitivity flag.
+     */
+    boolean caseSensitive() default true;
+
+    public static final String KEY = "validation.is.enum.violation";
+    public static final String MESSAGE = "{0} is not a valid enum constant";
+}

--- a/ninja-core/src/main/java/ninja/validation/Validators.java
+++ b/ninja-core/src/main/java/ninja/validation/Validators.java
@@ -232,6 +232,40 @@ public class Validators {
         }
     }
 
+    public static class EnumValidator implements Validator<String> {
+        private final IsEnum isEnum;
+
+        public EnumValidator(IsEnum anEnum) {
+            isEnum = anEnum;
+        }
+
+        @Override
+        public void validate(String value, String field, Validation validation) {
+            if (value != null) {
+                Enum<?>[] values = isEnum.enumClass().getEnumConstants();
+                for (Enum<?> v : values) {
+                    if (isEnum.caseSensitive()) {
+                        if (v.name().equals(value)) {
+                            return;
+                        }
+                    } else {
+                        if (v.name().equalsIgnoreCase(value)) {
+                            return;
+                        }
+                    }
+                }
+
+                validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                        IsEnum.KEY, field, IsEnum.MESSAGE, new Object [] {value, isEnum.enumClass().getName()}));
+            }
+        }
+
+        @Override
+        public Class<String> getValidatedType() {
+            return String.class;
+        }
+    }
+
     private static String fieldKey(String fieldName, String configuredFieldKey) {
         if (configuredFieldKey.length() > 0) {
             return configuredFieldKey;

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version X.X.X
+=============
+
+ * 2014-08-01 Added type support for byte, char, short, enums, and arrays (gitblit)
+
 Version 3.3.0
 =============
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
@@ -7,7 +7,7 @@ Injecting stuff into your controller - method scope
 
 Ninja can inject a lot of stuff into your methods by default. For instance 
 variable parts of routes via <code>@PathParam</code>. 
-Or query / form parameters via <code>@Param</code>.  
+Or query / form parameters via <code>@Param</code> and <code>@Params</code>.  
 
 Argument extractors allow you to use the very same mechanism 
 (annotations of method parameters) to 
@@ -16,6 +16,25 @@ inject inject arbitrary things into the method of a controller.
 This allows you to process a request, extract things 
 (like a user currently logged in), and provide this via an annotation.
 
+### Built-in Supported Types
+
+- String
+- Boolean (boolean)
+- Byte (byte)
+- Short (short)
+- Character (char)
+- Integer (int)
+- Long (long)
+- Float (float)
+- Double (double)
+- Enum *requires runtime class registration in your conf.Module*
+- Arrays of all these types (e.g. String[], int[], Enum[])
+
+**NOTE:**
+Collections and generics are not supported for parameter injection.  Types
+must be explicitly declared and basic arrays must be used to ensure runtime
+type-safety.
+ 
 
 How to write an argument extractor
 ----------------------------------

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
@@ -45,15 +45,18 @@ Getting parameters into your controllers
 A controller usually not only renders stuff, 
 but also takes some inputs and does something with them.
 
-You can get parts of the url inside your controller via two annotations:
-<code>@Param</code> and <code>@PathParam</code>. Via @PathParam you can get 
-variable parts of a route (described in more details in the routing section).
-And @Param allows you to get Query or Form parameters.
+You can get parts of the url inside your controller via three annotations:
+<code>@Param</code>, <code>@Params</code> and <code>@PathParam</code>. Via
+@PathParam you can get variable parts of a route (described in more details
+in the routing section).
+
+@Param allows you to get single-value Query or Form parameters.
+@Params allows you to get multi-value Query parameters.
 
 Let's say and the user visits the following Url...
 
 <pre class="prettyprint">
-/user/12345/my@email.com/userDashboard?debug=false
+/user/12345/my@email.com/userDashboard?debug=false&filter=new&filter=urgent
 </pre>
 
 ... and we got a route definition like that:
@@ -74,7 +77,9 @@ public class AppController {
     public Result userDashboard(
             @PathParam("id") String id, 
             @PathParam("email") String email, 
-            @Param("debug") String debug) {
+            @Param("debug") String debug,
+            @Params("filters") String [] filters,
+            @Header("user-agent") String userAgent) {
 
         //do something with the parameters...
 
@@ -109,7 +114,7 @@ public class ApplicationController {
 }
 </pre>
 
-Ninja can not only inject PathParam and Param objects. But also the Context.
+Ninja can not only inject @PathParam and @Param objects. But also the Context.
 The context is a request scoped object that holds all informations of the current
 request - parameters, headers and so on...
 

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -132,6 +134,41 @@ public class ControllerMethodInvokerTest {
     }
 
     @Test
+    public void headerAnnotatedArgumentShouldBePassed() throws Exception {
+        when(context.getHeader("param1")).thenReturn("value");
+        create("header").invoke(mockController, context);
+        verify(mockController).header("value");
+    }
+
+    @Test
+    public void headerAnnotatedArgumentShouldHandleNull() throws Exception {
+        when(context.getHeader("param1")).thenReturn(null);
+        create("header").invoke(mockController, context);
+        verify(mockController).header(null);
+    }
+
+    @Test
+    public void headersAnnotatedArgumentShouldReturnNull() throws Exception {
+        when(context.getHeaders("param1")).thenReturn(new ArrayList<String>());
+        create("headers").invoke(mockController, context);
+        verify(mockController).headers(null);
+    }
+
+    @Test
+    public void headersAnnotatedArgumentShouldBePassed() throws Exception {
+        when(context.getHeaders("param1")).thenReturn(Arrays.asList("a", "b", "c"));
+        create("headers").invoke(mockController, context);
+        verify(mockController).headers(new String [] {"a", "b", "c"});
+    }
+
+    @Test
+    public void headersAnnotatedArgumentShouldHandleNull() throws Exception {
+        when(context.getHeader("param1")).thenReturn(null);
+        create("headers").invoke(mockController, context);
+        verify(mockController).headers(null);
+    }
+
+    @Test
     public void integerParamShouldBeParsedToInteger() throws Exception {
         when(context.getParameter("param1")).thenReturn("20");
         create("integerParam").invoke(mockController, context);
@@ -172,6 +209,122 @@ public class ControllerMethodInvokerTest {
         when(context.getParameter("param1")).thenReturn("blah");
         create("intParam").invoke(mockController, context);
         verify(mockController).intParam(0);
+        assertTrue(validation.hasFieldViolation("param1"));
+    }
+
+    @Test
+    public void shortParamShouldBeParsedToShort() throws Exception {
+        when(context.getParameter("param1")).thenReturn("20");
+        create("shortParam").invoke(mockController, context);
+        verify(mockController).shortParam((short)20);
+    }
+
+    @Test
+    public void shortParamShouldHandleNull() throws Exception {
+        create("shortParam").invoke(mockController, context);
+        verify(mockController).shortParam(null);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void shortValidationShouldWork() throws Exception {
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("shortParam").invoke(mockController, context);
+        verify(mockController).shortParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+    }
+
+    @Test
+    public void primShortParamShouldBeParsedToShort() throws Exception {
+        when(context.getParameter("param1")).thenReturn("20");
+        create("primShortParam").invoke(mockController, context);
+        verify(mockController).primShortParam((short) 20);
+    }
+
+    @Test
+    public void primShortParamShouldHandleNull() throws Exception {
+        create("primShortParam").invoke(mockController, context);
+        verify(mockController).primShortParam((short)0);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void primShortValidationShouldWork() throws Exception {
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("primShortParam").invoke(mockController, context);
+        verify(mockController).primShortParam((short)0);
+        assertTrue(validation.hasFieldViolation("param1"));
+    }
+
+    @Test
+    public void characterParamShouldBeParsedToCharacter() throws Exception {
+        when(context.getParameter("param1")).thenReturn("ABC");
+        create("characterParam").invoke(mockController, context);
+        verify(mockController).characterParam('A');
+    }
+
+    @Test
+    public void characterParamShouldHandleNull() throws Exception {
+        create("characterParam").invoke(mockController, context);
+        verify(mockController).characterParam(null);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void charParamShouldBeParsedToCharacter() throws Exception {
+        when(context.getParameter("param1")).thenReturn("ABC");
+        create("charParam").invoke(mockController, context);
+        verify(mockController).charParam('A');
+    }
+
+    @Test
+    public void charParamShouldHandleNull() throws Exception {
+        create("charParam").invoke(mockController, context);
+        verify(mockController).charParam('\0');
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void byteParamShouldBeParsedToByte() throws Exception {
+        when(context.getParameter("param1")).thenReturn("20");
+        create("byteParam").invoke(mockController, context);
+        verify(mockController).byteParam((byte)20);
+    }
+
+    @Test
+    public void byteParamShouldHandleNull() throws Exception {
+        create("byteParam").invoke(mockController, context);
+        verify(mockController).byteParam(null);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void byteValidationShouldWork() throws Exception {
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("byteParam").invoke(mockController, context);
+        verify(mockController).byteParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+    }
+
+    @Test
+    public void primByteParamShouldBeParsedToByte() throws Exception {
+        when(context.getParameter("param1")).thenReturn("20");
+        create("primByteParam").invoke(mockController, context);
+        verify(mockController).primByteParam((byte) 20);
+    }
+
+    @Test
+    public void primByteParamShouldHandleNull() throws Exception {
+        create("primByteParam").invoke(mockController, context);
+        verify(mockController).primByteParam((byte) 0);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void primByteValidationShouldWork() throws Exception {
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("primByteParam").invoke(mockController, context);
+        verify(mockController).primByteParam((byte) 0);
         assertTrue(validation.hasFieldViolation("param1"));
     }
 
@@ -334,6 +487,130 @@ public class ControllerMethodInvokerTest {
         create("primDoubleParam").invoke(mockController, context);
         verify(mockController).primDoubleParam(0);
         assertTrue(validation.hasFieldViolation("param1"));
+    }
+
+    @Test
+    public void enumParamShouldBeParsedToEnumCaseSensitive() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("Red");
+        create("enumParam").invoke(mockController, context);
+        verify(mockController).enumParam(Rainbow.Red);
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumParamShouldBeParsedToEnumCaseInsensitive() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class, false);
+        when(context.getParameter("param1")).thenReturn("red");
+        create("enumParam").invoke(mockController, context);
+        verify(mockController).enumParam(Rainbow.Red);
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumParamShouldHandleNull() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        create("enumParam").invoke(mockController, context);
+        verify(mockController).enumParam(null);
+        assertFalse(validation.hasViolations());
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumParamValidationShouldWork() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("enumParam").invoke(mockController, context);
+        verify(mockController).enumParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumParamUnregisteredShouldFail() throws Exception {
+        try {
+            when(context.getParameter("param1")).thenReturn("red");
+            create("enumParam").invoke(mockController, context);
+            assertTrue("Enum was unregistered! This should have failed.", false);
+        } catch (Exception e) {
+            assertTrue(e instanceof RoutingException);
+        }
+    }
+
+    @Test
+    public void enumCsvParamSingleShouldBeParsed() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("Red");
+        create("enumCsvParam").invoke(mockController, context);
+        verify(mockController).enumCsvParam(new Rainbow[] { Rainbow.Red });
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumCsvParamMultipleShouldBeParsed() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("Red,Orange,Yellow");
+        create("enumCsvParam").invoke(mockController, context);
+        verify(mockController).enumCsvParam(new Rainbow[] { Rainbow.Red, Rainbow.Orange, Rainbow.Yellow});
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumCsvParamShouldReturnNull() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("");
+        create("enumCsvParam").invoke(mockController, context);
+        verify(mockController).enumCsvParam(null);
+        assertFalse(validation.hasFieldViolation("param1"));
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumCsvParamValidationShouldWork() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameter("param1")).thenReturn("red,orange,yellow");
+        create("enumCsvParam").invoke(mockController, context);
+        verify(mockController).enumCsvParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumArrayParamSingleShouldBeParsed() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("Blue"));
+        create("enumArrayParam").invoke(mockController, context);
+        verify(mockController).enumArrayParam(new Rainbow[] { Rainbow.Blue });
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumArrayParamMultipleShouldBeParsed() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("Blue", "Indigo", "Violet"));
+        create("enumArrayParam").invoke(mockController, context);
+        verify(mockController).enumArrayParam(new Rainbow[] { Rainbow.Blue, Rainbow.Indigo, Rainbow.Violet});
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumArrayParamShouldReturnNull() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameterValues("param1")).thenReturn(new ArrayList<String>());
+        create("enumArrayParam").invoke(mockController, context);
+        verify(mockController).enumArrayParam(null);
+        assertFalse(validation.hasFieldViolation("param1"));
+        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+
+    @Test
+    public void enumArrayParamValidationShouldWork() throws Exception {
+        ParamParsers.registerEnum(Rainbow.class);
+        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("blue", "indigo", "violet"));
+        create("enumArrayParam").invoke(mockController, context);
+        verify(mockController).enumArrayParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
@@ -552,8 +829,16 @@ public class ControllerMethodInvokerTest {
         public Result pathParam(@PathParam("param1") String param1);
         public Result sessionParam(@SessionParam("param1") String param1);
         public Result attribute(@Attribute("param1") Dep param1);
+        public Result header(@Header("param1") String param1);
+        public Result headers(@Headers("param1") String [] param1);
         public Result integerParam(@Param("param1") Integer param1);
         public Result intParam(@Param("param1") int param1);
+        public Result shortParam(@Param("param1") Short param1);
+        public Result primShortParam(@Param("param1") short param1);
+        public Result characterParam(@Param("param1") Character param1);
+        public Result charParam(@Param("param1") char param1);
+        public Result byteParam(@Param("param1") Byte param1);
+        public Result primByteParam(@Param("param1") byte param1);
         public Result booleanParam(@Param("param1") Boolean param1);
         public Result primBooleanParam(@Param("param1") boolean param1);
         public Result longParam(@Param("param1") Long param1);
@@ -562,6 +847,9 @@ public class ControllerMethodInvokerTest {
         public Result primFloatParam(@Param("param1") float param1);
         public Result doubleParam(@Param("param1") Double param1);
         public Result primDoubleParam(@Param("param1") double param1);
+        public Result enumParam(@Param("param1") Rainbow param1);
+        public Result enumCsvParam(@Param("param1") Rainbow [] param1);
+        public Result enumArrayParam(@Params("param1") Rainbow [] param1);
         public Result noArgArgumentExtractor(@NoArg String param1);
         public Result classArgArgumentExtractor(@ClassArg String param1);
         public Result guiceArgumentExtractor(@GuiceAnnotation(foo = "bar") String param1);
@@ -694,4 +982,8 @@ public class ControllerMethodInvokerTest {
         public int range;
     }
 
+
+    public enum Rainbow {
+        Red, Orange, Yellow, Green, Blue, Indigo, Violet
+    }
 }


### PR DESCRIPTION
This PR adds support for many of the remaining standard types, including `array[]` combinations of all supported types.

It also introduces a method to register your enum subclasses.  Enums must be registered in `conf.Module` to ensure they are available to `NinjaBootstrap` when it builds routes.  I use enums quite frequently, and I wanted automatic mapping from request parameters to my enum constants without having to write oodles of ArgumentExtractors.

I added an annotation `@Params` to explicitly use the array type. (?filter=alpha&filter=beta&filter=gamma)

``` java
Result doSomething(@Params String [] values)
```

 I added implicit support for parsing CSV-formatted query parameters. (?filter=alpha,beta,gama)

``` java
Result doSomething(@Param String [] values)
```

I added `@Header` and `@Headers` to inject request headers into your method.

``` java
Result doSometing(@Header("user-agent" userAgent)
```

Some of these changes may address parts of #87 - although I have stayed away from proper Collections support, favoring simple and explicit `T[]`.

I have some ideas on supporting `java.util.Date`, `java.sql.Time` and `java.sql.Timestamp`, but I'll leave those for a separate PR.
