### PR TITLE
Add Http Basic Authentication filter and proper 401 unauthorized support

### DIFF
--- a/ninja-core/src/main/java/ninja/BasicAuthFilter.java
+++ b/ninja-core/src/main/java/ninja/BasicAuthFilter.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+import java.nio.charset.Charset;
+
+import ninja.utils.NinjaConstant;
+import ninja.utils.NinjaProperties;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.google.inject.Inject;
+
+/**
+ * A Ninja filter that implements HTTP BASIC Authentication.
+ *
+ * @author James Moger
+ *
+ */
+public class BasicAuthFilter implements Filter {
+
+    protected final Ninja ninja;
+
+    protected final UsernamePasswordValidator credentialsValidator;
+
+    protected final String challenge;
+
+    protected final String realm;
+
+    @Inject
+    public BasicAuthFilter(Ninja ninja,
+                           NinjaProperties ninjaProperties,
+                           UsernamePasswordValidator validator) {
+        this.ninja = ninja;
+        this.credentialsValidator = validator;
+        this.realm = ninjaProperties.getWithDefault(
+                NinjaConstant.applicationName, "Ninja");
+        this.challenge = "Basic realm=\"" + realm + "\"";
+    }
+
+    @Override
+    public Result filter(FilterChain chain, Context context) {
+
+        if (context.getSession() == null) {
+            // no session
+            return ninja.getUnauthorizedResult(context);
+
+        } else if (context.getSession().get(SecureFilter.USERNAME) == null) {
+            // no login, conditionally challenge
+            String header = context.getHeader("Authorization");
+
+            if (header != null && header.startsWith("Basic")) {
+                // Authorization: Basic BASE64PACKET
+                String packet = header.substring("Basic".length()).trim();
+                String credentials = new String(Base64.decodeBase64(packet),
+                        Charset.forName(NinjaConstant.UTF_8));
+
+                // credentials = username:password
+                final String[] values = credentials.split(":", 2);
+                final String username = values[0];
+                final String password = values[1];
+
+                if (credentialsValidator
+                        .validateCredentials(username, password)) {
+
+                    context.getSession().put(SecureFilter.USERNAME, username);
+
+                    return chain.next(context);
+                }
+            }
+
+            Result result = ninja.getUnauthorizedResult(context).addHeader(
+                    Result.WWW_AUTHENTICATE, challenge);
+            return result;
+
+        } else {
+            return chain.next(context);
+        }
+    }
+}

--- a/ninja-core/src/main/java/ninja/Ninja.java
+++ b/ninja-core/src/main/java/ninja/Ninja.java
@@ -65,9 +65,21 @@ public interface Ninja {
     Result getNotFoundResult(Context context);
     
     /**
+     * Should handle cases where access is unauthorized
+     *
+     * Should lead to a html error 401 - unauthorized
+     * (and be used with the same mindset).
+     *
+     * By default, WWW-Authenticate is set to None.
+     *
+     * Usually used by BasicAuthFilter for instance(...).
+     */
+    Result getUnauthorizedResult(Context context);
+
+    /**
      * Should handle cases where access is forbidden
-     * 
-     * Should lead to a html error 403 - not found
+     *
+     * Should lead to a html error 403 - forbidden
      * (and be used with the same mindset).
      * 
      * Usually used by SecureFilter for instance(...).

--- a/ninja-core/src/main/java/ninja/NinjaDefault.java
+++ b/ninja-core/src/main/java/ninja/NinjaDefault.java
@@ -191,12 +191,36 @@ public class NinjaDefault implements Ninja {
     }
     
     @Override
+    public Result getUnauthorizedResult(Context context) {
+
+        String messageI18n
+                = messages.getWithDefault(
+                        NinjaConstant.I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_KEY,
+                        NinjaConstant.I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_DEFAULT,
+                        context,
+                        Optional.<Result>absent());
+
+        Message message = new Message(messageI18n);
+
+        // WWW-Authenticate must be included per the spec
+        // http://www.ietf.org/rfc/rfc2617.txt 3.2.1 The WWW-Authenticate Response Header
+        Result result = Results
+                        .unauthorized()
+                        .addHeader(Result.WWW_AUTHENTICATE, "None")
+                        .render(message)
+                        .template(NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED);
+
+        return result;
+
+    }
+
+    @Override
     public Result getForbiddenResult(Context context) {
         
         String messageI18n 
                 = messages.getWithDefault(
-                        NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_KEY,
-                        NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_DEFAULT,
+                        NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_KEY,
+                        NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_DEFAULT,
                         context,
                         Optional.<Result>absent());
         

--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -88,6 +88,8 @@ public class Result {
     public static final String DATE = "Date";
     public static final String EXPIRES = "Expires";
 
+    public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+
     private int statusCode;
 
     /* The object that will be rendered. Could be a Java Pojo. Or a map. Or xyz. Will be

--- a/ninja-core/src/main/java/ninja/UsernamePasswordValidator.java
+++ b/ninja-core/src/main/java/ninja/UsernamePasswordValidator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+/**
+ * Defines a validator for authentication filters like ninja.BasicAuthFilter.
+ *
+ * @author James Moger
+ *
+ */
+public interface UsernamePasswordValidator {
+
+    /**
+     * Returns true if the supplied username and password are valid.
+     *
+     * @param username
+     * @param password
+     * @return true if username and password are correct
+     */
+    boolean validateCredentials(String username, String password);
+
+}

--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -39,6 +39,7 @@ public interface NinjaConstant {
     String LOCATION_VIEW_FTL_HTML_NOT_FOUND = "views/system/404notFound.ftl.html";
     String LOCATION_VIEW_FTL_HTML_BAD_REQUEST = "views/system/400badRequest.ftl.html";
     String LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR = "views/system/500internalServerError.ftl.html";
+    String LOCATION_VIEW_FTL_HTML_UNAUTHORIZED = "views/system/401unauthorized.ftl.html";
     String LOCATION_VIEW_FTL_HTML_FORBIDDEN = "views/system/403forbidden.ftl.html";
     
     // i18n keys and default messages of Ninja
@@ -51,7 +52,10 @@ public interface NinjaConstant {
     
     String I18N_NINJA_SYSTEM_NOT_FOUND_TEXT_KEY = "ninja.system.not_found.text";
     String I18N_NINJA_SYSTEM_NOT_FOUND_TEXT_DEFAULT = "Oops. The requested route cannot be found.";
-    
+
+    String I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_KEY = "ninja.system.unauthorized.text";
+    String I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_DEFAULT = "Oops. You are unauthorized.";
+
     String I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_KEY = "ninja.system.forbidden.text";
     String I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_DEFAULT = "Oops. That''s forbidden and all we know.";
     

--- a/ninja-core/src/main/java/views/system/401unauthorized.ftl.html
+++ b/ninja-core/src/main/java/views/system/401unauthorized.ftl.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<title>${message.text}</title>
+</head>
+<body>
+	<h1>${message.text}</h1>
+</body>
+</html>

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,10 @@
+Version X.X.X
+=============
+
+ * 2014-08-01 Implement proper 401 unauthorized support (gitblit)
+ * 2014-08-01 Add an HTTP Basic Authentication filter and a UsernamePasswordValidator interface (gitblit)
+
+
 Version 3.3.0
 =============
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/filters.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/filters.md
@@ -4,7 +4,7 @@ Filtering
 Introduction
 ------------
 
-Powerful powerful powerful. This is what filers are.
+Powerful powerful powerful. This is what filters are.
 
 Let's say you want to implement authorization in your application. Only users
 authorized should be able to access a certain route and controller. Otherwise
@@ -97,3 +97,37 @@ be filtered.
 Sometimes it is also useful to have a <code>BaseController</code> that is annotated with 
 <code>@FilterWith</code>. Other controllers extending <code>BaseContoller</code> will automatically
 inherit <code>@FilterWith</code>.
+
+BasicAuthFilter
+---------------
+
+Ninja ships with an implementation of HTTP Basic Authentication.  You need to bind a 
+`UsernamePasswordValidator` in your `conf.Modules` class and then annotate your secured
+controllers or controller methods with `@FilterWith(BasicAuthFilter)`.
+
+<pre class="prettyprint">
+public class Module extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+		// bind a UsernamePasswordValidator
+		bind(UsernamePasswordValidator.class).toInstance(new UsernamePasswordValidator() {
+
+			@Override
+			public boolean validateCredentials(String username, String password) {
+				return "user".equals(username) && "password".equals(password);
+			}
+		});
+    }
+}
+
+public MyController {
+
+    @FilterWith(BasicAuthFilter.class)
+    public Result secureMethod(Context context) {
+        // do something
+    }
+    
+}    
+</pre>

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -35,6 +35,7 @@ contributed to Ninja. In some random order:
  * Matt Jones (mattjonesorg)
  * Naum Naumovski (Buffer0verflow)
  * Primož Kokol
+ * James Moger (gitblit)
 
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-core/src/test/java/ninja/BasicAuthFilterTest.java
+++ b/ninja-core/src/test/java/ninja/BasicAuthFilterTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ninja;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.Charset;
+
+import ninja.session.Session;
+import ninja.utils.NinjaConstant;
+import ninja.utils.NinjaProperties;
+
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BasicAuthFilterTest {
+
+    @Mock
+    private NinjaProperties ninjaProperties;
+
+    @Mock
+    private Context context;
+
+    @Mock
+    private Session sessionCookie;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    Ninja ninja;
+
+    @Mock
+    Result result;
+
+    BasicAuthFilter basicAuthFilter;
+
+    @Before
+    public void setup() {
+        String app = "Ninja";
+        String challenge = "Basic realm=\"" + app + "\"";
+
+        when(ninjaProperties.getWithDefault(NinjaConstant.applicationName, app))
+                .thenReturn(app);
+
+        basicAuthFilter = new BasicAuthFilter(ninja, ninjaProperties,
+                new UsernamePasswordValidator() {
+
+                    @Override
+                    public boolean validateCredentials(String username,
+                                                       String password) {
+                        return "james".equals(username)
+                                && "bond".equals(password);
+                    }
+                });
+
+        when(ninja.getUnauthorizedResult(context)).thenReturn(result);
+        when(result.status(Result.SC_401_UNAUTHORIZED)).thenReturn(result);
+        when(result.addHeader(Result.WWW_AUTHENTICATE, challenge)).thenReturn(
+                result);
+
+    }
+
+    @Test
+    public void testNullSession() {
+
+        when(context.getSession()).thenReturn(null);
+
+        // filter that
+        basicAuthFilter.filter(filterChain, context);
+
+        verifyZeroInteractions(filterChain);
+    }
+
+    @Test
+    public void testUnauthenticatedSession() {
+
+        when(context.getSession()).thenReturn(sessionCookie);
+        when(sessionCookie.get(SecureFilter.USERNAME)).thenReturn(null);
+        when(result.getTemplate()).thenReturn(
+                NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED);
+
+        // filter that
+        Result result = basicAuthFilter.filter(filterChain, context);
+
+        assertEquals(NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED,
+                result.getTemplate());
+        verifyZeroInteractions(filterChain);
+    }
+
+    @Test
+    public void testWorkingSessionWhenUsernameIsThere() {
+
+        when(context.getSession()).thenReturn(sessionCookie);
+        when(sessionCookie.get(SecureFilter.USERNAME)).thenReturn("myname");
+
+        // filter that
+        basicAuthFilter.filter(filterChain, context);
+
+        verify(filterChain).next(context);
+    }
+
+    @Test
+    public void testSessionIsNotReturingWithInvalidCredentials() {
+
+        when(context.getSession()).thenReturn(sessionCookie);
+        when(sessionCookie.get(SecureFilter.USERNAME)).thenReturn(null);
+        when(result.getTemplate()).thenReturn(
+                NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED);
+        when(context.getHeader("Authorization")).thenReturn(
+                auth("test", "user"));
+
+        // filter that
+        Result result = basicAuthFilter.filter(filterChain, context);
+
+        assertEquals(NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED,
+                result.getTemplate());
+        verifyZeroInteractions(filterChain);
+    }
+
+    @Test
+    public void testSessionIsReturningWithValidCredentials() {
+
+        when(context.getSession()).thenReturn(sessionCookie);
+        when(sessionCookie.get(SecureFilter.USERNAME)).thenReturn(null);
+        when(context.getHeader("Authorization")).thenReturn(
+                auth("james", "bond"));
+
+        // filter that
+        basicAuthFilter.filter(filterChain, context);
+
+        verify(filterChain).next(context);
+    }
+
+    private String auth(String username, String password) {
+        return "Basic "
+                + Base64.encodeBase64String((username + ":" + password)
+                        .getBytes(Charset.forName("UTF-8")));
+    }
+
+}


### PR DESCRIPTION
Ninja would benefit from optional http basic authentication, and here it is.  :)

**Step 1:** You need to bind a credentials validator:

``` java
public class Module extends AbstractModule {

    @Override
    protected void configure() {

        // bind a UsernamePasswordValidator
        bind(UsernamePasswordValidator.class).toInstance(new UsernamePasswordValidator() {

            @Override
            public boolean validateCredentials(String username, String password) {
                return "user".equals(username) && "password".equals(password);
            }
        });
    }
}
```

**Step 2:** Annotate protected resources as desired `@FilterWith(BasicAuthFilter.class)`

``` java
@FilterWith(BasicAuthFilter.class)
public class MyProtectedApiController {
}
```

**Note**
I found a discrepancy in _forbidden_ message reporting which I have addressed.  Hopefully that was correct.
