### PR TITLE
#224 Made it possible to enable and disable

### DIFF
--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -39,6 +39,7 @@ public interface Context {
      * code completion. Internal stuff like setting routes should go here.
      */
     interface Impl extends Context {
+        
         void setRoute(Route route);
     }
 
@@ -51,6 +52,13 @@ public interface Context {
      * X Forwarded for header, used when behind fire walls and proxies.
      */
     public String X_FORWARD_HEADER = "X-Forwarded-For";
+    
+    /**
+     * Used to enable or disable usage of X-Forwarded-For header in
+     * getRemoteAddr(). Can be set in application.conf to true or false. If
+     * not set it's assumed to be false;
+     */
+    public String NINJA_PROPERTIES_X_FORWARDED_FOR = "ninja.x_forwarded_for_enabled";
         
     /**
      * please use Result.SC_*
@@ -107,15 +115,16 @@ public interface Context {
 
     /**
      * Returns the Internet Protocol (IP) address of the client
-     * or last proxy that sent the request.
-     * For HTTP servlets, same as the value of the
-     * CGI variable <code>REMOTE_ADDR</code>.
+     * or last proxy that sent the request. For HTTP servlets, same as the 
+     * value of the CGI variable <code>REMOTE_ADDR</code>.
      * 
-     * This will honour the X-Forwarded-For flag if set. If you require the raw 
-     * IP address use {@code getHttpServletRequest().getRemoteAddr()}
+     * To honour the X-Forwarded-For flag make sure you set 
+     * "ninja.ninja.x_forwarded_for_enabled=true" in your application.conf. Default
+     * behavior is NOT to take X-Forwarded-For flag into account.
      *
      * @return a <code>String</code> containing the
-     * IP address of the client that sent the request
+     *         IP address of the client that sent the request. Takes into 
+     *         account X-Forwarded-For header if configured to do so.
      */
     public String getRemoteAddr();
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
@@ -267,7 +267,7 @@ Encoding / Decoding of Urls is not as easy as you think it is. Ninja tries to si
 as much as possible, but as user of the Api you have to know what you are 
 submitting to Ninja.
 
-We recommend the following [excellent article from Lunatech](http://www.lunatech-research.com/archives/2009/02/03/what-every-web-developer-must-know-about-url-encoding) 
+We recommend the following [excellent article from Lunatech](http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding)
 before you use encoding / decoding actively in your application.
 
 Let's reconsider the controller method from above:

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -70,6 +70,8 @@ public class ContextImpl implements Context.Impl {
     private final BodyParserEngineManager bodyParserEngineManager;
 
     private final FlashScope flashScope;
+    
+    private final NinjaProperties ninjaProperties;
 
     private final Session session;
     private final ResultHandler resultHandler;
@@ -83,14 +85,17 @@ public class ContextImpl implements Context.Impl {
     Logger logger;
 
     @Inject
-    public ContextImpl(BodyParserEngineManager bodyParserEngineManager,
+    public ContextImpl(
+            BodyParserEngineManager bodyParserEngineManager,
             FlashScope flashCookie,
-            Session sessionCookie,
+            NinjaProperties ninjaProperties,
             ResultHandler resultHandler,
+            Session sessionCookie,
             Validation validation) {
 
         this.bodyParserEngineManager = bodyParserEngineManager;
         this.flashScope = flashCookie;
+        this.ninjaProperties = ninjaProperties;
         this.session = sessionCookie;
         this.resultHandler = resultHandler;
         this.validation = validation;
@@ -329,6 +334,24 @@ public class ContextImpl implements Context.Impl {
 
     @Override
     public String getRemoteAddr() {
+        
+        boolean isUsageOfXForwardedHeaderEnabled 
+                = ninjaProperties.getBooleanWithDefault(
+                        Context.NINJA_PROPERTIES_X_FORWARDED_FOR, false);
+        
+        String remoteAddr;
+        
+        if (!isUsageOfXForwardedHeaderEnabled) {
+            remoteAddr = httpServletRequest.getRemoteAddr();
+        } else {
+            remoteAddr = calculateRemoteAddrAndTakeIntoAccountXForwardHeader();
+        }
+        
+        return remoteAddr;
+    }
+    
+    private String calculateRemoteAddrAndTakeIntoAccountXForwardHeader() {
+        
         String remoteAddr = getHeader(X_FORWARD_HEADER);
 
         if (remoteAddr != null) {
@@ -346,6 +369,7 @@ public class ContextImpl implements Context.Impl {
         } else {
             remoteAddr = httpServletRequest.getRemoteAddr();
         }
+        
         return remoteAddr;
     }
 

--- a/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
@@ -51,6 +51,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.common.collect.Maps;
+import ninja.utils.NinjaProperties;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContextImplTest {
@@ -81,6 +82,9 @@ public class ContextImplTest {
 
     @Mock
     private BodyParserEngine bodyParserEngine;
+    
+    @Mock
+    private NinjaProperties ninjaProperties;
 
     private ContextImpl context;
 
@@ -92,8 +96,13 @@ public class ContextImplTest {
         when(httpServletRequest.getRequestURI()).thenReturn("/");
 
 
-        context = new ContextImpl(bodyParserEngineManager, flashCookie, sessionCookie,
-                resultHandler, validation);
+        context = new ContextImpl(
+                bodyParserEngineManager, 
+                flashCookie, 
+                ninjaProperties,
+                resultHandler, 
+                sessionCookie,
+                validation);
     }
 
     @Test
@@ -123,10 +132,62 @@ public class ContextImplTest {
     }
 
     @Test
-    public void testGetRemoteAddr() {
+    public void testGetRemoteAddrReturnsDefaultRemoteAddr() {
 
         //say the httpServletRequest to return a certain value:
         when(httpServletRequest.getRemoteAddr()).thenReturn("mockedRemoteAddr");
+        when(httpServletRequest.getHeader(Context.X_FORWARD_HEADER)).thenReturn("x-forwarded-for-mockedRemoteAddr");
+
+        //init the context from a (mocked) servlet
+        context.init(httpServletRequest, httpServletResponse);
+
+        //make sure this is correct
+        assertEquals("mockedRemoteAddr", context.getRemoteAddr());
+    }
+    
+    @Test
+    public void testGetRemoteAddrParsesXForwardedForIfSetInApplicationConf() {
+
+        //say the httpServletRequest to return a certain value:
+        when(httpServletRequest.getRemoteAddr()).thenReturn("mockedRemoteAddr");
+        when(httpServletRequest.getHeader(Context.X_FORWARD_HEADER)).thenReturn("192.168.1.44");
+
+        when(ninjaProperties.getBooleanWithDefault(Context.NINJA_PROPERTIES_X_FORWARDED_FOR, false))
+                .thenReturn(Boolean.TRUE);
+
+        //init the context from a (mocked) servlet
+        context.init(httpServletRequest, httpServletResponse);
+
+        //make sure this is correct
+        assertEquals("192.168.1.44", context.getRemoteAddr());
+    }
+    
+    @Test
+    public void testGetRemoteAddrParsesXForwardedForIfMoreThanOneHostPresent() {
+
+        //say the httpServletRequest to return a certain value:
+        when(httpServletRequest.getRemoteAddr()).thenReturn("mockedRemoteAddr");
+        when(httpServletRequest.getHeader(Context.X_FORWARD_HEADER)).thenReturn("192.168.1.1, 192.168.1.2, 192.168.1.3");
+
+        when(ninjaProperties.getBooleanWithDefault(Context.NINJA_PROPERTIES_X_FORWARDED_FOR, false))
+                .thenReturn(Boolean.TRUE);
+
+        //init the context from a (mocked) servlet
+        context.init(httpServletRequest, httpServletResponse);
+
+        //make sure this is correct
+        assertEquals("192.168.1.1", context.getRemoteAddr());
+    }
+    
+    @Test
+    public void testGetRemoteAddrUsesFallbackIfXForwardedForIsNotValidInetAddr() {
+
+        //say the httpServletRequest to return a certain value:
+        when(httpServletRequest.getRemoteAddr()).thenReturn("mockedRemoteAddr");
+        when(httpServletRequest.getHeader(Context.X_FORWARD_HEADER)).thenReturn("I_AM_NOT_A_VALID_ADDRESS");
+
+        when(ninjaProperties.getBooleanWithDefault(Context.NINJA_PROPERTIES_X_FORWARDED_FOR, false))
+                .thenReturn(Boolean.TRUE);
 
         //init the context from a (mocked) servlet
         context.init(httpServletRequest, httpServletResponse);


### PR DESCRIPTION
X-Forwaded-For header parsing now optional in context.getRemoteAddr().
Implemented via key "ninja.x_forwarded_for_enabled=true|false"
in application.conf. Defaults to false if not set.
