### PR TITLE
Log the registered template and body parser engines

### DIFF
--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -16,25 +16,25 @@
 
 package ninja;
 
-import com.google.common.base.Optional;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import ninja.utils.NinjaProperties;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
-import java.util.HashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import static ninja.Route.PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
 
 public class RouterImpl implements Router {
 
@@ -79,7 +79,7 @@ public class RouterImpl implements Router {
     public String getReverseRoute(
             Class<?> controllerClass,
             String controllerMethodName) {
-        
+
         Optional<Map<String, Object>> parameterMap = Optional.absent();
 
         return getReverseRoute(controllerClass, controllerMethodName, parameterMap);
@@ -167,6 +167,8 @@ public class RouterImpl implements Router {
             routes.add(routeBuilder.buildRoute(injector));
         }
         this.routes = ImmutableList.copyOf(routes);
+
+        logRoutes();
     }
 
     @Override
@@ -324,7 +326,7 @@ public class RouterImpl implements Router {
             }
 
         }
-        
+
         return urlWithReplacedPlaceholders;
     }
 
@@ -332,7 +334,7 @@ public class RouterImpl implements Router {
             String routeWithoutContextPath,
             NinjaProperties ninjaProperties) {
 
-        
+
 
         // contextPath can only be empty. never null.
         return ninjaProperties.getContextPath()
@@ -341,4 +343,52 @@ public class RouterImpl implements Router {
 
     }
 
+    private void logRoutes() {
+        // determine the width of the columns
+        int maxMethodLen = 0;
+        int maxPathLen = 0;
+        int maxControllerLen = 0;
+
+        for (Route route : getRoutes()) {
+
+            maxMethodLen = Math.max(maxMethodLen, route.getHttpMethod().length());
+            maxPathLen = Math.max(maxPathLen, route.getUri().length());
+
+            if (route.getControllerClass() != null) {
+
+                int controllerLen = route.getControllerClass().getName().length()
+                    + route.getControllerMethod().getName().length();
+                maxControllerLen = Math.max(maxControllerLen, controllerLen);
+
+            }
+
+        }
+
+        // log the routing table
+        int borderLen = 10 + maxMethodLen + maxPathLen + maxControllerLen;
+        String border = Strings.padEnd("", borderLen, '-');
+
+        logger.info(border);
+        logger.info("Registered routes");
+        logger.info(border);
+
+        for (Route route : getRoutes()) {
+
+            if (route.getControllerClass() != null) {
+
+                logger.info("{} {}  =>  {}.{}()",
+                    Strings.padEnd(route.getHttpMethod(), maxMethodLen, ' '),
+                    Strings.padEnd(route.getUri(), maxPathLen, ' '),
+                    route.getControllerClass().getName(),
+                    route.getControllerMethod().getName());
+
+            } else {
+
+              logger.info("{} {}", route.getHttpMethod(), route.getUri());
+
+            }
+
+        }
+
+    }
 }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManager.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManager.java
@@ -16,10 +16,14 @@
 
 package ninja.bodyparser;
 
+import java.util.Set;
+
 import com.google.inject.ImplementedBy;
 
 @ImplementedBy(BodyParserEngineManagerImpl.class)
 public interface BodyParserEngineManager {
+
+    Set<String> getContentTypes();
 
     BodyParserEngine getBodyParserEngineForContentType(String contentType);
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManager.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManager.java
@@ -23,8 +23,20 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(BodyParserEngineManagerImpl.class)
 public interface BodyParserEngineManager {
 
+    /**
+     * Returns a set of the registered body parser engine content types.
+     *
+     * @return the registered content types
+     */
     Set<String> getContentTypes();
 
+    /**
+     * Find the body parser engine for the given content type
+     *
+     * @param contentType
+     *            The content type
+     * @return The body parser engine, if found
+     */
     BodyParserEngine getBodyParserEngineForContentType(String contentType);
 
 }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -18,9 +18,9 @@ package ninja.bodyparser;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.inject.Binding;
 import com.google.inject.Inject;
@@ -74,7 +74,7 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
 
     @Override
     public Set<String> getContentTypes() {
-        return new TreeSet<String>(contentTypeToBodyParserMap.keySet());
+        return ImmutableSet.copyOf(contentTypeToBodyParserMap.keySet());
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -16,11 +16,18 @@
 
 package ninja.bodyparser;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Binding;
 import com.google.inject.Inject;
@@ -31,7 +38,9 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
-    
+
+    private final Logger logger = LoggerFactory.getLogger(BodyParserEngineManagerImpl.class);
+
     // Keep a reference of providers rather than instances, so body parser engines
     // don't have to be singleton if they don't want
     private final Map<String, Provider<? extends BodyParserEngine>> contentTypeToBodyParserMap;
@@ -41,8 +50,8 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
                                        Provider<BodyParserEngineJson> bodyParserEngineJson,
                                        Provider<BodyParserEngineXml> bodyParserEngineXml,
                                        Injector injector) {
-        
-        
+
+
         Map<String, Provider<? extends BodyParserEngine>> map = Maps.newHashMap();
 
         // First put the built in ones in, this is so they can be overridden by
@@ -53,8 +62,8 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
                 bodyParserEngineJson);
         map.put(bodyParserEngineXml.get().getContentType(),
                 bodyParserEngineXml);
-        
-        
+
+
         // Now lookup all explicit bindings, and find the ones that implement
         // BodyParserEngine
         for (Map.Entry<Key<?>, Binding<?>> binding : injector.getBindings()
@@ -67,9 +76,9 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
             }
         }
 
-        contentTypeToBodyParserMap = ImmutableMap.copyOf(map);
-        
+        this.contentTypeToBodyParserMap = ImmutableMap.copyOf(map);
 
+        logBodyParserEngines();
     }
 
     @Override
@@ -87,6 +96,42 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
             return provider.get();
         } else {
             return null;
+        }
+
+    }
+
+    protected void logBodyParserEngines() {
+        List<String> outputTypes = Lists.newArrayList(getContentTypes());
+        Collections.sort(outputTypes);
+
+        int maxContentTypeLen = 0;
+        int maxBodyParserEngineLen = 0;
+
+        for (String contentType : outputTypes) {
+
+            BodyParserEngine bodyParserEngine = getBodyParserEngineForContentType(contentType);
+
+            maxContentTypeLen = Math.max(maxContentTypeLen,
+                    contentType.length());
+            maxBodyParserEngineLen = Math.max(maxBodyParserEngineLen,
+                    bodyParserEngine.getClass().getName().length());
+
+        }
+
+        int borderLen = 6 + maxContentTypeLen + maxBodyParserEngineLen;
+        String border = Strings.padEnd("", borderLen, '-');
+
+        logger.info(border);
+        logger.info("Registered request bodyparser engines");
+        logger.info(border);
+
+        for (String contentType : outputTypes) {
+
+            BodyParserEngine templateEngine = getBodyParserEngineForContentType(contentType);
+            logger.info("{}  =>  {}",
+                    Strings.padEnd(contentType, maxContentTypeLen, ' '),
+                    templateEngine.getClass().getName());
+
         }
 
     }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -17,6 +17,8 @@
 package ninja.bodyparser;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -68,6 +70,11 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
         contentTypeToBodyParserMap = ImmutableMap.copyOf(map);
         
 
+    }
+
+    @Override
+    public Set<String> getContentTypes() {
+        return new TreeSet<String>(contentTypeToBodyParserMap.keySet());
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManager.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManager.java
@@ -16,8 +16,9 @@
 
 package ninja.template;
 
+import java.util.Set;
+
 import com.google.inject.ImplementedBy;
-import com.google.inject.Singleton;
 
 /**
  * Template engine manager. Has a number of built in template engines, and
@@ -27,9 +28,11 @@ import com.google.inject.Singleton;
 @ImplementedBy(TemplateEngineManagerImpl.class)
 public interface TemplateEngineManager {
 
+    Set<String> getContentTypes();
+
     /**
      * Find the template engine for the given content type
-     * 
+     *
      * @param contentType
      *            The content type
      * @return The template engine, if found

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManager.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManager.java
@@ -28,6 +28,11 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(TemplateEngineManagerImpl.class)
 public interface TemplateEngineManager {
 
+    /**
+     * Returns a set of the registered template engine content types.
+     *
+     * @return the registered content types
+     */
     Set<String> getContentTypes();
 
     /**

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -18,6 +18,8 @@ package ninja.template;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binding;
@@ -68,6 +70,11 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
         }
 
         contentTypeToTemplateEngineMap = ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public Set<String> getContentTypes() {
+        return new TreeSet<String>(contentTypeToTemplateEngineMap.keySet());
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -19,9 +19,9 @@ package ninja.template;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -74,7 +74,7 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
 
     @Override
     public Set<String> getContentTypes() {
-        return new TreeSet<String>(contentTypeToTemplateEngineMap.keySet());
+        return ImmutableSet.copyOf(contentTypeToTemplateEngineMap.keySet());
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -16,12 +16,19 @@
 
 package ninja.template;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -31,6 +38,8 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class TemplateEngineManagerImpl implements TemplateEngineManager {
+
+    private final Logger logger = LoggerFactory.getLogger(TemplateEngineManagerImpl.class);
 
     // Keep a reference of providers rather than instances, so template engines
     // don't have
@@ -69,7 +78,9 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
             }
         }
 
-        contentTypeToTemplateEngineMap = ImmutableMap.copyOf(map);
+        this.contentTypeToTemplateEngineMap = ImmutableMap.copyOf(map);
+
+        logTemplateEngines();
     }
 
     @Override
@@ -87,5 +98,48 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
         } else {
             return null;
         }
+    }
+
+    protected void logTemplateEngines() {
+        List<String> outputTypes = Lists.newArrayList(getContentTypes());
+        Collections.sort(outputTypes);
+
+        if (outputTypes.isEmpty()) {
+
+            logger.error("No registered template engines?! Please install a template module!");
+            return;
+
+        }
+
+        int maxContentTypeLen = 0;
+        int maxTemplateEngineLen = 0;
+
+        for (String contentType : outputTypes) {
+
+            TemplateEngine templateEngine = getTemplateEngineForContentType(contentType);
+
+            maxContentTypeLen = Math.max(maxContentTypeLen,
+                    contentType.length());
+            maxTemplateEngineLen = Math.max(maxTemplateEngineLen,
+                    templateEngine.getClass().getName().length());
+
+        }
+
+        int borderLen = 6 + maxContentTypeLen + maxTemplateEngineLen;
+        String border = Strings.padEnd("", borderLen, '-');
+
+        logger.info(border);
+        logger.info("Registered response template engines");
+        logger.info(border);
+
+        for (String contentType : outputTypes) {
+
+            TemplateEngine templateEngine = getTemplateEngineForContentType(contentType);
+            logger.info("{}  =>  {}",
+                    Strings.padEnd(contentType, maxContentTypeLen, ' '),
+                    templateEngine.getClass().getName());
+
+        }
+
     }
 }

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.bodyparser;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import ninja.Router;
+import ninja.RouterImpl;
+import ninja.i18n.Lang;
+import ninja.i18n.LangImpl;
+import ninja.utils.LoggerProvider;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaProperties;
+import ninja.utils.NinjaPropertiesImpl;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class BodyParserEngineManagerImplTest {
+
+    @Test
+    public void testContentTypes() {
+        List<String> types = Lists.newArrayList(createBodyParserEngineManager().getContentTypes());
+        Collections.sort(types);
+        assertThat(types.toString(),
+                equalTo("[application/json, application/x-www-form-urlencoded, application/xml]"));
+    }
+
+    private BodyParserEngineManager createBodyParserEngineManager(final Class<?>... toBind) {
+        return createInjector(toBind).getInstance(BodyParserEngineManager.class);
+    }
+
+    private Injector createInjector(final Class<?>... toBind) {
+        return Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+
+            	bind(Logger.class).toProvider(LoggerProvider.class);
+            	bind(Lang.class).to(LangImpl.class);
+                bind(Router.class).to(RouterImpl.class);
+
+            	bind(NinjaProperties.class).toInstance(new NinjaPropertiesImpl(NinjaMode.test));
+
+                for (Class<?> clazz : toBind) {
+
+                    bind(clazz);
+
+                }
+            }
+        });
+    }
+}

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineManagerImplTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineManagerImplTest.java
@@ -16,12 +16,19 @@
 
 package ninja.template;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
 import ninja.ContentTypes;
 import ninja.Context;
 import ninja.Result;
+import ninja.Router;
+import ninja.RouterImpl;
 import ninja.i18n.Lang;
 import ninja.i18n.LangImpl;
 import ninja.utils.LoggerProvider;
@@ -32,11 +39,10 @@ import ninja.utils.NinjaPropertiesImpl;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import ninja.Router;
-import ninja.RouterImpl;
 
 public class TemplateEngineManagerImplTest {
 
@@ -76,6 +82,14 @@ public class TemplateEngineManagerImplTest {
                 ContentTypes.TEXT_HTML), instanceOf(OverrideHtmlTemplateEngine.class));
     }
 
+    @Test
+    public void testContentTypes() {
+        List<String> types = Lists.newArrayList(createTemplateEngineManager().getContentTypes());
+        Collections.sort(types);
+        assertThat(types.toString(),
+                equalTo("[application/javascript, application/json, application/xml, text/html]"));
+    }
+
 	@Test
 	public void testGetNonExistingProducesNoNPE() {
 		TemplateEngineManager manager = createTemplateEngineManager(OverrideJsonTemplateEngine.class);
@@ -83,10 +97,12 @@ public class TemplateEngineManagerImplTest {
 	}
 
     public static abstract class MockTemplateEngine implements TemplateEngine {
+        @Override
         public void invoke(Context context, Result result) {
 
         }
 
+        @Override
         public String getSuffixOfTemplatingEngine() {
             return null;
 
@@ -122,17 +138,17 @@ public class TemplateEngineManagerImplTest {
         return Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
-            	
-            	bind(Logger.class).toProvider(LoggerProvider.class);  
+
+            	bind(Logger.class).toProvider(LoggerProvider.class);
             	bind(Lang.class).to(LangImpl.class);
                 bind(Router.class).to(RouterImpl.class);
-            	
+
             	bind(NinjaProperties.class).toInstance(new NinjaPropertiesImpl(NinjaMode.test));
-            	
+
                 for (Class<?> clazz : toBind) {
-                	
-                    bind(clazz);                 
-                    
+
+                    bind(clazz);
+
                 }
             }
         });

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
@@ -26,6 +26,8 @@ import ninja.Context;
 import ninja.Ninja;
 import ninja.Route;
 import ninja.Router;
+import ninja.bodyparser.BodyParserEngine;
+import ninja.bodyparser.BodyParserEngineManager;
 import ninja.template.TemplateEngine;
 import ninja.template.TemplateEngineManager;
 import ninja.application.ApplicationRoutes;
@@ -195,6 +197,10 @@ public class NinjaBootstrap {
             TemplateEngineManager templateEngineManager = injector
                     .getInstance(TemplateEngineManager.class);
             logTemplateEngines(templateEngineManager);
+
+            BodyParserEngineManager bodyParserEngineManager = injector
+                    .getInstance(BodyParserEngineManager.class);
+            logBodyParserEngines(bodyParserEngineManager);
 
             return injector;
 
@@ -420,4 +426,41 @@ public class NinjaBootstrap {
 
     }
 
+    protected void logBodyParserEngines(BodyParserEngineManager bodyParserEngineManager) {
+        Set<String> outputTypes = bodyParserEngineManager.getContentTypes();
+
+        int maxContentTypeLen = 0;
+        int maxBodyParserEngineLen = 0;
+
+        for (String contentType : outputTypes) {
+
+            BodyParserEngine bodyParserEngine = bodyParserEngineManager
+                    .getBodyParserEngineForContentType(contentType);
+
+            maxContentTypeLen = Math.max(maxContentTypeLen,
+                    contentType.length());
+            maxBodyParserEngineLen = Math.max(maxBodyParserEngineLen,
+                    bodyParserEngine.getClass().getName().length());
+
+        }
+
+        int borderLen = 10 + maxContentTypeLen + maxBodyParserEngineLen;
+        String border = Strings.padEnd("", borderLen, '-');
+
+        logger.info("Registered request bodyparser engines");
+        logger.info(border);
+
+        for (String contentType : outputTypes) {
+
+            BodyParserEngine templateEngine = bodyParserEngineManager
+                    .getBodyParserEngineForContentType(contentType);
+            logger.info("{}  =>  {}",
+                    Strings.padEnd(contentType, maxContentTypeLen, ' '),
+                    templateEngine.getClass().getName());
+
+        }
+
+        logger.info(border);
+
+    }
 }

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
@@ -23,7 +23,6 @@ import ninja.Configuration;
 import ninja.Context;
 import ninja.Ninja;
 import ninja.NinjaDefault;
-import ninja.Route;
 import ninja.Router;
 import ninja.application.ApplicationRoutes;
 import ninja.lifecycle.LifecycleSupport;
@@ -37,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -313,60 +311,7 @@ public class NinjaBootstrap {
             applicationRoutes.init(router);
             router.compileRoutes();
 
-            logRoutes(router);
-
         }
-
-    }
-
-    protected void logRoutes(Router router) {
-        // determine the width of the columns
-        int maxMethodLen = 0;
-        int maxPathLen = 0;
-        int maxControllerLen = 0;
-
-        for (Route route : router.getRoutes()) {
-
-            maxMethodLen = Math.max(maxMethodLen, route.getHttpMethod().length());
-            maxPathLen = Math.max(maxPathLen, route.getUri().length());
-
-            if (route.getControllerClass() != null) {
-
-                int controllerLen = route.getControllerClass().getName().length()
-                    + route.getControllerMethod().getName().length();
-                maxControllerLen = Math.max(maxControllerLen, controllerLen);
-
-            }
-
-        }
-
-        // log the routing table
-        int borderLen = 10 + maxMethodLen + maxPathLen + maxControllerLen;
-        String border = Strings.padEnd("", borderLen, '-');
-
-        logger.info(border);
-        logger.info("Registered routes");
-        logger.info(border);
-
-        for (Route route : router.getRoutes()) {
-
-            if (route.getControllerClass() != null) {
-
-                logger.info("{} {}  =>  {}.{}()",
-                    Strings.padEnd(route.getHttpMethod(), maxMethodLen, ' '),
-                    Strings.padEnd(route.getUri(), maxPathLen, ' '),
-                    route.getControllerClass().getName(),
-                    route.getControllerMethod().getName());
-
-            } else {
-
-              logger.info("{} {}", route.getHttpMethod(), route.getUri());
-
-            }
-
-        }
-
-        logger.info(border);
 
     }
 

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaBootstrap.java
@@ -18,8 +18,8 @@ package ninja.servlet;
 
 import com.google.common.base.Optional;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import ninja.Configuration;
 import ninja.Context;
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -383,7 +384,9 @@ public class NinjaBootstrap {
     }
 
     protected void logTemplateEngines(TemplateEngineManager templateEngineManager) {
-        Set<String> outputTypes = templateEngineManager.getContentTypes();
+        List<String> outputTypes = Lists.newArrayList(templateEngineManager.getContentTypes());
+        Collections.sort(outputTypes);
+
         if (outputTypes.isEmpty()) {
 
             logger.error("No registered template engines?! Please install a template module!");
@@ -427,7 +430,8 @@ public class NinjaBootstrap {
     }
 
     protected void logBodyParserEngines(BodyParserEngineManager bodyParserEngineManager) {
-        Set<String> outputTypes = bodyParserEngineManager.getContentTypes();
+        List<String> outputTypes = Lists.newArrayList(bodyParserEngineManager.getContentTypes());
+        Collections.sort(outputTypes);
 
         int maxContentTypeLen = 0;
         int maxBodyParserEngineLen = 0;


### PR DESCRIPTION
It would be helpful to log the registered template engines with their content types and the bodyparser engines with their accept types.
