### PR TITLE
Add explicit text/plain template engine

### DIFF
--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -328,29 +328,34 @@ public class Result {
     
 
     /**
-     * This method directly renders the String to the output. It
-     * completely bypasses any rendering engine.
-     * 
+     * This method directly renders the String to the output. It completely
+     * bypasses any rendering engine.
+     *
      * Thus you can render anything you want.
-     * 
-     * Chaining of resultRaw().resultRaw()... is NOT supported. Mixing with render()
-     * is NOT supported.
-     * 
-     * It is always recommended to implement your own RenderingEngine OR
-     * use existing rendering engines.
-     * 
-     * Example:
-     * <code>
+     *
+     * Chaining of resultRaw().resultRaw()... is NOT supported. Mixing with
+     * render() is NOT supported.
+     *
+     * It is always recommended to implement your own RenderingEngine OR use
+     * existing rendering engines.
+     *
+     * Example: <code>
      * public Result controllerMethod() {
      *    String customJson = "{\"user\" : \"john@woo.com\"}";
-     * 
+     *
      *    return Results.json().renderRaw(customJson);
      * }
      * </code>
-     * 
-     * @param string The string to render.
-     * @return A result that will render the string directly to the output stream.
+     *
+     * @param string
+     *            The string to render.
+     * @return A result that will render the string directly to the output
+     *         stream.
+     * @deprecated => use text().render(string), html().render(string),
+     *             json().render(string), xml().render(string), or
+     *             contentType(type).render(string).
      */
+    @Deprecated
     public Result renderRaw(final String string) {
  
         Renderable renderable = new Renderable() {
@@ -674,6 +679,16 @@ public class Result {
         return this;
     }
     
+    /**
+     * Set the content type of this result to {@link Result#TEXT_PLAIN}.
+     *
+     * @return the same result where you executed this method on. But the content type is now {@link Result#TEXT_PLAIN}.
+     */
+    public Result text() {
+        contentType = TEXT_PLAIN;
+        return this;
+    }
+
     /**
      * Set the content type of this result to {@link Result#APPLICATON_XML}.
      * 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -51,6 +51,7 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
                                      Provider<TemplateEngineJson> templateEngineJson,
                                      Provider<TemplateEngineJsonP> templateEngineJsonP,
                                      Provider<TemplateEngineXml> templateEngineXmlProvider,
+                                     Provider<TemplateEngineText> templateEngineTextProvider,
                                      Injector injector) {
 
         Map<String, Provider<? extends TemplateEngine>> map = new HashMap<String, Provider<? extends TemplateEngine>>();
@@ -65,6 +66,8 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
                 templateEngineJsonP);
         map.put(templateEngineXmlProvider.get().getContentType(),
                 templateEngineXmlProvider);
+        map.put(templateEngineTextProvider.get().getContentType(),
+                templateEngineTextProvider);
 
         // Now lookup all explicit bindings, and find the ones that implement
         // TemplateEngine

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineText.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineText.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.utils.ResponseStreams;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class TemplateEngineText implements TemplateEngine {
+
+    private final Logger logger = LoggerFactory.getLogger(TemplateEngineText.class);
+
+    @Inject
+    public TemplateEngineText() {
+
+    }
+
+    @Override
+    public void invoke(Context context, Result result) {
+
+        ResponseStreams responseStreams = context.finalizeHeaders(result);
+
+        try (Writer outputWriter = responseStreams.getWriter()) {
+
+           outputWriter.write(result.getRenderable().toString());
+
+        } catch (IOException e) {
+
+            logger.error("Error while rendering plain text", e);
+        }
+
+
+    }
+
+    @Override
+    public String getContentType() {
+        return Result.TEXT_PLAIN;
+    }
+
+    @Override
+    public String getSuffixOfTemplatingEngine() {
+        // intentionally returns null...
+        return null;
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 3.x.x
 =============
 
+* 2014-09-22 Add explicit `text/plain` template engine and deprecated Result.renderRaw(String). Results.text().render(myString) is the preferred syntax.  (gitblit)
 * 2014-09-12 Add ServletContext to ContextImpl to improve 3rd-party integration (gitblit)
 * 2014-09-12 Log registered routes on startup (gitblit)
 * 2014-08-29 Added nicer error screens (ra)

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineManagerImplTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineManagerImplTest.java
@@ -87,7 +87,7 @@ public class TemplateEngineManagerImplTest {
         List<String> types = Lists.newArrayList(createTemplateEngineManager().getContentTypes());
         Collections.sort(types);
         assertThat(types.toString(),
-                equalTo("[application/javascript, application/json, application/xml, text/html]"));
+                equalTo("[application/javascript, application/json, application/xml, text/html, text/plain]"));
     }
 
 	@Test

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineTextTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineTextTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.TreeMap;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.utils.ResponseStreams;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for text/plain render.
+ */
+public class TemplateEngineTextTest {
+
+    Context context;
+    ResponseStreams responseStreams;
+    Result result;
+    StringWriter writer;
+
+    @Before
+    public void setUp() throws IOException {
+        context = mock(Context.class);
+        responseStreams = mock(ResponseStreams.class);
+        result = mock(Result.class);
+
+        Map<String, String> map = new TreeMap<String, String>() {
+            {
+                put("apples", "oranges");
+                put("cars", "trucks");
+            }
+        };
+
+        when(result.getRenderable()).thenReturn(map);
+        writer = new StringWriter();
+        when(context.finalizeHeaders(result)).thenReturn(responseStreams);
+        when(responseStreams.getWriter()).thenReturn(writer);
+    }
+
+    @Test
+    public void testTextRendering() throws IOException {
+
+        TemplateEngineText textEngine = new TemplateEngineText();
+        textEngine.invoke(context, result);
+
+        String text = writer.toString();
+        assertEquals("{apples=oranges, cars=trucks}", text);
+        verify(context).finalizeHeaders(result);
+    }
+
+}


### PR DESCRIPTION
This change allows you to return something like this:

```
Results.text().render(object);
```

The object's `toString()` will be invoked by the `TemplateEngineText` class.

This is more natural than the currently supported syntax:

```
Results.text().renderRaw(object.toString());
```

and fits in better with the other stock return types:

```
Results.json().render(object);
Results.jsonp().render(object);
Results.html().render(object);
Results.xml().render(object);
```

With the current state of _develop_ the former syntax will throw an exception because of the unbound template engine for `text/plain`.
