### PR TITLE
Add FreeMarker support for PrettyTime localized relative date formatting

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -76,6 +76,12 @@
     <dependencies>
     
         <dependency>
+            <groupId>org.ocpsoft.prettytime</groupId>
+            <artifactId>prettytime</artifactId>
+            <version>3.2.1.Final</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.7.2</version>

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -18,6 +18,7 @@ package ninja.template;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -247,8 +248,11 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         // E.g.: ${i18n("mykey", myPlaceholderVariable)}
         //////////////////////////////////////////////////////////////////////
         map.put("i18n", new TemplateEngineFreemarkerI18nMethod(messages, context, result));
-        
-        
+
+        Optional<String> requestLang = lang.getLanguage(context, Optional.of(result));
+        Locale locale = lang.getLocaleFromStringOrDefault(requestLang);
+        map.put("prettyTime", new TemplateEngineFreemarkerPrettyTimeMethod(locale));
+
         map.put("reverseRoute", templateEngineFreemarkerReverseRouteMethod);
         map.put("assetsAt", templateEngineFreemarkerAssetsAtMethod);
         map.put("webJarsAt", templateEngineFreemarkerWebJarsAtMethod);

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethod.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.ocpsoft.prettytime.PrettyTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import freemarker.template.SimpleDate;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+/**
+ * PrettyTime integration for Ninja-FreeMarker.
+ *
+ * @author James Moger
+ *
+ */
+public class TemplateEngineFreemarkerPrettyTimeMethod implements
+        TemplateMethodModelEx {
+
+    public final static Logger logger = LoggerFactory
+            .getLogger(TemplateEngineFreemarkerPrettyTimeMethod.class);
+
+    private final PrettyTime prettyTime;
+
+    public TemplateEngineFreemarkerPrettyTimeMethod(Locale locale) {
+
+        this.prettyTime = new PrettyTime(locale);
+
+    }
+
+    @Override
+    public TemplateModel exec(List args) throws TemplateModelException {
+
+        Date date = getFormattableObject(args.get(0));
+
+        String result = prettyTime.format(date);
+
+        return new SimpleScalar(result);
+
+    }
+
+    private Date getFormattableObject(Object value) {
+
+        if (value instanceof SimpleDate) {
+            return ((SimpleDate) value).getAsDate();
+        } else {
+            throw new RuntimeException(
+                    "Formattable object for PrettyTime not found!");
+        }
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 3.x.x
 =============
 
+* 2014-09-26 Add support for ${prettyTime(date)} to FreeMarker integration for localized relative-date formatting like "2 days ago" (gitblit)
 * 2014-09-22 Add explicit `text/plain` template engine and deprecated Result.renderRaw(String). Results.text().render(myString) is the preferred syntax.  (gitblit)
 * 2014-09-12 Add ServletContext to ContextImpl to improve 3rd-party integration (gitblit)
 * 2014-09-12 Log registered routes on startup (gitblit)

--- a/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
@@ -124,6 +124,15 @@ i18n allows you to render translated strings. For instance <code>${i18n(&quot;my
 you to render the value for myi18nKey in the correct language for your user.
 Please refer to chapter "internationalization" for more informations.
 
+
+### prettyTime(...)
+
+prettyTime allows you to format localized relative dates.
+<code>${prettyTime(myDate)}</code>
+
+For instance, if you had a date object that represented yesterday, prettyTime would format that as *1 day ago* in the
+preferred Locale of the request.
+
 Advanced usage of Freemarker
 ----------------------------
 

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethodTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethodTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ninja.template;
+
+import static org.junit.Assert.assertThat;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import freemarker.template.SimpleDate;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateModel;
+
+/**
+ *
+ * @author James Moger
+ */
+public class TemplateEngineFreemarkerPrettyTimeMethodTest {
+
+    Map<Locale, String> expections = new HashMap<Locale, String>() {
+
+        private static final long serialVersionUID = 1L;
+
+        {
+            put(Locale.ENGLISH, "1 day ago");
+            put(Locale.GERMAN, "vor 1 Tag");
+            put(Locale.FRENCH, "il y a 1 jour");
+            put(Locale.ITALIAN, "1 giorno fa");
+            put(Locale.CHINESE, "1 天 前");
+            put(Locale.JAPANESE, "1 日 前");
+            put(Locale.KOREAN, "1일 전");
+        }
+    };
+
+    @Test
+    public void testThatJavaUtilDateWorks() throws Exception {
+
+        test(new SimpleDate(new java.util.Date(getTime()), SimpleDate.DATE));
+    }
+
+    @Test
+    public void testThatJavaSqlDateWorks() throws Exception {
+
+        test(new SimpleDate(new Date(getTime())));
+    }
+
+    @Test
+    public void testThatJavaSqlTimeWorks() throws Exception {
+
+        test(new SimpleDate(new Time(getTime())));
+    }
+
+    @Test
+    public void testThatJavaSqlTimestampWorks() throws Exception {
+
+        test(new SimpleDate(new Timestamp(getTime())));
+    }
+
+    private long getTime() {
+        // return yesterday
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.DATE, -1);
+        return c.getTimeInMillis();
+    }
+
+    public void test(SimpleDate simpleDate) throws Exception {
+
+        for (Map.Entry<Locale, String> entry : expections.entrySet()) {
+
+            Locale locale = entry.getKey();
+            String expected = entry.getValue();
+
+            TemplateEngineFreemarkerPrettyTimeMethod method = new TemplateEngineFreemarkerPrettyTimeMethod(
+                    locale);
+
+            List args = new ArrayList();
+            args.add(simpleDate);
+
+            TemplateModel returnValue = method.exec(args);
+
+            assertThat(((SimpleScalar) returnValue).getAsString(),
+                    CoreMatchers.equalTo(expected));
+        }
+    }
+}

--- a/ninja-servlet-integration-test/src/main/java/conf/Routes.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Routes.java
@@ -30,10 +30,9 @@ import controllers.FilterController;
 import controllers.I18nController;
 import controllers.InjectionExampleController;
 import controllers.PersonController;
+import controllers.PrettyTimeController;
 import controllers.UdpPingController;
 import controllers.UploadController;
-import ninja.Context;
-import ninja.servlet.ContextImpl;
 
 public class Routes implements ApplicationRoutes {
 
@@ -94,7 +93,7 @@ public class Routes implements ApplicationRoutes {
 
         router.GET().route("/api/person.xml").with(PersonController.class, "getPersonXml");
         router.POST().route("/api/person.xml").with(PersonController.class, "postPersonXml");
-        
+
         router.GET().route("/api/person").with(PersonController.class, "getPersonViaContentNegotiation");
         router.GET().route("/api/person_with_content_negotiation_fallback").with(PersonController.class, "getPersonViaContentNegotiationAndFallback");
 
@@ -142,6 +141,12 @@ public class Routes implements ApplicationRoutes {
         router.GET().route("/i18n/{language}").with(I18nController.class, "indexWithLanguage");
 
         // /////////////////////////////////////////////////////////////////////
+        // PrettyTime:
+        // /////////////////////////////////////////////////////////////////////
+        router.GET().route("/prettyTime").with(PrettyTimeController.class, "index");
+        router.GET().route("/prettyTime/{language}").with(PrettyTimeController.class, "indexWithLanguage");
+
+        // /////////////////////////////////////////////////////////////////////
         // Upload showcase
         // /////////////////////////////////////////////////////////////////////
         router.GET().route("/upload").with(UploadController.class, "upload");
@@ -153,7 +158,7 @@ public class Routes implements ApplicationRoutes {
         if (!ninjaProperties.isProd()) {
             router.GET().route("/_test/testPage").with(ApplicationController.class, "testPage");
         }
-        
+
         router.GET().route("/bad_request").with(ApplicationController.class, "badRequest");
 
         router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");

--- a/ninja-servlet-integration-test/src/main/java/controllers/PrettyTimeController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/PrettyTimeController.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.Results;
+import ninja.i18n.Lang;
+import ninja.params.PathParam;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class PrettyTimeController {
+
+    @Inject
+    Lang lang;
+
+    public Result index(Context context) {
+        // Only render the page. It contains some language specific strings.
+        // It will use the requested language (or a fallback language)
+        // from Accept-Language header
+        Result result = Results.html();
+        // just in case we set the language => we remove it...
+        lang.clearLanguage(result);
+
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.DATE, -1);
+        Date date = c.getTime();
+        result.render("date", date);
+
+        return result;
+    }
+
+
+    public Result indexWithLanguage(@PathParam("language") String language) {
+
+        Result result = Results.ok().html().template("/views/PrettyTimeController/index.ftl.html");
+        // This gets an url like /prettyTime/en
+        // language is then the "en" part of the url.
+
+        // We take that part and set that language as the default language
+        // of the framework for this user.
+        lang.setLanguage(language, result);
+
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.DATE, -1);
+        Date date = c.getTime();
+        result.render("date", date);
+
+        return result;
+
+    }
+
+}

--- a/ninja-servlet-integration-test/src/main/java/views/PrettyTimeController/index.ftl.html
+++ b/ninja-servlet-integration-test/src/main/java/views/PrettyTimeController/index.ftl.html
@@ -1,0 +1,23 @@
+<#import "../layout/defaultLayout.ftl.html" as layout> 
+<@layout.myLayout "Home page">
+
+<header class="jumbotron subhead">
+	<h1>This demonstrates localized PrettyTime dates:</h1>
+
+</header>
+
+<hr>
+
+<h2>PrettyTime in the templates</h2>
+<ul>
+	<h1>${date?date} = ${prettyTime(date)}</h1>
+	
+	<li>Implicit language is: ${lang}</li>
+  
+	<li>A redirect at /redirects back to index... <a href="/redirect">/redirect</a></li>
+</ul>
+
+</@layout.myLayout>
+
+
+

--- a/ninja-servlet-integration-test/src/test/java/controllers/PrettyTimeControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/PrettyTimeControllerTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import ninja.NinjaTest;
+
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+
+public class PrettyTimeControllerTest extends NinjaTest {
+
+    String TEXT_EN = "1 day ago";
+    String TEXT_DE = "vor 1 Tag";
+    String TEXT_FR = "il y a 1 jour";
+    String TEXT_IT = "1 giorno fa";
+    String TEXT_ZH = "1 天 前";
+    String TEXT_JA = "1 日 前";
+    String TEXT_KO = "1일 전";
+
+    @Test
+    public void testThatPrettyTimeWorksEn() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "en-US");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_EN));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksDe() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "de-DE");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_DE));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksFr() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "fr-FR");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_FR));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksIt() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "it-IT");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_IT));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksZh() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "zh-CN");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_ZH));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksJa() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "ja-JP");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_JA));
+
+    }
+
+    @Test
+    public void testThatPrettyTimeWorksKo() {
+
+        Map<String, String> headers = Maps.newHashMap();
+        headers.put("Accept-Language", "ko-KO");
+
+        String result = ninjaTestBrowser.makeRequest(getServerAddress()
+                + "/prettyTime", headers);
+
+        assertTrue(result
+                .contains(TEXT_KO));
+
+    }
+
+}


### PR DESCRIPTION
[PrettyTime](http://ocpsoft.org/prettytime) is a localized relative date formatter that is genuinely useful.

This PR adds a `${prettyTime(myDate)}` function to the FreeMarker template integration that respects the Locale preference of the request, just like the `${i18n('key')}` function.
