### PR TITLE
Add support for hot reloading of configuration files

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -111,6 +111,9 @@ public interface NinjaConstant {
      */
     final String serverName = "application.server.name";
 
+    /** User to enable changed-file reloading of external file configuration. */
+    final String applicationHotReloadExternalConfig = "application.hotReloadExternalConfig";
+
     /**
      * Time until session expires.
      */

--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -97,6 +97,12 @@ public class NinjaPropertiesImpl implements NinjaProperties {
             prefixedDefaultConfiguration = defaultConfiguration.subset("%"
                     + ninjaMode.name());
 
+            // allow application.conf to be reloaded on changes in dev mode
+            if (NinjaMode.dev == ninjaMode) {
+                defaultConfiguration
+                        .setReloadingStrategy(new FileChangedReloadingStrategy());
+            }
+
         } else {
 
             // If the property was set, but the file not found we emit

--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -145,8 +145,10 @@ public class NinjaPropertiesImpl implements NinjaProperties {
 
                 // allow the external configuration to be reloaded at
                 // runtime based on detected file changes
-                externalConfiguration
-                        .setReloadingStrategy(new FileChangedReloadingStrategy());
+                if (externalConfiguration.getBoolean(NinjaConstant.applicationHotReloadExternalConfig, false)) {
+                    externalConfiguration
+                            .setReloadingStrategy(new FileChangedReloadingStrategy());
+                }
 
                 // Copy special prefix of mode to parent configuration
                 // By convention it will be something like %test.myproperty

--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -26,6 +26,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,7 @@ public class NinjaPropertiesImpl implements NinjaProperties {
         Configuration prefixedDefaultConfiguration = null;
 
         // (Optional) Config set via a system property
-        Configuration externalConfiguration = null;
+        PropertiesConfiguration externalConfiguration = null;
 
         // (Optional) Config of prefixed mode corresponding to current mode (eg.
         // %test.myproperty=...)
@@ -135,6 +136,11 @@ public class NinjaPropertiesImpl implements NinjaProperties {
                 throw new RuntimeException(errorMessage);
 
             } else {
+
+                // allow the external configuration to be reloaded at
+                // runtime based on detected file changes
+                externalConfiguration
+                        .setReloadingStrategy(new FileChangedReloadingStrategy());
 
                 // Copy special prefix of mode to parent configuration
                 // By convention it will be something like %test.myproperty

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,8 +1,9 @@
 Version 3.x.x
 =============
 
-* 2014-10-01 Add automatic hot reloading support for external (`-Dninja.external.conf`) configuration files for all runtime modes (gitblit)
-* 2014-10-01 Add automatic hot reloading support for language `messages` files in **dev** mode (gitblit)
+* 2014-10-01 Add automatic hot-reload support for `-Dninja.external.conf` external configuration for all runtime modes (gitblit)
+* 2014-10-01 Add automatic hot-reload support for `application.conf` in **dev** mode (gitblit)
+* 2014-10-01 Add automatic hot-reload support for language `messages` files in **dev** mode (gitblit)
 
 Version 3.3.3
 =============

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,9 +1,9 @@
 Version 3.x.x
 =============
 
-* 2014-10-01 Add automatic hot-reload support for `-Dninja.external.conf` external configuration for all runtime modes (gitblit)
-* 2014-10-01 Add automatic hot-reload support for `application.conf` in **dev** mode (gitblit)
-* 2014-10-01 Add automatic hot-reload support for language `messages` files in **dev** mode (gitblit)
+* 2014-10-06 Add optional hot-reload support for `-Dninja.external.conf` external configuration for all runtime modes if *application.hotReloadExternalConfig=true* (gitblit)
+* 2014-10-06 Add automatic hot-reload support for `application.conf` in **dev** mode (gitblit)
+* 2014-10-06 Add automatic hot-reload support for language `messages` files in **dev** mode (gitblit)
 
 Version 3.3.3
 =============

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version 3.x.x
+=============
+
+* 2014-10-01 Add automatic hot reloading support for external (`-Dninja.external.conf`) configuration files for all runtime modes (gitblit)
+* 2014-10-01 Add automatic hot reloading support for language `messages` files in **dev** mode (gitblit)
+
 Version 3.3.3
 =============
 

--- a/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
+++ b/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
@@ -148,3 +148,12 @@ It tries to load in the following order:
 Ninja uses the excellent Apache Configurations library to do the loading. Please refer to
 [their manual](http://commons.apache.org/configuration/userguide/howto_filebased.html#Loading) for more information.
 
+=== Hot-reloading external configuration ===
+
+By default Ninja does not reload your external configuration. However for some installations it may be very
+useful to hot-reload this config instead of restarting your application.
+
+    application.hotReloadExternalConfig=true
+
+That setting applied in your external config file will enable runtime reloading of the external file based
+on the modification time.


### PR DESCRIPTION
There are two scenarios where hot-reloading of Ninja configuration files
would be very useful:
1. reloading localized messages files while in dev mode (i.e. realtime externalization)
2. reloading externally specified application configuration for all runtime modes
