### PR TITLE
Revise the boolean setting controlling external configuration hot-reloading

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -111,9 +111,6 @@ public interface NinjaConstant {
      */
     final String serverName = "application.server.name";
 
-    /** User to enable changed-file reloading of external file configuration. */
-    final String applicationHotReloadExternalConfig = "application.hotReloadExternalConfig";
-
     /**
      * Time until session expires.
      */

--- a/ninja-core/src/main/java/ninja/utils/NinjaProperties.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaProperties.java
@@ -42,6 +42,13 @@ public interface NinjaProperties {
     String NINJA_EXTERNAL_CONF = "ninja.external.configuration";
 
     /**
+     * The System property used to enable hot-reloading of the external
+     * configuration file at runtime.
+     *
+     */
+    String NINJA_EXTERNAL_RELOAD = "ninja.external.reload";
+
+    /**
      * The default configuration. Make sure that file exists. Otherwise the
      * application won't start up.
      */

--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -145,7 +145,8 @@ public class NinjaPropertiesImpl implements NinjaProperties {
 
                 // allow the external configuration to be reloaded at
                 // runtime based on detected file changes
-                if (externalConfiguration.getBoolean(NinjaConstant.applicationHotReloadExternalConfig, false)) {
+                final boolean shouldReload = Boolean.getBoolean(NINJA_EXTERNAL_RELOAD);
+                if (shouldReload) {
                     externalConfiguration
                             .setReloadingStrategy(new FileChangedReloadingStrategy());
                 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,7 @@
 Version 3.x.x
 =============
 
-* 2014-10-06 Add optional hot-reload support for `-Dninja.external.conf` external configuration for all runtime modes if *application.hotReloadExternalConfig=true* (gitblit)
+* 2014-10-06 Add optional hot-reload support for `-Dninja.external.conf` external configuration for all runtime modes if `-Dninja.external.reload=true` (gitblit)
 * 2014-10-06 Add automatic hot-reload support for `application.conf` in **dev** mode (gitblit)
 * 2014-10-06 Add automatic hot-reload support for language `messages` files in **dev** mode (gitblit)
 

--- a/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
+++ b/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
@@ -153,7 +153,6 @@ Ninja uses the excellent Apache Configurations library to do the loading. Please
 By default Ninja does not reload your external configuration. However for some installations it may be very
 useful to hot-reload this config instead of restarting your application.
 
-    application.hotReloadExternalConfig=true
+    java -Dninja.external.reload=true -Dninja.external.configuration=conf/production.conf
 
-That setting applied in your external config file will enable runtime reloading of the external file based
-on the modification time.
+This tells Ninja to reload your configuration if it is modified during runtime.


### PR DESCRIPTION
The addition of the setting within the external application.conf file to control
enabling/disabling runtime hot-reloading for #235 was hastily done.

In retrospect, it would be better to control this behavior by use of a System
property which complements the system property already used to specify the
external configuration location.

```
java -Dninja.external.reload=true -Dninja.external.configuration=app.conf
```
