### PR TITLE
Removed '?' wildchar (if ends with) when reversing the route.

### DIFF
--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -134,6 +134,10 @@ public class RouterImpl implements Router {
                     urlWithReplacedPlaceholders,
                     ninjaProperties);
 
+            if(finalUrl.endsWith("?")) {
+                finalUrl= finalUrl.substring(0, finalUrl.length() - 1);
+            }
+
             return finalUrl;
 
         }

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -132,6 +132,7 @@
 
             <item name="Deployment" collapse="true" href="./documentation/deployment/getting_started.html">
                 <item name="Ninja standalone" href="./documentation/deployment/ninja_standalone.html"/>
+                <item name="Multi module maven project" href="./documentation/deployment/multi_module_maven_project.html"/>
                 <item name="War based deployment" href="./documentation/deployment/war_based_deployment.html"/>
                 <item name="Cloud hosting options" href="./documentation/deployment/cloud_hosting_options.html"/>
             </item>

--- a/ninja-core/src/test/java/ninja/RouterImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouterImplTest.java
@@ -59,7 +59,8 @@ public class RouterImplTest {
         // add route:
         router.GET().route("/testroute").with(TestController.class, "index");
         router.GET().route("/user/{email}/{id: .*}").with(TestController.class, "user");
-
+        router.GET().route("/user/profile/?").with(TestController.class, "userProfileWithWildChar");
+        router.GET().route("/user/profile/").with(TestController.class, "userProfileWithoutWildChar");
         router.compileRoutes();
     }
 
@@ -74,6 +75,22 @@ public class RouterImplTest {
         assertThat(route, CoreMatchers.equalTo("/testroute"));
 
     }
+
+    @Test
+    public void testGetReverseRouteWhenPathContainsWildCharacter() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReverseRoute(TestController.class, "userProfileWithWildChar");
+
+        assertThat(route, CoreMatchers.equalTo("/user/profile/"));
+
+        route = router.getReverseRoute(TestController.class, "userProfileWithoutWildChar");
+
+        assertThat(route, CoreMatchers.equalTo("/user/profile/"));
+    }
+
 
     @Test
     public void testGetReverseRouteContextPathWorks() {
@@ -140,6 +157,17 @@ public class RouterImplTest {
 
         }
 
+        public Result userProfileWithoutWildChar() {
+
+            return Results.ok();
+
+        }
+
+        public Result userProfileWithWildChar(){
+
+            return Results.ok();
+
+        }
     }
 
 }


### PR DESCRIPTION
Minor fix:
Curretly, getReverseRoute() includes the wild character '?' when reversing a route which ends with '?' (/?, for eg) and this PR fixes that trailing char.

Thanks
Sojin
