### PR TITLE
Update Jetty, Jackson, Guava, Guice, H2, ehcache, spymemcached, commons-...

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,18 @@
 Version X
 =========
 
+ * 2014-10-23 Updated libraries:
+    * com.fasterxml.jackson.core:jackson-core ................... 2.4.1 -> 2.4.3
+    * com.fasterxml.jackson.dataformat:jackson-dataformat-xml ... 2.4.1 -> 2.4.3
+    * com.fasterxml.jackson.module:jackson-module-afterburner ... 2.4.1 -> 2.4.3
+    * com.google.guava:guava .................................... 17.0 -> 18.0
+    * com.google.inject.extensions:guice-persist ................ 4.0-beta4 -> 4.0-beta5
+    * com.h2database:h2 ......................................... 1.4.178 -> 1.4.182    
+    * net.sf.ehcache:ehcache .................................... 2.8.3 -> 2.8.5
+    * net.spy:spymemcached ...................................... 2.11.3 -> 2.11.4
+    * org.apache.commons:commons-email .......................... 1.3.2 -> 1.3.3
+    * org.eclipse.jetty:jetty-server ............................ 9.2.1.v20140609 -> 9.2.3.v20140905
+    * org.eclipse.jetty:jetty-servlet ........................... 9.2.1.v20140609 -> 9.2.3.v20140905
 * 2014-10-16 Bump to Freemarker 2.3.21 (ra).
 * 2014-10-18 Added a Metrics module with reporters for Graphite, Ganglia, InfluxDB, and Librato (gitblit & ra)
 * 2014-10-10 Stability improvement for Jpa blog archetype - setup works now in a predictable manner for testcases ra).

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <siteProjectVersion>${project.version}</siteProjectVersion>
-        <jetty.version>9.2.1.v20140609</jetty.version>
+        <jetty.version>9.2.3.v20140905</jetty.version>
         <hibernate.version>4.3.5.Final</hibernate.version>
-        <jackson.version>2.4.1</jackson.version>
+        <jackson.version>2.4.3</jackson.version>
+        <guice.version>4.0-beta5</guice.version>
         <metrics.version>3.1.0</metrics.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
@@ -345,19 +346,19 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <version>4.0-beta5</version>
+                <version>${guice.version}</version>
             </dependency>
             
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-servlet</artifactId>
-                <version>4.0-beta5</version>
+                <version>${guice.version}</version>
             </dependency>
             
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-assistedinject</artifactId>
-                <version>4.0-beta4</version>
+                <version>${guice.version}</version>
             </dependency>
 
             <!-- We use Jackson for rendering jsons: -->
@@ -394,7 +395,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>17.0</version>
+                <version>18.0</version>
             </dependency>
 
             <!-- Needed for Hex transforms (security, cookies) and more... -->
@@ -448,7 +449,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-email</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3</version>
             </dependency>
 
             <!-- Commons configuration makes handling of properties files really simple. -->
@@ -490,14 +491,14 @@
             <dependency>
                 <groupId>net.sf.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
-                <version>2.8.3</version>
+                <version>2.8.5</version>
             </dependency>
         
             <!-- memcached client -->
             <dependency>
                 <groupId>net.spy</groupId>
                 <artifactId>spymemcached</artifactId>
-                <version>2.11.3</version>
+                <version>2.11.4</version>
             </dependency>
 	
             <!-- Migration framework -->
@@ -511,7 +512,7 @@
             <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-persist</artifactId>
-                <version>4.0-beta4</version>
+                <version>${guice.version}</version>
             </dependency>
 
             <dependency>
@@ -570,7 +571,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.178</version>
+                <version>1.4.182</version>
             </dependency>
             
             


### PR DESCRIPTION
Update our dependencies to the current releases. There actually is an ehcache 2.9.0 but I thought 2.8.5 might be better for now.
