### PR TITLE
Fixed issue #188

### DIFF
--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -185,7 +185,7 @@ public class Route {
             if (namedVariablePartOfRoute != null) {
                 // we convert that into a regex matcher group itself
                 namedVariablePartOfORouteReplacedWithRegex 
-                    = "(" + namedVariablePartOfRoute + ")";
+                    = "(" + Matcher.quoteReplacement(namedVariablePartOfRoute) + ")";
             } else {
                 // we convert that into the default namedVariablePartOfRoute regex group
                 namedVariablePartOfORouteReplacedWithRegex 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,18 +1,19 @@
 Version X
 =========
 
- * 2014-10-23 Updated libraries:
-    * com.fasterxml.jackson.core:jackson-core ................... 2.4.1 -> 2.4.3
-    * com.fasterxml.jackson.dataformat:jackson-dataformat-xml ... 2.4.1 -> 2.4.3
-    * com.fasterxml.jackson.module:jackson-module-afterburner ... 2.4.1 -> 2.4.3
-    * com.google.guava:guava .................................... 17.0 -> 18.0
-    * com.google.inject.extensions:guice-persist ................ 4.0-beta4 -> 4.0-beta5
-    * com.h2database:h2 ......................................... 1.4.178 -> 1.4.182    
-    * net.sf.ehcache:ehcache .................................... 2.8.3 -> 2.8.5
-    * net.spy:spymemcached ...................................... 2.11.3 -> 2.11.4
-    * org.apache.commons:commons-email .......................... 1.3.2 -> 1.3.3
-    * org.eclipse.jetty:jetty-server ............................ 9.2.1.v20140609 -> 9.2.3.v20140905
-    * org.eclipse.jetty:jetty-servlet ........................... 9.2.1.v20140609 -> 9.2.3.v20140905
+* 2014-10-25 Fixed issue #188. Excessive backslash escaping in path param regex (bazi)
+* 2014-10-23 Updated libraries:
+  * com.fasterxml.jackson.core:jackson-core ................... 2.4.1 -> 2.4.3
+  * com.fasterxml.jackson.dataformat:jackson-dataformat-xml ... 2.4.1 -> 2.4.3
+  * com.fasterxml.jackson.module:jackson-module-afterburner ... 2.4.1 -> 2.4.3
+  * com.google.guava:guava .................................... 17.0 -> 18.0
+  * com.google.inject.extensions:guice-persist ................ 4.0-beta4 -> 4.0-beta5
+  * com.h2database:h2 ......................................... 1.4.178 -> 1.4.182    
+  * net.sf.ehcache:ehcache .................................... 2.8.3 -> 2.8.5
+  * net.spy:spymemcached ...................................... 2.11.3 -> 2.11.4
+  * org.apache.commons:commons-email .......................... 1.3.2 -> 1.3.3
+  * org.eclipse.jetty:jetty-server ............................ 9.2.1.v20140609 -> 9.2.3.v20140905
+  * org.eclipse.jetty:jetty-servlet ........................... 9.2.1.v20140609 -> 9.2.3.v20140905
 * 2014-10-20 Added ninja-jaxy-routes module, a JAX-RS style routes builder (gitblit)
 * 2014-10-16 Bump to Freemarker 2.3.21 (ra).
 * 2014-10-18 Added a Metrics module with reporters for Graphite, Ganglia, InfluxDB, and Librato (gitblit & ra)

--- a/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
@@ -266,6 +266,27 @@ public class RouteBuilderImplTest {
     }
 
     @Test
+    public void testRegexInRouteWorksWithEscapes() {
+        // Test escaped constructs in regex
+        // regex with escaped construct in a route
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/customers/\\d+");
+        Route route = buildRoute(routeBuilder);
+        assertTrue(route.matches("GET", "/customers/1234"));
+        assertFalse(route.matches("GET", "/customers/12ab"));
+
+        // regex with escaped construct in a route with variable parts
+        routeBuilder.GET().route("/customers/{id: \\d+}");
+        route = buildRoute(routeBuilder);
+        assertTrue(route.matches("GET", "/customers/1234"));
+        assertFalse(route.matches("GET", "/customers/12x"));
+
+        Map<String, String> map = route.getPathParametersEncoded("/customers/1234");
+        assertEquals(1, map.size());
+        assertEquals("1234", map.get("id"));
+    }
+
+    @Test
     public void testRegexInRouteWorksWithoutSlashAtTheEnd() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}/.*");

--- a/ninja-core/src/test/java/ninja/RouteTest.java
+++ b/ninja-core/src/test/java/ninja/RouteTest.java
@@ -42,7 +42,11 @@ public class RouteTest {
         assertThat(
                 Route.convertRawUriToRegex("/me/{username}"), 
                 CoreMatchers.equalTo("/me/([^/]*)")); 
-        
+
+        // check regex with escapes/backslashes (\)
+        assertThat(
+                Route.convertRawUriToRegex("/me/{id: \\d+}"),
+                CoreMatchers.equalTo("/me/(\\d+)"));
     }
     
 }


### PR DESCRIPTION
A route containing path params with regex is converted to regular expression by using `Matcher.appendReplacement` which has a special treatment of backslashes (\) and dollar signs ($) in replacement string.
There is a `Matcher.quoteReplacement` method which is intended to produce a _literal_ replacement string for `Matcher.appendReplacement` method.

I think using the method above would be the best and minimalistic solution for this issue to be solved.
