### PR TITLE
Added error message when no bodyparser for the content type was availabl...

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,7 @@
 Version X
 =========
 
- * 2014-10-26 Added error log when no suited BodyParserEngine was found
+ * 2014-10-26 Added error log when no suited BodyParserEngine was found(templarthelast)
  * 2014-10-23 Updated libraries:
     * com.fasterxml.jackson.core:jackson-core ................... 2.4.1 -> 2.4.3
     * com.fasterxml.jackson.dataformat:jackson-dataformat-xml ... 2.4.1 -> 2.4.3

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X
 =========
 
+ * 2014-10-26 Added error log when no suited BodyParserEngine was found
  * 2014-10-23 Updated libraries:
     * com.fasterxml.jackson.core:jackson-core ................... 2.4.1 -> 2.4.3
     * com.fasterxml.jackson.dataformat:jackson-dataformat-xml ... 2.4.1 -> 2.4.3

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -266,6 +266,7 @@ public class ContextImpl implements Context.Impl {
                 .getBodyParserEngineForContentType(contentTypeOnly);
 
         if (bodyParserEngine == null) {
+            logger.error("No BodyParserEngine found for Content-Type: " + CONTENT_TYPE);
             return null;
         }
 


### PR DESCRIPTION
When no Content-Type is sent the Content-Type "_/_" is used and because there is no default BodyParserEngine for this Content-Type a body request parse will always fail. 

The added error message should show the user that he needs to declare a proper Content-Type to automatically parse request bodies. 
