### PR TITLE
support to watch multiple class folders in maven multi module project

### DIFF
--- a/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
+++ b/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
@@ -183,8 +183,8 @@ public class NinjaRunMojo extends AbstractMojo {
                     NinjaMavenPluginConstants.NINJA_JETTY_CLASSNAME,
                     classpathItems,
                     excludesAsList, 
-                    contextPath,
                     port,
+                    contextPath,
                     directoriesToWatchRecursivelyForChanges);
             
             nWatchAndTerminate.startWatching();

--- a/ninja-maven-plugin/src/main/java/ninja/WatchAndRestartMachine.java
+++ b/ninja-maven-plugin/src/main/java/ninja/WatchAndRestartMachine.java
@@ -44,7 +44,7 @@ import com.sun.nio.file.SensitivityWatchEventModifier;
 public class WatchAndRestartMachine {
     
     List<String> exludePatterns;
-
+ 
     private static Logger logger = LoggerFactory.getLogger(WatchAndRestartMachine.class);
 
     RunClassInSeparateJvmMachine ninjaJettyInsideSeparateJvm;
@@ -61,11 +61,11 @@ public class WatchAndRestartMachine {
      */
     public WatchAndRestartMachine(
             String classNameWithMainToRun,
-            Path directoryToWatchRecursivelyForChanges,
             List<String> classpath,
             List<String> excludeRegexPatterns, 
+            String port,
             String contextPath,
-            String port) throws IOException {
+            Path... directoriesToWatchRecursivelyForChanges) throws IOException {
 
         
         this.exludePatterns = excludeRegexPatterns;
@@ -83,7 +83,7 @@ public class WatchAndRestartMachine {
         this.mapOfWatchKeysToPaths = new HashMap<WatchKey, Path>();
 
         //System.out.format("Scanning: %s ...\n", directoryToWatchRecursivelyForChanges);
-        registerAll(directoryToWatchRecursivelyForChanges);
+        registerAll(directoriesToWatchRecursivelyForChanges);
 
     }
 
@@ -125,17 +125,19 @@ public class WatchAndRestartMachine {
     }
 
 
-    private void registerAll(final Path path) throws IOException {
-        // register directory and sub-directories
-        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path path,
-                    BasicFileAttributes attrs)
-                    throws IOException {
-                register(path);
-                return FileVisitResult.CONTINUE;
-            }
-        });
+    private void registerAll(final Path... paths) throws IOException {
+        for(Path path : paths) {
+    		// register directory and sub-directories
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path path,
+                        BasicFileAttributes attrs)
+                        throws IOException {
+                    register(path);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
     }
 
     public void startWatching() {


### PR DESCRIPTION
Hey guys, I added support to enable ninjs superdev mode for maven multi module projects with quite minimal changes. If maven project contains modules they are picked up via maven session projects / reactor projects. If not everything works as it was designed before. 

We plan to use this feature with the following simplified maven multi module project:

parent-project
- module-a
- module-b
- module-c

You may call mvn ninja:run on parent-project to enable superdev mode for all modules contained.
