### PR TITLE
Fix for: 266

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
+++ b/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
@@ -88,15 +88,17 @@ public class ControllerMethodInvoker {
         }
 
         // Replace a null extractor with a bodyAs extractor, but make sure there's only one
-        boolean bodyAsFound = false;
+        int bodyAsFound = -1;
         for (int i = 0; i < argumentExtractors.length; i++) {
             if (argumentExtractors[i] == null) {
-                if (bodyAsFound) {
-                    throw new RoutingException("Only one parameter may be deserialised as the body " +
-                            method.getDeclaringClass().getName() + "." + method.getName() + "()");
+                if (bodyAsFound > -1) {
+                    throw new RoutingException("Only one parameter may be deserialised as the body "
+                            + method.getDeclaringClass().getName() + "." + method.getName() + "()\n"
+                            + "Extracted parameter is type: " + paramTypes[bodyAsFound].getName() + "\n"
+                            + "Extra parmeter is type: " + paramTypes[i].getName());
                 } else {
                     argumentExtractors[i] = new ArgumentExtractors.BodyAsExtractor(paramTypes[i]);
-                    bodyAsFound = true;
+                    bodyAsFound = i;
                 }
             }
         }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,6 @@
 Version X.X.X
 =============
-
+ * 2014-12-20 #266 Enhanced body parameter exception message (t3hc13h)
  * 2014-12-14 #257 Add protocol to ninja.Context (chrsin)
  * 2014-12-14 #269 Fix name of import (fzakaria)
  * 2014-12-09 Removed default secret key from simple archetype (inkookim + ra)

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -39,6 +39,7 @@ contributed to Ninja. In some random order:
  * Hidetaka Koda (eiryu)
  * Pedro Sena Tanaka (pedro-stanaka)
  * Azilet Beishenaliev (bazi)
+ * Andrew Berglund (t3hc13h)
  
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen


### PR DESCRIPTION
The message now prints the type of the first (Extracted) and the extra parameter which is causing the exception. I considered including the parameter name but since that may be replaced at compile time I figured knowing the types would be good enough for the time being.
