### PR TITLE
Fix for: #263 (part 2) utf8 chars breaking integration tests on US Windows

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
-
+ 
+ * 2014-12-20 #263 (part 2) utf8 chars breaking integration tests on US Windows
  * 2014-12-14 #257 Add protocol to ninja.Context (chrsin)
  * 2014-12-14 #269 Fix name of import (fzakaria)
  * 2014-12-09 Removed default secret key from simple archetype (inkookim + ra)

--- a/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
@@ -141,7 +141,7 @@ public class NinjaTestBrowser {
             response = httpClient.execute(getRequest);
 
             BufferedReader br = new BufferedReader(new InputStreamReader(
-                    (response.getEntity().getContent())));
+                    response.getEntity().getContent(), "UTF-8"));
 
             String output;
             while ((output = br.readLine()) != null) {
@@ -197,7 +197,7 @@ public class NinjaTestBrowser {
             response = httpClient.execute(postRequest);
 
             BufferedReader br = new BufferedReader(new InputStreamReader(
-                    (response.getEntity().getContent())));
+                    response.getEntity().getContent(), "UTF-8"));
 
             String output;
             while ((output = br.readLine()) != null) {


### PR DESCRIPTION
#263 Has two parts, the new line break in robots.txt and the integration test failures.

On my US Windows box the default encoding is clobbering the unicode in
the responses when read by NinjectTestBrowser. 

Explicitly setting the encoding on the response streams fixes the PrettyTimeController and PersonController integration tests.
