### PR TITLE
method should not throw generic exception

### DIFF
--- a/ninja-core/src/main/java/ninja/postoffice/commonsmail/PostofficeCommonsmailImpl.java
+++ b/ninja-core/src/main/java/ninja/postoffice/commonsmail/PostofficeCommonsmailImpl.java
@@ -16,11 +16,14 @@
 
 package ninja.postoffice.commonsmail;
 
+import javax.mail.internet.AddressException;
+
 import ninja.postoffice.Mail;
 import ninja.postoffice.Postoffice;
 import ninja.postoffice.guice.PostofficeConstant;
 import ninja.utils.NinjaProperties;
 
+import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.MultiPartEmail;
 
 import com.google.inject.Inject;
@@ -82,7 +85,7 @@ public class PostofficeCommonsmailImpl implements Postoffice {
     }
 
     @Override
-    public void send(Mail mail) throws Exception {
+    public void send(Mail mail) throws EmailException, AddressException {
 
         // create a correct multipart email based on html / txt content:
         MultiPartEmail multiPartEmail = commonsmailHelper.createMultiPartEmailWithContent(mail);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,11 @@
 Version X.X.X
 =============
 
+ * 2015-01-26 Changed generic exception in postoffice to specific ones (svenkubiak)
+
+Version 4.0.4
+=============
+
  * 2015-01-03 Bump to doctester 1.1.6 (sparkoo)
 
 Version 4.0.3


### PR DESCRIPTION
The send method in PostOffice should not through a generic exception, but rather the specific ones. Either that, or we put a try-catch inside the send method. Let me know, what you think.
