### PR TITLE
Added Support for Jax Routes methods without own path

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,8 @@
 Version X.X.X
 =============
 
- * 2012-02-03 minor refactoring in JaxyRoutes init (lukaseichler)
+ * 2015-02-05 Added Support for JaxRoutes methods without own path (lukaseichler)
+ * 2015-02-03 minor refactoring in JaxyRoutes init (lukaseichler)
  * 2015-02-03 Added method to add and unset a cookie from context (svenkubiak)
  * 2015-01-03 Added access to the freemarker configuration and default suffix (jlannoy)
 

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -19,9 +19,11 @@ package ninja.jaxy;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +38,6 @@ import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -56,6 +57,10 @@ public class JaxyRoutes implements ApplicationRoutes {
     final NinjaProperties ninjaProperties;
 
     final NinjaMode runtimeMode;
+    private Reflections reflections;
+    private Set<Method> methods;
+    private Map<Class<?>, Set<String>> controllers;
+    private Router router;
 
     @Inject
     public JaxyRoutes(NinjaProperties ninjaProperties) {
@@ -79,20 +84,58 @@ public class JaxyRoutes implements ApplicationRoutes {
      */
     @Override
     public void init(Router router) {
+        this.router = router;
+        configureReflections();
 
-        ConfigurationBuilder builder = new ConfigurationBuilder();
+        controllers = Maps.newHashMap();
+        methods = Sets.newHashSet();
 
-        Set<URL> packagesToScan = getPackagesToScanForRoutes();
-        builder.addUrls(packagesToScan);
+        processFoundMethods();
+        sortMethods();
+        registerMethods();
+    }
 
-        builder.addScanners(new MethodAnnotationsScanner());
-        Reflections reflections = new Reflections(builder);
+    /**
+     * Takes all methods and registers them at the controller using the path: Class:@Path + Method:@Path.
+     * If no @Path Annotation is present at the method just the Class:@Path is used.
+     */
+    private void registerMethods() {
+        // register routes for all the methods
+        for (Method method : methods) {
 
-        // collect the allowed annotated methods
-        Map<Class<?>, Set<String>> controllers = Maps.newHashMap();
-        List<Method> methods = Lists.newArrayList();
-        for (Method method : reflections.getMethodsAnnotatedWith(Path.class)) {
+            final Class<?> controllerClass = method.getDeclaringClass();
+            final Path methodPath = method.getAnnotation(Path.class);
+            final Set<String> controllerPaths = controllers
+                    .get(controllerClass);
 
+            String[] paths = {"/"};
+            if (methodPath != null) {
+                paths = methodPath.value();
+            }
+            for (String controllerPath : controllerPaths) {
+
+                for (String methodPathSpec : paths) {
+
+                    final String httpMethod = getHttpMethod(method);
+                    final String fullPath = controllerPath + methodPathSpec;
+                    final String methodName = method.getName();
+
+                    router.METHOD(httpMethod).route(fullPath)
+                            .with(controllerClass, methodName);
+
+                }
+
+            }
+
+        }
+    }
+
+    /**
+     * Takes the found methods and checks if they have a valid format.
+     * If they do, the controller path classes for these methods are generated
+     */
+    private void processFoundMethods() {
+        for (Method method : findControllerMethods()) {
             if (allowMethod(method)) {
 
                 // add the method to our todo list
@@ -107,18 +150,16 @@ public class JaxyRoutes implements ApplicationRoutes {
                     controllers.put(controllerClass, paths);
 
                 }
-
             }
-
         }
+    }
 
-        if (methods.isEmpty()) {
-            // nothing to do
-            return;
-        }
-
-        // Sort the methods into registration order
-        Collections.sort(methods, new Comparator<Method>() {
+    /**
+     * Sorts the methods into registration order
+     */
+    private void sortMethods() {
+        List<Method> methodList = new ArrayList<>(methods);
+        Collections.sort(methodList, new Comparator<Method>() {
 
             @Override
             public int compare(Method m1, Method m2) {
@@ -150,32 +191,36 @@ public class JaxyRoutes implements ApplicationRoutes {
                 }
             }
         });
+        methods = new LinkedHashSet<>(methodList);
+    }
 
-        // register routes for all the methods
-        for (Method method : methods) {
+    /**
+     * Searches for Methods that have either a Path Annotation or a HTTP-Method Annotation
+     */
+    private Set<Method> findControllerMethods() {
+        Set<Method> methods = Sets.newLinkedHashSet();
 
-            final Class<?> controllerClass = method.getDeclaringClass();
-            final Path methodPath = method.getAnnotation(Path.class);
-            final Set<String> controllerPaths = controllers
-                    .get(controllerClass);
+        methods.addAll(reflections.getMethodsAnnotatedWith(Path.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(DELETE.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(GET.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(HEAD.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(OPTIONS.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(PATCH.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(POST.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(PUT.class));
+        methods.addAll(reflections.getMethodsAnnotatedWith(PUT.class));
 
-            for (String controllerPath : controllerPaths) {
+        return methods;
+    }
 
-                for (String methodPathSpec : methodPath.value()) {
+    private void configureReflections() {
+        ConfigurationBuilder builder = new ConfigurationBuilder();
 
-                    final String httpMethod = getHttpMethod(method);
-                    final String fullPath = controllerPath + methodPathSpec;
-                    final String methodName = method.getName();
+        Set<URL> packagesToScan = getPackagesToScanForRoutes();
+        builder.addUrls(packagesToScan);
 
-                    router.METHOD(httpMethod).route(fullPath)
-                            .with(controllerClass, methodName);
-
-                }
-
-            }
-
-        }
-
+        builder.addScanners(new MethodAnnotationsScanner());
+        reflections = new Reflections(builder);
     }
 
     /**
@@ -193,29 +238,26 @@ public class JaxyRoutes implements ApplicationRoutes {
         Set<String> paths = Sets.newLinkedHashSet();
         Path controllerPath = controllerClass.getAnnotation(Path.class);
 
-        if (controllerPath != null) {
+        if (controllerPath == null) {
+            return parentPaths;
+        }
 
-            if (parentPaths.isEmpty()) {
+        if (parentPaths.isEmpty()) {
 
-                // add all controller paths
-                paths.addAll(Arrays.asList(controllerPath.value()));
+            // add all controller paths
+            paths.addAll(Arrays.asList(controllerPath.value()));
 
-            } else {
+        } else {
 
-                // create controller paths based on the parent paths
-                for (String parentPath : parentPaths) {
+            // create controller paths based on the parent paths
+            for (String parentPath : parentPaths) {
 
-                    for (String path : controllerPath.value()) {
-                        paths.add(parentPath + path);
-                    }
-
+                for (String path : controllerPath.value()) {
+                    paths.add(parentPath + path);
                 }
 
             }
 
-        } else {
-            // add all parent paths
-            paths.addAll(parentPaths);
         }
 
         return paths;

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -268,7 +268,7 @@ public class JaxyRoutes implements ApplicationRoutes {
      *
      * @return the set of packages to scan
      */
-    private Set<URL> getPackagesToScanForRoutes() {
+    public Set<URL> getPackagesToScanForRoutes() {
 
         Set<URL> packagesToScanForRoutes = Sets.newHashSet();
 

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -34,6 +34,8 @@ import ninja.utils.NinjaMode;
 import ninja.utils.NinjaProperties;
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
@@ -197,18 +199,17 @@ public class JaxyRoutes implements ApplicationRoutes {
     /**
      * Searches for Methods that have either a Path Annotation or a HTTP-Method Annotation
      */
+    @SuppressWarnings("unchecked")
     private Set<Method> findControllerMethods() {
         Set<Method> methods = Sets.newLinkedHashSet();
 
         methods.addAll(reflections.getMethodsAnnotatedWith(Path.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(DELETE.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(GET.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(HEAD.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(OPTIONS.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(PATCH.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(POST.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(PUT.class));
-        methods.addAll(reflections.getMethodsAnnotatedWith(PUT.class));
+        Reflections annotationReflections = new Reflections("", new TypeAnnotationsScanner(), new SubTypesScanner());
+        for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
+            if (httpMethod.isAnnotation()) {
+                methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));
+            }
+        }
 
         return methods;
     }

--- a/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
@@ -22,7 +22,6 @@ import ninja.Route;
 import ninja.RouterImpl;
 import ninja.utils.NinjaMode;
 import ninja.utils.NinjaPropertiesImpl;
-
 import org.doctester.testbrowser.Request;
 import org.doctester.testbrowser.Response;
 import org.hamcrest.CoreMatchers;
@@ -31,11 +30,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import com.google.inject.Injector;
 import testapplication.conf.Routes;
 import testapplication.controllers.ApplicationController;
-
-import com.google.inject.Injector;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApplicationControllerTest extends NinjaDocTester {
@@ -292,4 +289,10 @@ public class ApplicationControllerTest extends NinjaDocTester {
 
     }
 
+    @Test
+    public void testWithoutMethodPath() throws Exception {
+        Response response = makeRequest(Request.GET().url(
+                testServerUrl().path("/base/middle/app/")));
+        Assert.assertThat(response.payload, CoreMatchers.equalTo("route without method path works."));
+    }
 }

--- a/ninja-jaxy-routes/src/test/java/testapplication/controllers/ApplicationController.java
+++ b/ninja-jaxy-routes/src/test/java/testapplication/controllers/ApplicationController.java
@@ -139,4 +139,9 @@ public class ApplicationController extends MiddleController {
 
     }
 
+    @GET
+    public Result testWithoutMethodPath() {
+        return Results.text().render("route without method path works.");
+    }
+
 }


### PR DESCRIPTION
- I added Support for Jaxy Routes methods without own path to allow something like this: 

``` java
@Path("/app")
class Controller {

    @Get
    public Result get() {
        Results.text().render("get.");
    }
}
```

This makes the @Path annotation on a method optional. If there isn't one the path of the class will be used. 
- The method `getPackagesToScanForRoutes` was made public to be able to write custom annotation based Routers that search in more than just one package
- Furthermore the huge init-method was split into smaller pieces
