### PR TITLE
Re-throw template errors and buffer templates.

### DIFF
--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -318,30 +318,20 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         ResponseStreams responseStreams = context.finalizeHeaders(result);
 
         try {
-            
             // Fully buffer the response so in the case of a template error we can 
             // return the applications 500 error message. Without fully buffering 
             // we can't guarantee we haven't flushed part of the response to the
             // client.
-            
             StringWriter buffer = new StringWriter(64 * 1024);
-            
             freemarkerTemplate.process(map, buffer);
-            
             Writer writer = responseStreams.getWriter();
-            
             writer.write(buffer.toString());
-            
             writer.close();
-            
         } catch (Exception e) {            
             logger.error(
-                    "Error processing Freemarker Template {} ", templateName, e);
-            
-            throw new RuntimeException(e);
-            
+                    "Error processing Freemarker Template {} ", templateName, e);   
+            throw new RuntimeException(e);   
         }
-
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -51,6 +51,7 @@ import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
 import freemarker.template.Version;
+import java.io.StringWriter;
 
 @Singleton
 public class TemplateEngineFreemarker implements TemplateEngine {
@@ -316,12 +317,24 @@ public class TemplateEngineFreemarker implements TemplateEngine {
         
         ResponseStreams responseStreams = context.finalizeHeaders(result);
 
-        try (Writer writer = responseStreams.getWriter()) {
+        try {
             
-            freemarkerTemplate.process(map, writer);
-
-        } catch (Exception e) {
+            // Fully buffer the response so in the case of a template error we can 
+            // return the applications 500 error message. Without fully buffering 
+            // we can't guarantee we haven't flushed part of the response to the
+            // client.
             
+            StringWriter buffer = new StringWriter(64 * 1024);
+            
+            freemarkerTemplate.process(map, buffer);
+            
+            Writer writer = responseStreams.getWriter();
+            
+            writer.write(buffer.toString());
+            
+            writer.close();
+            
+        } catch (Exception e) {            
             logger.error(
                     "Error processing Freemarker Template {} ", templateName, e);
             

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerExceptionHandler.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerExceptionHandler.java
@@ -54,7 +54,12 @@ public class TemplateEngineFreemarkerExceptionHandler implements
                                         Environment env,
                                         Writer out) throws TemplateException {
 
-        if (!ninjaProperties.isProd()) {
+        if (ninjaProperties.isProd()) {
+            // Let the exception bubble up to the central handlers
+            // so the application can return the correct error page
+            // or perform some other application specific action.
+            throw te;
+        } else {
             // print out full stacktrace if we are in test or dev mode
 
             PrintWriter pw = (out instanceof PrintWriter) ? (PrintWriter) out
@@ -78,14 +83,7 @@ public class TemplateEngineFreemarkerExceptionHandler implements
                     + "<pre><xmp>");
             te.printStackTrace(pw);
             pw.println("</xmp></pre></div></html>");
-            pw.flush();
-            pw.close();
             logger.error("Templating error.", te);
         }
-        // Let the exception bubble up to the central handlers
-        // so the application can return the correct error page
-        // or perform some other application specific action.
-        throw te;
-
     }
 }

--- a/ninja-core/src/main/resources/views/broken.ftl.html
+++ b/ninja-core/src/main/resources/views/broken.ftl.html
@@ -1,0 +1,1 @@
+Just a plain template for testing...${bang}


### PR DESCRIPTION
Added rethrowing of template errors in prod mode so the application can
return it's 500 code or otherwise handle the exception from the main
exception handling code. This requires full buffering of the template
output since we can't guarantee that we haven't flushed some part of the
response to the user. I think in most cases this will not matter, as the
performance tests I ran showed slightly higher GC pressure but a bit
more reqs/s with full buffering.
