### PR TITLE
Using context.getContextPath() as prefix in cookie path.

### DIFF
--- a/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
+++ b/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
@@ -83,7 +83,7 @@ public class FlashScopeImpl implements FlashScope {
 
                 Cookie.Builder cookie = Cookie.builder(applicationCookiePrefix
                     + NinjaConstant.FLASH_SUFFIX, "");
-                cookie.setPath("/");
+                cookie.setPath(context.getContextPath() + "/");
                 cookie.setSecure(false);
                 cookie.setMaxAge(0);
 
@@ -102,7 +102,7 @@ public class FlashScopeImpl implements FlashScope {
 
                 Cookie.Builder cookie = Cookie.builder(applicationCookiePrefix
                         + ninja.utils.NinjaConstant.FLASH_SUFFIX, flashData);
-                cookie.setPath("/");
+                cookie.setPath(context.getContextPath() + "/");
                 cookie.setSecure(false);
                 // "-1" does not set "Expires" for that cookie
                 // => Cookie will live as long as the browser is open theoretically

--- a/ninja-core/src/main/java/ninja/session/SessionImpl.java
+++ b/ninja-core/src/main/java/ninja/session/SessionImpl.java
@@ -202,7 +202,7 @@ public class SessionImpl implements Session {
                 Cookie.Builder expiredSessionCookie = Cookie.builder(
                         applicationCookiePrefix + NinjaConstant.SESSION_SUFFIX,
                         "");
-                expiredSessionCookie.setPath("/");
+                expiredSessionCookie.setPath(context.getContextPath() + "/");
                 expiredSessionCookie.setMaxAge(0);
 
                 result.addCookie(expiredSessionCookie.build());
@@ -224,7 +224,7 @@ public class SessionImpl implements Session {
 
             Cookie.Builder cookie = Cookie.builder(applicationCookiePrefix
                     + NinjaConstant.SESSION_SUFFIX, sign + "-" + sessionData);
-            cookie.setPath("/");
+            cookie.setPath(context.getContextPath() + "/");
 
             if(applicationCookieDomain != null){
                 cookie.setDomain(applicationCookieDomain);


### PR DESCRIPTION
This PR should restrict the validity of Ninja's cookies to the application context, rather than them being valid on the whole server.
