### PR TITLE
Use maven basedir for launched JVM process

### DIFF
--- a/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
+++ b/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
@@ -105,7 +105,7 @@ public class NinjaRunMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        
+         
         // If not set up in pom.xml then use system property.
         if (contextPath == null) {
             String contextPathProperty 
@@ -181,7 +181,8 @@ public class NinjaRunMojo extends AbstractMojo {
                     classpathItems,
                     excludesAsList, 
                     contextPath,
-                    port);
+                    port,
+                    mavenProject.getBasedir());
             
             nWatchAndTerminate.startWatching();
             

--- a/ninja-maven-plugin/src/main/java/ninja/RunClassInSeparateJvmMachine.java
+++ b/ninja-maven-plugin/src/main/java/ninja/RunClassInSeparateJvmMachine.java
@@ -44,12 +44,16 @@ public class RunClassInSeparateJvmMachine {
     private String contextPath;
 
     private String port;
+    
+    // basedir of project this plugin run in
+    private File mavenBaseDir;
 
     public RunClassInSeparateJvmMachine(
             String classNameWithMainToRun,
             List<String> classpath, 
             String contextPath,
-            String port) {
+            String port,
+            File mavenBaseDir) {
 
         this.classNameWithMainToRun = classNameWithMainToRun;
 
@@ -58,6 +62,8 @@ public class RunClassInSeparateJvmMachine {
         this.contextPath = contextPath;
 
         this.port = port;
+        
+        this.mavenBaseDir = mavenBaseDir;
 
         // initial startup
         try {
@@ -136,10 +142,11 @@ public class RunClassInSeparateJvmMachine {
         commandLine.add("-cp");
         commandLine.add(classpathAsString);
         commandLine.add(classNameWithMainToRun);
-        
+
         ProcessBuilder builder = new ProcessBuilder(commandLine);
         
-        builder.directory(new File(System.getProperty(NinjaMavenPluginConstants.USER_DIR)));
+        // launch JVM process with dir set to basedir of maven project that launched us
+        builder.directory(mavenBaseDir);
 
         builder.redirectErrorStream(true);
 

--- a/ninja-maven-plugin/src/main/java/ninja/WatchAndRestartMachine.java
+++ b/ninja-maven-plugin/src/main/java/ninja/WatchAndRestartMachine.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.nio.file.SensitivityWatchEventModifier;
+import java.io.File;
 
 public class WatchAndRestartMachine {
     
@@ -65,13 +66,14 @@ public class WatchAndRestartMachine {
             List<String> classpath,
             List<String> excludeRegexPatterns, 
             String contextPath,
-            String port) throws IOException {
+            String port,
+            File mavenBaseDir) throws IOException {
 
         
         this.exludePatterns = excludeRegexPatterns;
         
         this.ninjaJettyInsideSeparateJvm = new RunClassInSeparateJvmMachine(
-                classNameWithMainToRun, classpath, contextPath, port);
+                classNameWithMainToRun, classpath, contextPath, port, mavenBaseDir);
 
         this.restartAfterSomeTimeAndChanges 
                 = new DelayedRestartTrigger(


### PR DESCRIPTION
The current ninja maven plugin assumes that the user will run "mvn" from "user.dir" system property (the directory the user was in when they launched maven).  A more robust method is to use the basedir property of the maven project class at runtime.  The main issue is for a multi-module project, the user will likely initiate maven from the parent project.  That causes hot-reloading of templates to fail since the maven ninja plugin assumes src/main/java is relative to the working directory -- but really its relative to the maven project running the plugin.

This pull request fixes this issue.  I've tested it on single and multi-module maven projects and it works great.
