### PR TITLE
Dependency fix

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -84,12 +84,6 @@
             <artifactId>prettytime</artifactId>
             <version>3.2.1.Final</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.7.2</version>
-        </dependency>
     
         <!-- Thread-safe alternative for Java JDK time stuff -->
         <dependency>
@@ -206,9 +200,11 @@
         </dependency>
         
         <!-- ehcache implementation -->
+        <!-- IMPORTANT: only pull in core (~1MB) vs. entire distro which includes a server (~7MB) -->
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
+            <groupId>net.sf.ehcache.internal</groupId>
+            <artifactId>ehcache-core</artifactId>
+            <version>2.8.5</version>
         </dependency>
         
         <!-- memcached client -->

--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -204,7 +204,6 @@
         <dependency>
             <groupId>net.sf.ehcache.internal</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.8.5</version>
         </dependency>
         
         <!-- memcached client -->

--- a/pom.xml
+++ b/pom.xml
@@ -501,9 +501,10 @@
             </dependency>
         
             <!-- ehcache implementation -->
+            <!-- IMPORTANT: only pull in core (~1MB) vs. entire distro which includes a server (~7MB) -->
             <dependency>
-                <groupId>net.sf.ehcache</groupId>
-                <artifactId>ehcache</artifactId>
+                <groupId>net.sf.ehcache.internal</groupId>
+                <artifactId>ehcache-core</artifactId>
                 <version>2.8.5</version>
             </dependency>
         


### PR DESCRIPTION
This commit optimizes ninja-core's dependencies to reduce pulling in extra libraries -- where they are not necessary.  Before these couple tweaks, my assembled tarball of a Ninja-based app weighed in around 31.5 MB in dependencies (ninja-standalone + ninja-ebean + mysql-connector).  After these two small changes, I shrunk it by 19% down to 25.6 MB.  Folks who aren't using the ninja-ebean or mysql-connector libraries will have even more success.

ninja-core: org.jsoup
- Doing a grep on "org.jsoup" for example found zero results
- Seemed like an old/dead dependency
- Saves 0.3 MB for final runtime lib dependencies

ninja-core: ehcache-core rather than entire full ehcache
- ehcache-core just contains vital parts to make caching work
- ehcache is the full distro with its server component, etc.
- Saves 5.6 MB for final runtime lib dependencies

It looks like ehcache's new v3 series will also continue the idea of distributing just a "core" library. Folks who need the entire distro can still add the dependency to their own project.
