### PR TITLE
On-The-Fly minification of js and css assets

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -252,6 +252,15 @@
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
         </dependency>
+        
+        <!-- Minification -->
+         <dependency>
+	     	<groupId>com.yahoo.platform.yui</groupId>
+		     <artifactId>yuicompressor</artifactId>
+		     <version>2.4.7</version>
+		     <!-- 2.4.8 seems to have issue on windows : https://github.com/yui/yuicompressor/issues/78 -->
+		     <!-- 2.4.8 failed to process empty file (demo01) : https://github.com/yui/yuicompressor/issues/130 -->
+	    </dependency>
 
     </dependencies>
 

--- a/ninja-core/src/main/java/ninja/utils/MinificationUtils.java
+++ b/ninja-core/src/main/java/ninja/utils/MinificationUtils.java
@@ -1,0 +1,152 @@
+package ninja.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+import org.mozilla.javascript.ErrorReporter;
+import org.mozilla.javascript.EvaluatorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yahoo.platform.yui.compressor.CssCompressor;
+import com.yahoo.platform.yui.compressor.JavaScriptCompressor;
+
+/**
+ * Convenient class for minification of css and js assets
+ * Based on
+ * https://github.com/davidB/yuicompressor-maven-plugin/blob/master/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java 
+ * 
+ * @author svenkubiak
+ *
+ */
+public final class MinificationUtils {
+    private static Logger LOG = LoggerFactory.getLogger(MinificationUtils.class);
+    private static final String OUTPUTPATH = "/src/main/java/assets/";
+    private static final String ENCODING = "UTF-8";
+    private static final String JS = "js";
+    private static final String CSS = "css";
+    private static final boolean DISABLEOPTIMIZATION = false;
+    private static final boolean PRESERVESEMICOLONS = false;
+    private static final boolean VERBOSE = false;
+    private static final boolean MUNGE = true;
+    private static final int LINEBREAK = -1;
+   
+    public static void minify(String absolutePath) {
+        if (absolutePath == null || absolutePath.contains("min")) {
+            return;
+        }
+        
+        if (absolutePath.endsWith(JS)) {
+            minifyJS(new File(absolutePath));
+        } else if (absolutePath.endsWith(CSS)) {
+            minifyCSS(new File(absolutePath));
+        }
+    }
+    
+    private static void minifyJS(File inputFile) {
+        InputStreamReader inputStreamReader = null;
+        OutputStreamWriter outputStreamWriter = null;
+        try {
+            File outputFile = getOutputFile(inputFile, JS);
+            inputStreamReader = new InputStreamReader(new FileInputStream(inputFile), ENCODING);
+            outputStreamWriter = new OutputStreamWriter(new FileOutputStream(outputFile));
+            
+            JavaScriptCompressor compressor = new JavaScriptCompressor(inputStreamReader, new MinificationErrorReporter());
+            compressor.compress(outputStreamWriter, LINEBREAK, MUNGE, VERBOSE, PRESERVESEMICOLONS, DISABLEOPTIMIZATION);  
+            
+            outputStreamWriter.flush();
+            
+            log(inputFile, outputFile);
+        } catch (IOException e) {
+            LOG.error("Failed to minify JS");
+        } finally {
+            try {
+                inputStreamReader.close();
+                outputStreamWriter.close();
+            } catch (IOException e) {
+                LOG.error("Failed to close reader/writer while minifing JS", e);
+            }
+        }
+    }
+
+    private static void log(File inputFile, File outputFile) {
+        LOG.info(String.format("Minified asset %s (%db) -> %s (%db) [compressed to %d%% of original size]", inputFile.getName(), inputFile.length(), outputFile.getName(), outputFile.length(), ratioOfSize(inputFile, outputFile)));
+    }
+
+    private static void minifyCSS(File inputFile) {
+        InputStreamReader inputStreamReader = null;
+        OutputStreamWriter outputStreamWriter = null;
+        try {
+            File outputFile = getOutputFile(inputFile, CSS);
+            inputStreamReader = new InputStreamReader(new FileInputStream(inputFile), ENCODING);
+            outputStreamWriter = new OutputStreamWriter(new FileOutputStream(outputFile));
+            
+            CssCompressor compressor = new CssCompressor(inputStreamReader);
+            compressor.compress(outputStreamWriter, LINEBREAK);
+            
+            outputStreamWriter.flush();
+            
+            log(inputFile, outputFile);
+        } catch (IOException e) {
+            LOG.error("Failed to minify CSS", e);
+        } finally {
+            try {
+                inputStreamReader.close();
+                outputStreamWriter.close();
+            } catch (IOException e) {
+                LOG.error("Failed to close reader/writer while minifing CSS", e);
+            }
+        }
+    }
+    
+    private static File getOutputFile(File file, String suffix) {
+        String path = file.getAbsolutePath().split("target")[0];
+        
+        String fileName = file.getName();
+        fileName = fileName.substring(0, fileName.lastIndexOf("."));
+        
+        String folder = null;
+        if (CSS.equals(suffix)) {
+            folder = "stylesheets";
+        } else if (JS.equals(suffix)) {
+            folder = "javascripts";
+        }
+        
+        File outputFile = new File(path + OUTPUTPATH + "/" + folder + "/" + fileName + ".min." + suffix);
+        
+        return outputFile;
+    }
+    
+    private static long ratioOfSize(File inputFile, File outputFile) {
+        long inFile = Math.max(inputFile.length(), 1);
+        long outFile = Math.max(outputFile.length(), 1);
+        return (outFile * 100) / inFile;
+    }
+    
+    private static class MinificationErrorReporter implements ErrorReporter {
+        public void warning(String message, String sourceName, int line, String lineSource, int lineOffset) {
+            if (line < 0) {
+                LOG.warn(message);
+            } else {
+                LOG.warn(line + ':' + lineOffset + ':' + message);
+            }
+        }
+     
+        public void error(String message, String sourceName, int line, String lineSource, int lineOffset) {
+            if (line < 0) {
+                LOG.error(message);
+            } else {
+                LOG.error(line + ':' + lineOffset + ':' + message);
+            }
+        }
+     
+        public EvaluatorException runtimeError(String message, String sourceName, int line, String lineSource, int lineOffset) {
+            error(message, sourceName, line, lineSource, lineOffset);
+            return new EvaluatorException(message);
+        }
+    }
+}

--- a/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
+++ b/ninja-maven-plugin/src/main/java/ninja/NinjaRunMojo.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import ninja.standalone.NinjaJetty;
+import ninja.utils.MinificationUtils;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
@@ -150,7 +151,7 @@ public class NinjaRunMojo extends AbstractMojo {
             buildOutputDirectory);
         
         classpathItems.add(buildOutputDirectory);
-
+        MinificationUtils.basePath = mavenProject.getBasedir().getAbsolutePath(); 
        
         for (org.apache.maven.artifact.Artifact artifact : mavenProject.getArtifacts()) {
             classpathItems.add(artifact.getFile().toString());           


### PR DESCRIPTION
I recently took a look at the impressive java full stuck framework wisdom (worth a look at http://wisdom-framework.org/). Wisdom has some really nice features. On of them is on On-The-Fly minification of assets. 

I think this could be a really good enhancement for ninja, so I created a proof of concept. Here is how it works:
- I changed the WatchAndRestartMachine to check if a change on a asset (js|css) occured. 
- If a changed occured it will grab the content from the source file and create a new file adding min.css or min.js. Existing files will be overwritten. The JVM will not be restarted.
- The idea is, that the user uses the .min.js or .min.css in the frontend, but works in the raw files.
- ATM this only works in SuperDevMode, basically because as a developer I want to know, if the minification is correct.

Additional thoughts:
- <strike>The current implementation assumes that you store your css in "stylesheets" and js in "javascripts", which could be a good convention, but I think it would be nice to make this configurable via the application.conf. But I did not get the injection of NinjaProperties to work (yet).</strike>
-  <strike>Same goes for the outputpath, which currently is hard-coded to /src/main/java/assets </strike>

UPDATE: Added configuration via application.conf

Let me know, what you think.

Cheers,
Sven
