### PR TITLE
ExceptionResult on server error or bad request with underlying cause inc...

### DIFF
--- a/ninja-core/src/main/java/ninja/ExceptionResult.java
+++ b/ninja-core/src/main/java/ninja/ExceptionResult.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2012-2015 Joe Lauer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+/**
+ * A result when an error occurs in the application (e.g. internal server error).
+ * Will optionally include an <code>Exception</code> as the underlying cause for
+ * the error. Template engines may choose to use <code>ExceptionResult.getCause()</code>
+ * and/or <Code>Result.getRenderable()</code> during the rendering process to provide
+ * a detailed response.  A template engine may handle this type of result
+ * as follows:
+ * 
+ * <code>
+ * public void invoke(Context context, Result result) {
+ *       
+ *       if (result instanceof ExceptionResult) {
+ *           ExceptionResult exceptionResult = (ExceptionResult)result;
+ *           Exception cause = exceptionResult.getCause();
+ * 
+ *           // do something with cause
+ * 
+ *       }
+ * 
+ *       // rest of method
+ * 
+ * }
+ * </code>
+ * 
+ * @author Joe Lauer
+ */
+public class ExceptionResult extends Result {
+    
+    private final Exception cause;
+    
+    public ExceptionResult(int statusCode) {
+        super(statusCode);
+        this.cause = null;
+    }
+    
+    public ExceptionResult(int statusCode, Exception cause) {
+        super(statusCode);
+        this.cause = cause;
+    }
+
+    /**
+     * The underlying exception that caused this <code>ErrorResult</code>.
+     * @return The underlying cause of the exception or null if none was
+     *      provided.
+     */
+    public Exception getCause() {
+        return cause;
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/NinjaDefault.java
+++ b/ninja-core/src/main/java/ninja/NinjaDefault.java
@@ -170,7 +170,7 @@ public class NinjaDefault implements Ninja {
         Message message = new Message(messageI18n);
 
         Result result = Results
-                .internalServerError()
+                .internalServerError(exception)
                 .supportedContentTypes(Result.TEXT_HTML, Result.APPLICATION_JSON, Result.APPLICATION_XML)
                 .fallbackContentType(Result.TEXT_HTML)
                 .render(message)
@@ -216,7 +216,7 @@ public class NinjaDefault implements Ninja {
         Message message = new Message(messageI18n); 
            
         Result result = Results
-                        .badRequest()
+                        .badRequest(exception)
                         .supportedContentTypes(Result.TEXT_HTML, Result.APPLICATION_JSON, Result.APPLICATION_XML)
                         .fallbackContentType(Result.TEXT_HTML)
                         .render(message)

--- a/ninja-core/src/main/java/ninja/Results.java
+++ b/ninja-core/src/main/java/ninja/Results.java
@@ -66,7 +66,11 @@ public class Results {
     }
 
     public static Result badRequest() {
-        return status(Result.SC_400_BAD_REQUEST);
+        return new ExceptionResult(Result.SC_400_BAD_REQUEST);
+    }
+    
+    public static Result badRequest(Exception cause) {
+        return new ExceptionResult(Result.SC_400_BAD_REQUEST, cause);
     }
 
     public static Result noContent() {
@@ -75,7 +79,11 @@ public class Results {
     }
 
     public static Result internalServerError() {
-        return status(Result.SC_500_INTERNAL_SERVER_ERROR);
+        return new ExceptionResult(Result.SC_500_INTERNAL_SERVER_ERROR);
+    }
+    
+    public static Result internalServerError(Exception cause) {
+        return new ExceptionResult(Result.SC_500_INTERNAL_SERVER_ERROR, cause);
     }
 
     /**

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -4,7 +4,8 @@ Version X.X.X
  * 2015-02-23 Full page template buffering for better error pages (PR #311) (t3hc13h)
  * 2015-02-19 AuthenticityToken support (SecureFilter, template enhancements) (svenkubiak)
  * 2015-02-12 #301 Fixed system specific line separator for String comparison (raptaml)
- * 2012-02-03 minor refactoring in JaxyRoutes init (lukaseichler)
+ * 2015-02-05 Added Support for JaxRoutes methods without own path (lukaseichler)
+ * 2015-02-03 minor refactoring in JaxyRoutes init (lukaseichler)
  * 2015-02-03 Added method to add and unset a cookie from context (svenkubiak)
  * 2015-01-03 Added access to the freemarker configuration and default suffix (jlannoy)
 

--- a/ninja-core/src/site/markdown/documentation/modules.md
+++ b/ninja-core/src/site/markdown/documentation/modules.md
@@ -51,6 +51,10 @@ Authentication module
 
  * https://github.com/svenkubiak/ninja-authentication
 
+Hazelcast Cache Implementation
+
+ * https://github.com/raptaml/ninja-hazelcast-embedded
+
 <div class="alert alert-info">
 Please feel free to add your modules to this page as pull request 
 (ninja/ninja-core/src/site/markdown/documentation/modules.md)

--- a/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
+++ b/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
@@ -24,6 +24,7 @@ import ninja.lifecycle.LifecycleService;
 import ninja.utils.Message;
 import ninja.utils.NinjaConstant;
 import ninja.utils.ResultHandler;
+import org.hamcrest.CoreMatchers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -156,7 +157,6 @@ public class NinjaDefaultTest {
         ninjaDefault.onRouteRequest(contextImpl);
         
         verify(ninjaDefault).getInternalServerErrorResult(contextImpl, internalServerErrorException);
-    
     }
     
     @Test
@@ -173,7 +173,6 @@ public class NinjaDefaultTest {
         ninjaDefault.onRouteRequest(contextImpl);
         
         verify(ninjaDefault).getBadRequestResult(contextImpl, badRequest);
-    
     }
     
     @Test
@@ -208,6 +207,8 @@ public class NinjaDefaultTest {
         verify(ninjaDefault).getBadRequestResult(contextImpl, badRequestException);
         assertThat(result.getStatusCode(), equalTo(Result.SC_400_BAD_REQUEST));
     
+        assertThat(result, CoreMatchers.instanceOf(ExceptionResult.class));
+        assertSame(badRequestException, ((ExceptionResult)result).getCause());
     }
     
     @Test
@@ -220,6 +221,8 @@ public class NinjaDefaultTest {
         verify(ninjaDefault).getInternalServerErrorResult(contextImpl, anyException);
         assertThat(result.getStatusCode(), equalTo(Result.SC_500_INTERNAL_SERVER_ERROR));
 
+        assertThat(result, CoreMatchers.instanceOf(ExceptionResult.class));
+        assertSame(anyException, ((ExceptionResult)result).getCause());
     }
     
      
@@ -250,6 +253,8 @@ public class NinjaDefaultTest {
         assertThat(result.getStatusCode(), equalTo(Result.SC_500_INTERNAL_SERVER_ERROR));
         assertThat(result.getTemplate(), equalTo(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR));
         assertTrue(result.getRenderable() instanceof Message);
+        assertThat(result, CoreMatchers.instanceOf(ExceptionResult.class));
+        assertEquals("not important", ((ExceptionResult)result).getCause().getMessage());
 
         verify(messages).getWithDefault(
             Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_KEY), 
@@ -286,7 +291,9 @@ public class NinjaDefaultTest {
         assertThat(result.getStatusCode(), equalTo(Result.SC_400_BAD_REQUEST));
         assertThat(result.getTemplate(), equalTo(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST));
         assertTrue(result.getRenderable() instanceof Message);
-
+        assertThat(result, CoreMatchers.instanceOf(ExceptionResult.class));
+        assertEquals("not important", ((ExceptionResult)result).getCause().getMessage());
+        
         verify(messages).getWithDefault(
             Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_KEY), 
             Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_DEFAULT), 

--- a/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
@@ -22,7 +22,6 @@ import ninja.Route;
 import ninja.RouterImpl;
 import ninja.utils.NinjaMode;
 import ninja.utils.NinjaPropertiesImpl;
-
 import org.doctester.testbrowser.Request;
 import org.doctester.testbrowser.Response;
 import org.hamcrest.CoreMatchers;
@@ -31,11 +30,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import com.google.inject.Injector;
 import testapplication.conf.Routes;
 import testapplication.controllers.ApplicationController;
-
-import com.google.inject.Injector;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApplicationControllerTest extends NinjaDocTester {
@@ -292,4 +289,10 @@ public class ApplicationControllerTest extends NinjaDocTester {
 
     }
 
+    @Test
+    public void testWithoutMethodPath() throws Exception {
+        Response response = makeRequest(Request.GET().url(
+                testServerUrl().path("/base/middle/app/")));
+        Assert.assertThat(response.payload, CoreMatchers.equalTo("route without method path works."));
+    }
 }

--- a/ninja-jaxy-routes/src/test/java/testapplication/controllers/ApplicationController.java
+++ b/ninja-jaxy-routes/src/test/java/testapplication/controllers/ApplicationController.java
@@ -139,4 +139,9 @@ public class ApplicationController extends MiddleController {
 
     }
 
+    @GET
+    public Result testWithoutMethodPath() {
+        return Results.text().render("route without method path works.");
+    }
+
 }


### PR DESCRIPTION
Template engines currently have no way of accessing the underlying Exception (cause) of an internal server error or bad request.  While applications can override NinjaDefault and provide their own implementation and include the exception in the Renderable -- template engines rely on NinjaDefault to setup the Result.

I first tried to include the exception as a new key/value pair in the existing Renderable, but that broke existing applications that count the Renderable as a Message object in the case of a system error.  Thus, I created a new ExceptionResult class that extends Result (akin to AsyncResult) to optionally include the underlying cause of an exception.  The benefit is its backwards compatible and template engines can choose to "unwrap" the result if they wish to inspect the result for an exception.

I've been working on super detailed error pages for DEV mode.  I am considering a PR for that down the road, but I wanted to make sure including the exception was acceptable before I put more energy into it.
