### PR TITLE
Bug #303 - JSON / XML body parser

### DIFF
--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
@@ -24,8 +24,6 @@ import com.google.inject.Singleton;
 import ninja.ContentTypes;
 import ninja.Context;
 import ninja.exceptions.BadRequestException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,8 +37,6 @@ import java.io.InputStream;
  */
 @Singleton
 public class BodyParserEngineJson implements BodyParserEngine {
-
-    private final Logger logger = LoggerFactory.getLogger(BodyParserEngineJson.class);
 
     private final ObjectMapper objectMapper;
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
@@ -16,31 +16,28 @@
 
 package ninja.bodyparser;
 
-import java.io.IOException;
-
-import ninja.ContentTypes;
-import ninja.Context;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import ninja.ContentTypes;
+import ninja.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 @Singleton
 public class BodyParserEngineXml implements BodyParserEngine {
-    
+
     private final static Logger logger = LoggerFactory.getLogger(BodyParserEngineXml.class);
-    
+
     private final XmlMapper xmlMapper;
-    
 
     @Inject
     public BodyParserEngineXml(XmlMapper xmlMapper) {
-        
+
         this.xmlMapper = xmlMapper;
 
     }
@@ -49,22 +46,23 @@ public class BodyParserEngineXml implements BodyParserEngine {
         T t = null;
 
         try {
-            
             t = xmlMapper.readValue(context.getInputStream(), classOfT);
-
-        } catch (JsonParseException e) {
+        } catch (JsonParseException | JsonMappingException e) {
             logger.error("Error parsing incoming Xml", e);
-        } catch (JsonMappingException e) {
-            logger.error("Error parsing incoming Xml", e);
+            try {
+                t = classOfT.newInstance();
+            } catch (InstantiationException | IllegalAccessException ex) {
+                logger.error("Can't create new instance of class {}", classOfT.getName(), e);
+            }
         } catch (IOException e) {
             logger.error("Error parsing incoming Xml", e);
         }
 
         return t;
     }
-    
+
     public String getContentType() {
-        return ContentTypes.APPLICATION_XML; 
+        return ContentTypes.APPLICATION_XML;
     }
 
 }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
@@ -23,11 +23,19 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import ninja.ContentTypes;
 import ninja.Context;
+import ninja.exceptions.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+/**
+ * Built in Xml body parser.
+ *
+ * @author Raphael Bauer
+ * @author Thibault Meyer
+ * @see ninja.bodyparser.BodyParserEngine
+ */
 @Singleton
 public class BodyParserEngineXml implements BodyParserEngine {
 
@@ -43,22 +51,13 @@ public class BodyParserEngineXml implements BodyParserEngine {
     }
 
     public <T> T invoke(Context context, Class<T> classOfT) {
-        T t = null;
-
         try {
-            t = xmlMapper.readValue(context.getInputStream(), classOfT);
+            return xmlMapper.readValue(context.getInputStream(), classOfT);
         } catch (JsonParseException | JsonMappingException e) {
-            logger.error("Error parsing incoming Xml", e);
-            try {
-                t = classOfT.newInstance();
-            } catch (InstantiationException | IllegalAccessException ex) {
-                logger.error("Can't create new instance of class {}", classOfT.getName(), e);
-            }
+            throw new BadRequestException("Error parsing incoming Xml", e);
         } catch (IOException e) {
-            logger.error("Error parsing incoming Xml", e);
+            throw new BadRequestException("Invalid Xml document", e);
         }
-
-        return t;
     }
 
     public String getContentType() {

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
@@ -24,8 +24,6 @@ import com.google.inject.Singleton;
 import ninja.ContentTypes;
 import ninja.Context;
 import ninja.exceptions.BadRequestException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -38,8 +36,6 @@ import java.io.IOException;
  */
 @Singleton
 public class BodyParserEngineXml implements BodyParserEngine {
-
-    private final static Logger logger = LoggerFactory.getLogger(BodyParserEngineXml.class);
 
     private final XmlMapper xmlMapper;
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
@@ -41,9 +41,7 @@ public class BodyParserEngineXml implements BodyParserEngine {
 
     @Inject
     public BodyParserEngineXml(XmlMapper xmlMapper) {
-
         this.xmlMapper = xmlMapper;
-
     }
 
     public <T> T invoke(Context context, Class<T> classOfT) {

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineJsonTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineJsonTest.java
@@ -50,7 +50,7 @@ public class BodyParserEngineJsonTest {
                 BodyParserEngineJsonTest.DATA_LASTSEEN);
         final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
         final ObjectMapper jsonObjMapper = new ObjectMapper();
-        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        final BodyParserEngineJson bodyParserEngineJson = new BodyParserEngineJson(jsonObjMapper);
         SimpleTestForm testForm = null;
 
         try {
@@ -58,7 +58,7 @@ public class BodyParserEngineJsonTest {
         } catch (IOException ignore) {
         }
         try {
-            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+            testForm = bodyParserEngineJson.invoke(context, SimpleTestForm.class);
         } catch (BadRequestException ignore) {
         } finally {
             try {
@@ -89,7 +89,7 @@ public class BodyParserEngineJsonTest {
         final String jsonDocument = "";
         final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
         final ObjectMapper jsonObjMapper = new ObjectMapper();
-        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        final BodyParserEngineJson bodyParserEngineJson = new BodyParserEngineJson(jsonObjMapper);
         boolean badRequestThrown = false;
 
         try {
@@ -97,7 +97,7 @@ public class BodyParserEngineJsonTest {
         } catch (IOException ignore) {
         }
         try {
-            bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+            bodyParserEngineJson.invoke(context, SimpleTestForm.class);
         } catch (BadRequestException ignore) {
             badRequestThrown = true;
         } finally {
@@ -119,7 +119,7 @@ public class BodyParserEngineJsonTest {
                 BodyParserEngineJsonTest.DATA_LASTSEEN);
         final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
         final ObjectMapper jsonObjMapper = new ObjectMapper();
-        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        final BodyParserEngineJson bodyParserEngineJson = new BodyParserEngineJson(jsonObjMapper);
         boolean badRequestThrown = false;
 
         try {
@@ -127,7 +127,7 @@ public class BodyParserEngineJsonTest {
         } catch (IOException ignore) {
         }
         try {
-            bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+            bodyParserEngineJson.invoke(context, SimpleTestForm.class);
         } catch (BadRequestException ignore) {
             badRequestThrown = true;
         } finally {
@@ -142,14 +142,14 @@ public class BodyParserEngineJsonTest {
 
     @Test
     public void testJsonBodyWithFullSpacesAndEndOfLines() {
-        final String jsonDocument = String.format("  \n\n\n    {  \n    \"firstName\"    :   \"%s\", \"lastName\"\n : \"%s\", \"birthYear\":%d,\n \"lastSeen\":\"%s\"}   ",
+        final String jsonDocument = String.format("  \n\n\n    {  \n    \"firstName\"  \n  :   \"%s\", \"lastName\"\n : \"%s\", \"birthYear\":%d,\n \"lastSeen\":\"%s\"}   ",
                 BodyParserEngineJsonTest.DATA_FIRSTNAME,
                 BodyParserEngineJsonTest.DATA_LASTNAME,
                 BodyParserEngineJsonTest.DATA_BIRTHYEAR,
                 BodyParserEngineJsonTest.DATA_LASTSEEN);
         final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
         final ObjectMapper jsonObjMapper = new ObjectMapper();
-        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        final BodyParserEngineJson bodyParserEngineJson = new BodyParserEngineJson(jsonObjMapper);
         SimpleTestForm testForm = null;
 
         try {
@@ -157,7 +157,7 @@ public class BodyParserEngineJsonTest {
         } catch (IOException ignore) {
         }
         try {
-            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+            testForm = bodyParserEngineJson.invoke(context, SimpleTestForm.class);
         } catch (BadRequestException ignore) {
         } finally {
             try {
@@ -190,7 +190,7 @@ public class BodyParserEngineJsonTest {
                 BodyParserEngineJsonTest.DATA_LASTNAME);
         final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
         final ObjectMapper jsonObjMapper = new ObjectMapper();
-        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        final BodyParserEngineJson bodyParserEngineJson = new BodyParserEngineJson(jsonObjMapper);
         SimpleTestForm testForm = null;
 
         try {
@@ -198,7 +198,7 @@ public class BodyParserEngineJsonTest {
         } catch (IOException ignore) {
         }
         try {
-            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+            testForm = bodyParserEngineJson.invoke(context, SimpleTestForm.class);
         } catch (BadRequestException ignore) {
         } finally {
             try {

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineJsonTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineJsonTest.java
@@ -1,0 +1,231 @@
+package ninja.bodyparser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ninja.Context;
+import ninja.exceptions.BadRequestException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the Json body parser.
+ *
+ * @author Thibault Meyer
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BodyParserEngineJsonTest {
+
+    private static final String DATA_FIRSTNAME = "John";
+    private static final String DATA_LASTNAME = "Do";
+    private static final Integer DATA_BIRTHYEAR = 1664;
+    private static final String DATA_LASTSEEN = "2015-03-15 15:45:00";
+    private static final String PARSER_DATEFORMAT = "yyyy-MM-dd hh:mm:ss";
+    private static final String PARSER_DATETZ = "GMT";
+
+    @Mock
+    private Context context;
+
+    @Test
+    public void testValidJsonBody() {
+        final String jsonDocument = String.format("{\"firstName\":\"%s\", \"lastName\":\"%s\", \"birthYear\":%d, \"lastSeen\":\"%s\"}",
+                BodyParserEngineJsonTest.DATA_FIRSTNAME,
+                BodyParserEngineJsonTest.DATA_LASTNAME,
+                BodyParserEngineJsonTest.DATA_BIRTHYEAR,
+                BodyParserEngineJsonTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
+        final ObjectMapper jsonObjMapper = new ObjectMapper();
+        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        SimpleTestForm testForm = null;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        final Calendar cal = Calendar.getInstance();
+        final SimpleDateFormat dateFormat = new SimpleDateFormat(BodyParserEngineJsonTest.PARSER_DATEFORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(BodyParserEngineJsonTest.PARSER_DATETZ));
+        try {
+            cal.setTime(dateFormat.parse(BodyParserEngineJsonTest.DATA_LASTSEEN));
+        } catch (ParseException ignore) {
+        }
+        cal.setTimeZone(TimeZone.getTimeZone(BodyParserEngineJsonTest.PARSER_DATETZ));
+
+        assertTrue(testForm != null);
+        assertThat(testForm.firstName, equalTo(BodyParserEngineJsonTest.DATA_FIRSTNAME));
+        assertThat(testForm.lastName, equalTo(BodyParserEngineJsonTest.DATA_LASTNAME));
+        assertThat(testForm.birthYear, CoreMatchers.equalTo(BodyParserEngineJsonTest.DATA_BIRTHYEAR));
+        assertTrue(testForm.lastSeen != null);
+        assertTrue(testForm.lastSeen.compareTo(cal) == 0);
+    }
+
+    @Test
+    public void testEmptyJsonBody() {
+        final String jsonDocument = "";
+        final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
+        final ObjectMapper jsonObjMapper = new ObjectMapper();
+        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        boolean badRequestThrown = false;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+            badRequestThrown = true;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(badRequestThrown);
+    }
+
+    @Test
+    public void testInvalidJsonBody() {
+        final String jsonDocument = String.format("{\"firstName\":\"%s\", \"lastName\":\"%s\", \"birthYear\":%d, \"lastSeen\":\"%s\"",
+                BodyParserEngineJsonTest.DATA_FIRSTNAME,
+                BodyParserEngineJsonTest.DATA_LASTNAME,
+                BodyParserEngineJsonTest.DATA_BIRTHYEAR,
+                BodyParserEngineJsonTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
+        final ObjectMapper jsonObjMapper = new ObjectMapper();
+        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        boolean badRequestThrown = false;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+            badRequestThrown = true;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(badRequestThrown);
+    }
+
+    @Test
+    public void testJsonBodyWithFullSpacesAndEndOfLines() {
+        final String jsonDocument = String.format("  \n\n\n    {  \n    \"firstName\"    :   \"%s\", \"lastName\"\n : \"%s\", \"birthYear\":%d,\n \"lastSeen\":\"%s\"}   ",
+                BodyParserEngineJsonTest.DATA_FIRSTNAME,
+                BodyParserEngineJsonTest.DATA_LASTNAME,
+                BodyParserEngineJsonTest.DATA_BIRTHYEAR,
+                BodyParserEngineJsonTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
+        final ObjectMapper jsonObjMapper = new ObjectMapper();
+        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        SimpleTestForm testForm = null;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        final Calendar cal = Calendar.getInstance();
+        final SimpleDateFormat dateFormat = new SimpleDateFormat(BodyParserEngineJsonTest.PARSER_DATEFORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(BodyParserEngineJsonTest.PARSER_DATETZ));
+        try {
+            cal.setTime(dateFormat.parse(BodyParserEngineJsonTest.DATA_LASTSEEN));
+        } catch (ParseException ignore) {
+        }
+        cal.setTimeZone(TimeZone.getTimeZone(BodyParserEngineJsonTest.PARSER_DATETZ));
+
+        assertTrue(testForm != null);
+        assertThat(testForm.firstName, equalTo(BodyParserEngineJsonTest.DATA_FIRSTNAME));
+        assertThat(testForm.lastName, equalTo(BodyParserEngineJsonTest.DATA_LASTNAME));
+        assertThat(testForm.birthYear, CoreMatchers.equalTo(BodyParserEngineJsonTest.DATA_BIRTHYEAR));
+        assertTrue(testForm.lastSeen != null);
+        assertTrue(testForm.lastSeen.compareTo(cal) == 0);
+    }
+
+    @Test
+    public void testJsonBodyWithMissingVariables() {
+        final String jsonDocument = String.format("{\"firstName\":\"%s\", \"lastName\":\"%s\"}",
+                BodyParserEngineJsonTest.DATA_FIRSTNAME,
+                BodyParserEngineJsonTest.DATA_LASTNAME);
+        final InputStream is = new ByteArrayInputStream(jsonDocument.getBytes());
+        final ObjectMapper jsonObjMapper = new ObjectMapper();
+        final BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(jsonObjMapper);
+        SimpleTestForm testForm = null;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            testForm = bodyParserEnginePost.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(testForm != null);
+        assertThat(testForm.firstName, equalTo(BodyParserEngineJsonTest.DATA_FIRSTNAME));
+        assertThat(testForm.lastName, equalTo(BodyParserEngineJsonTest.DATA_LASTNAME));
+        assertTrue(testForm.birthYear == null);
+        assertTrue(testForm.lastSeen == null);
+    }
+
+    /**
+     * Simple form used during unit tests.
+     *
+     * @author Thibault Meyer
+     */
+    private static final class SimpleTestForm {
+
+        public String firstName;
+        public String lastName;
+        public Integer birthYear;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = BodyParserEngineJsonTest.PARSER_DATEFORMAT, timezone = BodyParserEngineJsonTest.PARSER_DATETZ)
+        public java.util.Calendar lastSeen;
+    }
+}

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineXmlTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineXmlTest.java
@@ -1,0 +1,218 @@
+package ninja.bodyparser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import ninja.Context;
+import ninja.exceptions.BadRequestException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the Xml body parser.
+ *
+ * @author Thibault Meyer
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BodyParserEngineXmlTest {
+
+    private static final String DATA_FIRSTNAME = "John";
+    private static final String DATA_LASTNAME = "Do";
+    private static final Integer DATA_BIRTHYEAR = 1664;
+    private static final String DATA_LASTSEEN = "2015-03-15 15:45:00";
+    private static final String PARSER_DATEFORMAT = "yyyy-MM-dd hh:mm:ss";
+    private static final String PARSER_DATETZ = "GMT";
+
+    @Mock
+    private Context context;
+
+    @Test
+    public void testValidXmlBody() {
+        final String xmlDocument = String.format("<form><firstName>%s</firstName><lastName>%s</lastName><birthYear>%d</birthYear><lastSeen>%s</lastSeen></form>",
+                BodyParserEngineXmlTest.DATA_FIRSTNAME,
+                BodyParserEngineXmlTest.DATA_LASTNAME,
+                BodyParserEngineXmlTest.DATA_BIRTHYEAR,
+                BodyParserEngineXmlTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(xmlDocument.getBytes());
+        final XmlMapper xmlObjMapper = new XmlMapper();
+        final BodyParserEngineXml bodyParserEngineXml = new BodyParserEngineXml(xmlObjMapper);
+        SimpleTestForm testForm = null;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            testForm = bodyParserEngineXml.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        final Calendar cal = Calendar.getInstance();
+        final SimpleDateFormat dateFormat = new SimpleDateFormat(BodyParserEngineXmlTest.PARSER_DATEFORMAT);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(BodyParserEngineXmlTest.PARSER_DATETZ));
+        try {
+            cal.setTime(dateFormat.parse(BodyParserEngineXmlTest.DATA_LASTSEEN));
+        } catch (ParseException ignore) {
+        }
+        cal.setTimeZone(TimeZone.getTimeZone(BodyParserEngineXmlTest.PARSER_DATETZ));
+
+        assertTrue(testForm != null);
+        assertThat(testForm.firstName, equalTo(BodyParserEngineXmlTest.DATA_FIRSTNAME));
+        assertThat(testForm.lastName, equalTo(BodyParserEngineXmlTest.DATA_LASTNAME));
+        assertThat(testForm.birthYear, CoreMatchers.equalTo(BodyParserEngineXmlTest.DATA_BIRTHYEAR));
+        assertTrue(testForm.lastSeen != null);
+        assertTrue(testForm.lastSeen.compareTo(cal) == 0);
+    }
+
+    @Test
+    public void testXmlBodyWithMissingVariables() {
+        final String xmlDocument = String.format("<form><firstName>%s</firstName><lastName>%s</lastName></form>",
+                BodyParserEngineXmlTest.DATA_FIRSTNAME,
+                BodyParserEngineXmlTest.DATA_LASTNAME);
+        final InputStream is = new ByteArrayInputStream(xmlDocument.getBytes());
+        final XmlMapper xmlObjMapper = new XmlMapper();
+        final BodyParserEngineXml bodyParserEngineXml = new BodyParserEngineXml(xmlObjMapper);
+        SimpleTestForm testForm = null;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            testForm = bodyParserEngineXml.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(testForm != null);
+        assertThat(testForm.firstName, equalTo(BodyParserEngineXmlTest.DATA_FIRSTNAME));
+        assertThat(testForm.lastName, equalTo(BodyParserEngineXmlTest.DATA_LASTNAME));
+        assertTrue(testForm.birthYear == null);
+        assertTrue(testForm.lastSeen == null);
+    }
+
+    @Test
+    public void testEmptyXmlBody() {
+        final String xmlDocument = "";
+        final InputStream is = new ByteArrayInputStream(xmlDocument.getBytes());
+        final XmlMapper xmlObjMapper = new XmlMapper();
+        final BodyParserEngineXml bodyParserEngineXml = new BodyParserEngineXml(xmlObjMapper);
+        boolean badRequestThrown = false;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            bodyParserEngineXml.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+            badRequestThrown = true;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(badRequestThrown);
+    }
+
+    @Test
+    public void testInvalidXmlBadCloseBody() {
+        final String xmlDocument = String.format("<form><firstName>%s</firstName><lastName>%s</lastName><birthYear>%d</birthYear><lastSeen>%s</lastSeen></>",
+                BodyParserEngineXmlTest.DATA_FIRSTNAME,
+                BodyParserEngineXmlTest.DATA_LASTNAME,
+                BodyParserEngineXmlTest.DATA_BIRTHYEAR,
+                BodyParserEngineXmlTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(xmlDocument.getBytes());
+        final XmlMapper xmlObjMapper = new XmlMapper();
+        final BodyParserEngineXml bodyParserEngineXml = new BodyParserEngineXml(xmlObjMapper);
+        boolean badRequestThrown = false;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            bodyParserEngineXml.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+            badRequestThrown = true;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(badRequestThrown);
+    }
+
+    @Test
+    public void testInvalidXmlMissingRootBody() {
+        final String xmlDocument = String.format("<firstName>%s</firstName><lastName>%s</lastName><birthYear>%d</birthYear><lastSeen>%s</lastSeen>",
+                BodyParserEngineXmlTest.DATA_FIRSTNAME,
+                BodyParserEngineXmlTest.DATA_LASTNAME,
+                BodyParserEngineXmlTest.DATA_BIRTHYEAR,
+                BodyParserEngineXmlTest.DATA_LASTSEEN);
+        final InputStream is = new ByteArrayInputStream(xmlDocument.getBytes());
+        final XmlMapper xmlObjMapper = new XmlMapper();
+        final BodyParserEngineXml bodyParserEngineXml = new BodyParserEngineXml(xmlObjMapper);
+        boolean badRequestThrown = false;
+
+        try {
+            Mockito.when(context.getInputStream()).thenReturn(is);
+        } catch (IOException ignore) {
+        }
+        try {
+            bodyParserEngineXml.invoke(context, SimpleTestForm.class);
+        } catch (BadRequestException ignore) {
+            badRequestThrown = true;
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ignore) {
+            }
+        }
+
+        assertTrue(badRequestThrown);
+    }
+
+    /**
+     * Simple form used during unit tests.
+     *
+     * @author Thibault Meyer
+     */
+    private static final class SimpleTestForm {
+
+        public String firstName;
+        public String lastName;
+        public Integer birthYear;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = BodyParserEngineXmlTest.PARSER_DATEFORMAT, timezone = BodyParserEngineXmlTest.PARSER_DATETZ)
+        public Calendar lastSeen;
+    }
+}


### PR DESCRIPTION
fix critical issue on JSON / XML parsing : when submitted document is empty (size: 0 bytes) or malformed, the method hasViolations() return false. This fix will correct this issue and the method hasViolations() now returning true when the document was not valid
