### PR TITLE
Changed the HTTP-Content parsing from Class<T> to TypeReference<T>

### DIFF
--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-
 import ninja.bodyparser.BodyParserEngineJson;
 import ninja.bodyparser.BodyParserEngineManager;
 import ninja.bodyparser.BodyParserEngineXml;
@@ -29,9 +28,7 @@ import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.utils.ResponseStreams;
 import ninja.validation.Validation;
-
 import org.apache.commons.fileupload.FileItemIterator;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 public interface Context {
 
@@ -431,31 +428,11 @@ public interface Context {
      * {@link BodyParserEngineJson} {@link BodyParserEngineXml} 
      * and {@link BodyParserEngineManager}
      *
-     * @deprecated use parseBody(TypeReference<T>) instead
      * @param classOfT
      *            The class of the result.
      * @return The parsed request or null if something went wrong.
      */
     <T> T parseBody(Class<T> classOfT);
-
-	// /////////////////////////////////////////////////////////////////////////
-	// Allows to get the nicely parsed content of the request.
-	// For instance if the content is a json you could simply get the json
-	// as Java object.
-	// /////////////////////////////////////////////////////////////////////////
-	/**
-	 * This will give you the request body nicely parsed. You can register your
-	 * own parsers depending on the request type.
-	 *
-	 * Have a look at {@link ninja.bodyparser.BodyParserEngine}
-	 * {@link BodyParserEngineJson} {@link BodyParserEngineXml}
-	 * and {@link BodyParserEngineManager}
-	 *
-	 * @param classOfT
-	 *            The class of the result.
-	 * @return The parsed request or null if something went wrong.
-	 */
-	<T> T parseBody(TypeReference<T> typeOfT);
 
     boolean isAsync();
         

--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -31,6 +31,7 @@ import ninja.utils.ResponseStreams;
 import ninja.validation.Validation;
 
 import org.apache.commons.fileupload.FileItemIterator;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 public interface Context {
 
@@ -429,14 +430,33 @@ public interface Context {
      * Have a look at {@link ninja.bodyparser.BodyParserEngine}
      * {@link BodyParserEngineJson} {@link BodyParserEngineXml} 
      * and {@link BodyParserEngineManager}
-     * 
+     *
+     * @deprecated use parseBody(TypeReference<T>) instead
      * @param classOfT
      *            The class of the result.
      * @return The parsed request or null if something went wrong.
      */
     <T> T parseBody(Class<T> classOfT);
 
-    
+	// /////////////////////////////////////////////////////////////////////////
+	// Allows to get the nicely parsed content of the request.
+	// For instance if the content is a json you could simply get the json
+	// as Java object.
+	// /////////////////////////////////////////////////////////////////////////
+	/**
+	 * This will give you the request body nicely parsed. You can register your
+	 * own parsers depending on the request type.
+	 *
+	 * Have a look at {@link ninja.bodyparser.BodyParserEngine}
+	 * {@link BodyParserEngineJson} {@link BodyParserEngineXml}
+	 * and {@link BodyParserEngineManager}
+	 *
+	 * @param classOfT
+	 *            The class of the result.
+	 * @return The parsed request or null if something went wrong.
+	 */
+	<T> T parseBody(TypeReference<T> typeOfT);
+
     boolean isAsync();
         
     /**

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -28,6 +28,7 @@ import ninja.utils.ResponseStreams;
 import ninja.validation.Validation;
 
 import org.apache.commons.fileupload.FileItemIterator;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * A wrapped context. Useful if filters want to modify the context before
@@ -157,7 +158,12 @@ public class WrappedContext implements Context {
         return wrapped.parseBody(classOfT);
     }
 
-    @Override
+	@Override
+	public <T> T parseBody(final TypeReference<T> typeOfT) {
+		return wrapped.parseBody(typeOfT);
+	}
+
+	@Override
     public boolean isAsync() {
         return wrapped.isAsync();
     }

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -21,14 +21,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.utils.ResponseStreams;
 import ninja.validation.Validation;
-
 import org.apache.commons.fileupload.FileItemIterator;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * A wrapped context. Useful if filters want to modify the context before
@@ -157,11 +154,6 @@ public class WrappedContext implements Context {
     public <T> T parseBody(Class<T> classOfT) {
         return wrapped.parseBody(classOfT);
     }
-
-	@Override
-	public <T> T parseBody(final TypeReference<T> typeOfT) {
-		return wrapped.parseBody(typeOfT);
-	}
 
 	@Override
     public boolean isAsync() {

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngine.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngine.java
@@ -17,20 +17,33 @@
 package ninja.bodyparser;
 
 import ninja.Context;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 public interface BodyParserEngine {
+
+	/**
+	 * Invoke the parser and get back a Java object populated
+	 * with the content of this request.
+	 *
+	 * MUST BE THREAD SAFE TO CALL!
+	 *
+	 * @param context The context
+	 * @param classOfT The class we expect
+	 * @return The object instance populated with all values from raw request
+	 */
+	<T> T invoke(Context context, Class<T> classOfT);
 
     /**
      * Invoke the parser and get back a Java object populated
      * with the content of this request.
-     * 
+     *
      * MUST BE THREAD SAFE TO CALL!
-     * 
+     *
      * @param context The context
      * @param classOfT The class we expect
      * @return The object instance populated with all values from raw request
      */
-    <T> T invoke(Context context, Class<T> classOfT);
+    <T> T invoke(Context context, TypeReference<T> typeOfT);
     
     /**
      * The content type this BodyParserEngine can handle

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngine.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngine.java
@@ -17,7 +17,6 @@
 package ninja.bodyparser;
 
 import ninja.Context;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 public interface BodyParserEngine {
 
@@ -33,18 +32,6 @@ public interface BodyParserEngine {
 	 */
 	<T> T invoke(Context context, Class<T> classOfT);
 
-    /**
-     * Invoke the parser and get back a Java object populated
-     * with the content of this request.
-     *
-     * MUST BE THREAD SAFE TO CALL!
-     *
-     * @param context The context
-     * @param classOfT The class we expect
-     * @return The object instance populated with all values from raw request
-     */
-    <T> T invoke(Context context, TypeReference<T> typeOfT);
-    
     /**
      * The content type this BodyParserEngine can handle
      * 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
@@ -45,7 +45,6 @@ public class BodyParserEngineJson implements BodyParserEngine {
 
     }
 
-    @Override
     public <T> T invoke(Context context, TypeReference<T> typeOfT) {
         T t = null;
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineJson.java
@@ -18,6 +18,7 @@ package ninja.bodyparser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 
 import ninja.ContentTypes;
 import ninja.Context;
@@ -25,6 +26,7 @@ import ninja.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -43,12 +45,13 @@ public class BodyParserEngineJson implements BodyParserEngine {
 
     }
 
-    public <T> T invoke(Context context, Class<T> classOfT) {
+    @Override
+    public <T> T invoke(Context context, TypeReference<T> typeOfT) {
         T t = null;
 
         try (InputStream inputStream = context.getInputStream()) {
 
-            t = objectMapper.readValue(inputStream, classOfT);
+            t = objectMapper.readValue(inputStream, typeOfT);
 
         } catch (IOException e) {
             logger.error("Error parsing incoming Json", e);
@@ -56,8 +59,18 @@ public class BodyParserEngineJson implements BodyParserEngine {
 
         return t;
     }
-    
-    public String getContentType() {
+
+	@Override
+	public <T> T invoke(final Context context, final Class<T> classOfT) {
+		return invoke(context, new TypeReference<T>() {
+			@Override
+			public Type getType() {
+				return classOfT;
+			}
+		});
+	}
+
+	public String getContentType() {
         return ContentTypes.APPLICATION_JSON; 
     }
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -44,7 +44,6 @@ public class BodyParserEnginePost implements BodyParserEngine {
 	}
 
 	@SuppressWarnings("unchecked")
-    @Override
     public <T> T invoke(Context context, TypeReference<T> typeOfT) {
         
         T t;

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineXml.java
@@ -17,15 +17,12 @@
 package ninja.bodyparser;
 
 import java.io.IOException;
-
+import java.lang.reflect.Type;
 import ninja.ContentTypes;
 import ninja.Context;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -45,25 +42,31 @@ public class BodyParserEngineXml implements BodyParserEngine {
 
     }
 
-    public <T> T invoke(Context context, Class<T> classOfT) {
+	public <T> T invoke(Context context, TypeReference<T> typeOfT) {
         T t = null;
 
         try {
             
-            t = xmlMapper.readValue(context.getInputStream(), classOfT);
+            t = xmlMapper.readValue(context.getInputStream(), typeOfT);
 
-        } catch (JsonParseException e) {
-            logger.error("Error parsing incoming Xml", e);
-        } catch (JsonMappingException e) {
-            logger.error("Error parsing incoming Xml", e);
         } catch (IOException e) {
             logger.error("Error parsing incoming Xml", e);
         }
 
         return t;
     }
-    
-    public String getContentType() {
+
+	@Override
+	public <T> T invoke(final Context context, final Class<T> classOfT) {
+		return invoke(context, new TypeReference<T>() {
+			@Override
+			public Type getType() {
+				return classOfT;
+			}
+		});
+	}
+
+	public String getContentType() {
         return ContentTypes.APPLICATION_XML; 
     }
 

--- a/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
+++ b/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
@@ -16,14 +16,14 @@
 
 package ninja.params;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-
 import ninja.Context;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.validation.Validation;
-
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
@@ -288,10 +288,16 @@ public class ArgumentExtractors {
     }
 
     public static class BodyAsExtractor<T> implements ArgumentExtractor<T> {
-        private final Class<T> bodyType;
+        private final TypeReference<T> bodyType = new TypeReference<T>() {
+	        @Override
+	        public Type getType() {
+		        return bodyClass;
+	        }
+        };
+	    private final Class<T> bodyClass;
 
-        public BodyAsExtractor(Class<T> bodyType) {
-            this.bodyType = bodyType;
+        public BodyAsExtractor(Class<T> bodyClass) {
+            this.bodyClass = bodyClass;
         }
 
         @Override
@@ -301,7 +307,7 @@ public class ArgumentExtractors {
 
         @Override
         public Class<T> getExtractedType() {
-            return bodyType;
+            return bodyClass;
         }
 
         @Override

--- a/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
+++ b/ninja-core/src/main/java/ninja/params/ArgumentExtractors.java
@@ -16,14 +16,12 @@
 
 package ninja.params;
 
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import ninja.Context;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.validation.Validation;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
@@ -288,12 +286,6 @@ public class ArgumentExtractors {
     }
 
     public static class BodyAsExtractor<T> implements ArgumentExtractor<T> {
-        private final TypeReference<T> bodyType = new TypeReference<T>() {
-	        @Override
-	        public Type getType() {
-		        return bodyClass;
-	        }
-        };
 	    private final Class<T> bodyClass;
 
         public BodyAsExtractor(Class<T> bodyClass) {
@@ -302,7 +294,7 @@ public class ArgumentExtractors {
 
         @Override
         public T extract(Context context) {
-            return context.parseBody(bodyType);
+            return context.parseBody(bodyClass);
         }
 
         @Override

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version x.x.x
 =============
 
+ * 2015-03-05 Changed body processing to create the actual objects (lukaseichler)
  * 2015-03-01 Bump to freemaker 2.3.22 (ra)
 
 

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserTest.java
@@ -1,0 +1,91 @@
+package ninja.bodyparser;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import ninja.Context;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BodyParserTest {
+
+	@Mock
+	Context context;
+
+	@Test
+	public void testJsonBodyParser() throws IOException {
+
+		Dto dto = new Dto();
+		dto.name = "Peter";
+		dto.id = 12345;
+
+		ObjectMapper mapper = new ObjectMapper();
+		InputStream stream = new ByteArrayInputStream(mapper.writeValueAsBytes(dto));
+		Mockito.when(context.getInputStream()).thenReturn(stream);
+
+		// do
+		BodyParserEngineJson bodyParserEnginePost = new BodyParserEngineJson(mapper);
+		Dto parsedDto = bodyParserEnginePost.invoke(context, Dto.class);
+
+		// and test:
+		assertNotNull(parsedDto);
+		assertEquals("Peter", parsedDto.name);
+		assertEquals(12345, dto.id);
+		dto = (Dto) parsedDto;
+	}
+
+	@Test
+	public void testXmlBodyParser() throws IOException {
+
+		Dto dto = new Dto();
+		dto.name = "Peter";
+		dto.id = 12345;
+
+		XmlMapper mapper = new XmlMapper();
+		InputStream stream = new ByteArrayInputStream(mapper.writeValueAsBytes(dto));
+		Mockito.when(context.getInputStream()).thenReturn(stream);
+
+		// do
+		BodyParserEngineXml bodyParserEnginePost = new BodyParserEngineXml(mapper);
+		Dto parsedDto = bodyParserEnginePost.invoke(context, Dto.class);
+
+		// and test:
+		assertNotNull(parsedDto);
+		assertEquals("Peter", parsedDto.name);
+		assertEquals(12345, dto.id);
+		dto = (Dto) parsedDto;
+	}
+
+	public static class Dto {
+		private int id;
+		private String name;
+
+		public Dto() {
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(final int id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+	}
+}

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -16,12 +16,6 @@
 
 package ninja.params;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -29,12 +23,10 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-
 import ninja.Context;
 import ninja.Result;
 import ninja.RoutingException;
@@ -45,16 +37,22 @@ import ninja.validation.NumberValue;
 import ninja.validation.Required;
 import ninja.validation.Validation;
 import ninja.validation.ValidationImpl;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -690,7 +688,7 @@ public class ControllerMethodInvokerTest {
     @Test
     public void bodyShouldBeParsedIntoLeftOverParameter() {
         Object body = new Object();
-        when(context.parseBody(Object.class)).thenReturn(body);
+        when(context.parseBody(any(TypeReference.class))).thenReturn(body);
         create("body").invoke(mockController, context);
         verify(mockController).body(body);
     }
@@ -785,8 +783,9 @@ public class ControllerMethodInvokerTest {
     }
 
     private void validateJSR303(Dto dto) {
-        when(context.parseBody(Dto.class)).thenReturn(dto);
-        create("JSR303Validation").invoke(mockController, context);
+	    when(context.parseBody(any(TypeReference.class))).thenReturn(dto);
+	    when(context.parseBody(Dto.class)).thenReturn(dto);
+	    create("JSR303Validation").invoke(mockController, context);
     }
 
     private void validateJSR303WithRequired(Dto dto) {

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -50,7 +49,6 @@ import com.google.inject.Inject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -688,7 +686,7 @@ public class ControllerMethodInvokerTest {
     @Test
     public void bodyShouldBeParsedIntoLeftOverParameter() {
         Object body = new Object();
-        when(context.parseBody(any(TypeReference.class))).thenReturn(body);
+        when(context.parseBody(Object.class)).thenReturn(body);
         create("body").invoke(mockController, context);
         verify(mockController).body(body);
     }
@@ -783,7 +781,7 @@ public class ControllerMethodInvokerTest {
     }
 
     private void validateJSR303(Dto dto) {
-	    when(context.parseBody(any(TypeReference.class))).thenReturn(dto);
+	    when(context.parseBody(Dto.class)).thenReturn(dto);
 	    when(context.parseBody(Dto.class)).thenReturn(dto);
 	    create("JSR303Validation").invoke(mockController, context);
     }

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -19,7 +19,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Type;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -58,7 +57,6 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.Inject;
 
 public class ContextImpl implements Context.Impl {
@@ -251,40 +249,29 @@ public class ContextImpl implements Context.Impl {
 
     @Override
     public <T> T parseBody(final Class<T> classOfT) {
-		return parseBody(new TypeReference<T>() {
-			@Override
-			public Type getType() {
-				return classOfT;
-			}
-		});
+	    String rawContentType = getRequestContentType();
+
+	    // If the Content-type: xxx header is not set we return null.
+	    // we cannot parse that request.
+	    if (rawContentType == null) {
+		    logger.debug("Not able to parse body because request did not send content type header at: {}", getRequestPath());
+		    return null;
+	    }
+
+	    // If Content-type is application/json; charset=utf-8 we split away the charset
+	    // application/json
+	    String contentTypeOnly = HttpHeaderUtils.getContentTypeFromContentTypeAndCharacterSetting(
+			    rawContentType);
+
+	    BodyParserEngine bodyParserEngine = bodyParserEngineManager
+			    .getBodyParserEngineForContentType(contentTypeOnly);
+
+	    if (bodyParserEngine == null) {
+		    logger.debug("No BodyParserEngine found for Content-Type {} at route {}", CONTENT_TYPE, getRequestPath());
+		    return null;
+	    }
+	    return bodyParserEngine.invoke(this, classOfT);
     }
-
-	@Override
-	public <T> T parseBody(final TypeReference<T> typeOfT) {
-		String rawContentType = getRequestContentType();
-
-		// If the Content-type: xxx header is not set we return null.
-		// we cannot parse that request.
-		if (rawContentType == null) {
-			logger.debug("Not able to parse body because request did not send content type header at: {}", getRequestPath());
-			return null;
-		}
-
-		// If Content-type is application/json; charset=utf-8 we split away the charset
-		// application/json
-		String contentTypeOnly = HttpHeaderUtils.getContentTypeFromContentTypeAndCharacterSetting(
-				rawContentType);
-
-		BodyParserEngine bodyParserEngine = bodyParserEngineManager
-				.getBodyParserEngineForContentType(contentTypeOnly);
-
-		if (bodyParserEngine == null) {
-			logger.debug("No BodyParserEngine found for Content-Type {} at route {}", CONTENT_TYPE, getRequestPath());
-			return null;
-		}
-
-		return bodyParserEngine.invoke(this, typeOfT);
-	}
 
 	@Override
     public FlashScope getFlashCookie() {

--- a/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
@@ -41,7 +41,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -671,7 +670,7 @@ public class ContextImplTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
 
         when(bodyParserEngineManager.getBodyParserEngineForContentType("application/json")).thenReturn(bodyParserEngine);
-        when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.isA(TypeReference.class))).thenReturn(new Dummy());
+        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(new Dummy());
 
         Object o = context.parseBody(Dummy.class);
 
@@ -693,7 +692,7 @@ public class ContextImplTest {
         Dummy dummy = new Dummy();
         dummy.name = "post";
         dummy.count = 245L;
-	    when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.any(TypeReference.class))).thenReturn(dummy);
+        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(dummy);
 
         Dummy o = context.parseBody(Dummy.class);
 
@@ -744,7 +743,7 @@ public class ContextImplTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
 
         when(bodyParserEngineManager.getBodyParserEngineForContentType("application/xml")).thenReturn(bodyParserEngine);
-	    when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.any(TypeReference.class))).thenReturn(new Dummy());
+        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(new Dummy());
 
         Object o = context.parseBody(Dummy.class);
 

--- a/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/ContextImplTest.java
@@ -16,23 +16,10 @@
 
 package ninja.servlet;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.Map;
-
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import ninja.ContentTypes;
 import ninja.Context;
 import ninja.Cookie;
@@ -47,7 +34,6 @@ import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
 import ninja.utils.ResultHandler;
 import ninja.validation.Validation;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,8 +41,19 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContextImplTest {
@@ -674,7 +671,7 @@ public class ContextImplTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
 
         when(bodyParserEngineManager.getBodyParserEngineForContentType("application/json")).thenReturn(bodyParserEngine);
-        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(new Dummy());
+        when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.isA(TypeReference.class))).thenReturn(new Dummy());
 
         Object o = context.parseBody(Dummy.class);
 
@@ -696,7 +693,7 @@ public class ContextImplTest {
         Dummy dummy = new Dummy();
         dummy.name = "post";
         dummy.count = 245L;
-        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(dummy);
+	    when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.any(TypeReference.class))).thenReturn(dummy);
 
         Dummy o = context.parseBody(Dummy.class);
 
@@ -747,7 +744,7 @@ public class ContextImplTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
 
         when(bodyParserEngineManager.getBodyParserEngineForContentType("application/xml")).thenReturn(bodyParserEngine);
-        when(bodyParserEngine.invoke(context, Dummy.class)).thenReturn(new Dummy());
+	    when(bodyParserEngine.invoke(Matchers.eq(context), Matchers.any(TypeReference.class))).thenReturn(new Dummy());
 
         Object o = context.parseBody(Dummy.class);
 

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -37,6 +37,7 @@ import ninja.validation.ValidationImpl;
 
 import org.apache.commons.fileupload.FileItemIterator;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Function;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
@@ -294,7 +295,13 @@ public class FakeContext implements Context {
         return classOfT.cast(body);
     }
 
-    @Override
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T parseBody(final TypeReference<T> typeOfT) {
+		return (T) body;
+	}
+
+	@Override
     public boolean isMultipart() {
         return false;
     }

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -295,12 +295,6 @@ public class FakeContext implements Context {
         return classOfT.cast(body);
     }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T> T parseBody(final TypeReference<T> typeOfT) {
-		return (T) body;
-	}
-
 	@Override
     public boolean isMultipart() {
         return false;


### PR DESCRIPTION
The current request processing creates for the request's body object something with the same class but instead of the actual object a hashmap is created. Which leads to castexceptions if this object is cast to the actual expected class. 

This pullrequest changes the current jackson usage of `body.parse(Class<T>)` to `body.parse(TypeReference<T>)` from which jackson can create proper objects. 
