### PR TITLE
Bug #320 - JSR validation language

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ValidatingArgumentExtractor.java
+++ b/ninja-core/src/main/java/ninja/params/ValidatingArgumentExtractor.java
@@ -16,17 +16,19 @@
 
 package ninja.params;
 
-import java.util.List;
-
 import ninja.Context;
 import ninja.validation.Validator;
 
+import java.util.List;
+
 /**
- * Argument extractor that wraps another argument extractor and validates its argument
+ * Argument extractor that wraps another argument extractor and validates
+ * its argument
  *
  * @author James Roper
  */
 public class ValidatingArgumentExtractor<T> implements ArgumentExtractor<T> {
+
     private final ArgumentExtractor<T> wrapped;
     private final List<Validator<T>> validators;
 
@@ -37,15 +39,15 @@ public class ValidatingArgumentExtractor<T> implements ArgumentExtractor<T> {
 
     @Override
     public T extract(Context context) {
-        T value = wrapped.extract(context);
+        final T value = this.wrapped.extract(context);
         // Check if we already have a validation error from a previous stage
-        if (context.getValidation().hasFieldViolation(wrapped.getFieldName())) {
+        if (context.getValidation().hasFieldViolation(this.wrapped.getFieldName())) {
             return value;
         }
         // Apply validators
-        for (Validator<T> validator : validators) {
-            validator.validate(value, wrapped.getFieldName(), context.getValidation(), context);
-            if (context.getValidation().hasFieldViolation(wrapped.getFieldName())) {
+        for (Validator<T> validator : this.validators) {
+            validator.validate(value, this.wrapped.getFieldName(), context);
+            if (context.getValidation().hasFieldViolation(this.wrapped.getFieldName())) {
                 // Break if validation failed
                 break;
             }
@@ -58,12 +60,11 @@ public class ValidatingArgumentExtractor<T> implements ArgumentExtractor<T> {
 
     @Override
     public Class<T> getExtractedType() {
-        return wrapped.getExtractedType();
+        return this.wrapped.getExtractedType();
     }
 
     @Override
     public String getFieldName() {
-        return wrapped.getFieldName();
+        return this.wrapped.getFieldName();
     }
 }
-

--- a/ninja-core/src/main/java/ninja/params/ValidatingArgumentExtractor.java
+++ b/ninja-core/src/main/java/ninja/params/ValidatingArgumentExtractor.java
@@ -44,7 +44,7 @@ public class ValidatingArgumentExtractor<T> implements ArgumentExtractor<T> {
         }
         // Apply validators
         for (Validator<T> validator : validators) {
-            validator.validate(value, wrapped.getFieldName(), context.getValidation());
+            validator.validate(value, wrapped.getFieldName(), context.getValidation(), context);
             if (context.getValidation().hasFieldViolation(wrapped.getFieldName())) {
                 // Break if validation failed
                 break;

--- a/ninja-core/src/main/java/ninja/validation/JSR303Validation.java
+++ b/ninja-core/src/main/java/ninja/validation/JSR303Validation.java
@@ -22,15 +22,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Validates that the annoted element is conform to its JSR303-Annotations
+ * Validates that the annotated element is conform to its JSR303-Annotations
  *
  * @author psommer
- *
  */
 @WithValidator(Validators.JSRValidator.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface JSR303Validation {
+
+    public static final String KEY = "validation.is.JSR303.violation";
+    public static final String MESSAGE = "{0} cannot be validated with JSR303 annotations";
+
     /**
      * The key for the violation message
      *
@@ -44,7 +47,4 @@ public @interface JSR303Validation {
      * @return The default message
      */
     String message() default MESSAGE;
-
-    public static final String KEY = "validation.is.JSR303.violation";
-    public static final String MESSAGE = "{0} cannot be validated with JSR303 annotations";
 }

--- a/ninja-core/src/main/java/ninja/validation/ValidationImpl.java
+++ b/ninja-core/src/main/java/ninja/validation/ValidationImpl.java
@@ -22,7 +22,8 @@ import java.util.List;
 /**
  * Validation object
  *
- * @author James Roper, Philip Sommer
+ * @author James Roper
+ * @author Philip Sommer
  */
 public class ValidationImpl implements Validation {
 
@@ -32,16 +33,16 @@ public class ValidationImpl implements Validation {
 
     @Override
     public boolean hasViolations() {
-        return !fieldViolations.isEmpty() || !generalViolations.isEmpty()
-                || !beanViolations.isEmpty();
+        return !this.fieldViolations.isEmpty() || !this.generalViolations.isEmpty()
+                || !this.beanViolations.isEmpty();
     }
 
     @Override
     public void addFieldViolation(FieldViolation fieldViolation) {
         if (fieldViolation.field == null) {
-            generalViolations.add(fieldViolation.constraintViolation);
+            this.generalViolations.add(fieldViolation.constraintViolation);
         } else {
-            fieldViolations.add(fieldViolation);
+            this.fieldViolations.add(fieldViolation);
         }
     }
 
@@ -52,7 +53,7 @@ public class ValidationImpl implements Validation {
 
     @Override
     public boolean hasFieldViolation(String field) {
-        for (FieldViolation fieldViolation : fieldViolations) {
+        for (FieldViolation fieldViolation : this.fieldViolations) {
             if (fieldViolation.field.contentEquals(field)) {
                 return true;
             }
@@ -62,13 +63,13 @@ public class ValidationImpl implements Validation {
 
     @Override
     public List<FieldViolation> getFieldViolations() {
-        return fieldViolations;
+        return this.fieldViolations;
     }
 
     @Override
     public List<FieldViolation> getFieldViolations(String field) {
         List<FieldViolation> violationsForThisField = new ArrayList<FieldViolation>();
-        for (FieldViolation fieldViolation : fieldViolations) {
+        for (FieldViolation fieldViolation : this.fieldViolations) {
             if (fieldViolation.field.contentEquals(field)) {
                 violationsForThisField.add(fieldViolation);
             }
@@ -78,12 +79,12 @@ public class ValidationImpl implements Validation {
 
     @Override
     public void addBeanViolation(FieldViolation fieldViolation) {
-        beanViolations.add(fieldViolation);
+        this.beanViolations.add(fieldViolation);
     }
 
     @Override
     public boolean hasBeanViolation(String field) {
-        for (FieldViolation beanViolation : beanViolations) {
+        for (FieldViolation beanViolation : this.beanViolations) {
             if (beanViolation.field.contentEquals(field)) {
                 return true;
             }
@@ -93,22 +94,21 @@ public class ValidationImpl implements Validation {
 
     @Override
     public boolean hasBeanViolations() {
-        return !beanViolations.isEmpty();
+        return !this.beanViolations.isEmpty();
     }
 
     @Override
     public List<FieldViolation> getBeanViolations() {
-        return beanViolations;
+        return this.beanViolations;
     }
 
     @Override
     public void addViolation(ConstraintViolation constraintViolation) {
-        generalViolations.add(constraintViolation);
+        this.generalViolations.add(constraintViolation);
     }
 
     @Override
     public List<ConstraintViolation> getGeneralViolations() {
-        return generalViolations;
+        return this.generalViolations;
     }
-
 }

--- a/ninja-core/src/main/java/ninja/validation/Validator.java
+++ b/ninja-core/src/main/java/ninja/validation/Validator.java
@@ -20,40 +20,24 @@ import ninja.Context;
 
 /**
  * A validator for validating parameters
- * 
+ *
  * @author James Roper
+ * @author Thibault Meyer
  */
 public interface Validator<T> {
-    /**
-     * Validate the given value
-     * 
-     * @param value
-     *            The value, may be null
-     * @param field
-     *            The name of the field being validated, if applicable
-     * @param validation
-     *            The validation context
-     */
-    @Deprecated
-    void validate(T value, String field, Validation validation);
 
     /**
      * Validate the given value
      *
-     * @param value
-     *            The value, may be null
-     * @param field
-     *            The name of the field being validated, if applicable
-     * @param validation
-     *            The validation context
-     * @param context
-     *            The Ninja request context
+     * @param value   The value, may be null
+     * @param field   The name of the field being validated, if applicable
+     * @param context The Ninja request context
      */
-    void validate(T value, String field, Validation validation, Context context);
+    void validate(T value, String field, Context context);
 
     /**
      * Get the type that this validator validates
-     * 
+     *
      * @return The type that the validator validates
      */
     Class<T> getValidatedType();

--- a/ninja-core/src/main/java/ninja/validation/Validator.java
+++ b/ninja-core/src/main/java/ninja/validation/Validator.java
@@ -16,6 +16,8 @@
 
 package ninja.validation;
 
+import ninja.Context;
+
 /**
  * A validator for validating parameters
  * 
@@ -32,7 +34,22 @@ public interface Validator<T> {
      * @param validation
      *            The validation context
      */
+    @Deprecated
     void validate(T value, String field, Validation validation);
+
+    /**
+     * Validate the given value
+     *
+     * @param value
+     *            The value, may be null
+     * @param field
+     *            The name of the field being validated, if applicable
+     * @param validation
+     *            The validation context
+     * @param context
+     *            The Ninja request context
+     */
+    void validate(T value, String field, Validation validation, Context context);
 
     /**
      * Get the type that this validator validates

--- a/ninja-core/src/main/java/ninja/validation/Validators.java
+++ b/ninja-core/src/main/java/ninja/validation/Validators.java
@@ -65,30 +65,25 @@ public class Validators {
 
         @Override
         public ConstraintDescriptor<?> getConstraintDescriptor() {
-            return descriptor;
+            return this.descriptor;
         }
 
         @Override
         public Object getValidatedValue() {
-            return value;
+            return this.value;
         }
     }
 
     public static class JSRValidator implements Validator<Object> {
 
         @Override
-        @Deprecated
-        public void validate(Object value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
-        }
-
-        @Override
-        public void validate(Object value, String field, Validation validation, ninja.Context context) {
+        public void validate(Object value, String field, Context context) {
             if (value != null) {
                 final ValidatorFactory validatorFactory = javax.validation.Validation.buildDefaultValidatorFactory();
                 final javax.validation.Validator validator = validatorFactory.getValidator();
                 final Set<javax.validation.ConstraintViolation<Object>> violations = validator.validate(value);
-                final Locale localeToUse = (context == null || context.getAcceptLanguage() == null) ? Locale.getDefault() : Locale.forLanguageTag(context.getAcceptLanguage().split(",", 2)[0]);
+                final Locale localeToUse = (context.getAcceptLanguage() == null) ? Locale.getDefault() : Locale.forLanguageTag(context.getAcceptLanguage().split(",", 2)[0]);
+                final Validation validation = context.getValidation();
 
                 for (javax.validation.ConstraintViolation<Object> violation : violations) {
                     final String violationMessage = validatorFactory.getMessageInterpolator().interpolate(
@@ -117,20 +112,14 @@ public class Validators {
         }
 
         @Override
-        @Deprecated
-        public void validate(Object value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
-        }
-
-        @Override
-        public void validate(Object value, String field, Validation validation, ninja.Context context) {
+        public void validate(Object value, String field, Context context) {
             if (value == null) {
-                validation.addFieldViolation(
+                context.getValidation().addFieldViolation(
                         field,
                         ConstraintViolation.createForFieldWithDefault(
-                                required.key(),
-                                fieldKey(field, required.fieldKey()),
-                                required.message()));
+                                this.required.key(),
+                                fieldKey(field, this.required.fieldKey()),
+                                this.required.message()));
             }
         }
 
@@ -148,33 +137,26 @@ public class Validators {
             this.length = length;
         }
 
-        @Override
-        @Deprecated
-        public void validate(String value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
-        }
-
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(String value, String field, Validation validation, Context context) {
+        public void validate(String value, String field, Context context) {
             if (value != null) {
-                if (length.max() != -1 && value.length() > length.max()) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(length.maxKey(),
-                                    fieldKey(field, length.fieldKey()),
-                                    length.maxMessage(), length.max(), value));
-                } else if (length.min() != -1 && value.length() < length.min()) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(length.minKey(),
-                                    fieldKey(field, length.fieldKey()),
-                                    length.minMessage(), length.min(), value));
+                if (this.length.max() != -1 && value.length() > this.length.max()) {
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.length.maxKey(),
+                                    fieldKey(field, this.length.fieldKey()),
+                                    this.length.maxMessage(), this.length.max(), value));
+                } else if (this.length.min() != -1 && value.length() < this.length.min()) {
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.length.minKey(),
+                                    fieldKey(field, this.length.fieldKey()),
+                                    this.length.minMessage(), this.length.min(), value));
                 }
             }
         }
@@ -190,33 +172,26 @@ public class Validators {
         private final IsInteger isInteger;
 
         public IntegerValidator(IsInteger integer) {
-            isInteger = integer;
-        }
-
-        @Override
-        @Deprecated
-        public void validate(String value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
+            this.isInteger = integer;
         }
 
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(String value, String field, Validation validation, Context context) {
+        public void validate(String value, String field, Context context) {
             if (value != null) {
                 try {
                     Long.parseLong(value);
                 } catch (NumberFormatException e) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(isInteger.key(),
-                                    fieldKey(field, isInteger.fieldKey()),
-                                    isInteger.message(), value));
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.isInteger.key(),
+                                    fieldKey(field, this.isInteger.fieldKey()),
+                                    this.isInteger.message(), value));
                 }
             }
         }
@@ -232,33 +207,26 @@ public class Validators {
         private final IsFloat isFloat;
 
         public FloatValidator(IsFloat aFloat) {
-            isFloat = aFloat;
-        }
-
-        @Override
-        @Deprecated
-        public void validate(String value, String field, Validation validation) {
-            this.validate(value, field, validation, null/**/);
+            this.isFloat = aFloat;
         }
 
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(String value, String field, Validation validation, Context context) {
+        public void validate(String value, String field, Context context) {
             if (value != null) {
                 try {
                     Double.parseDouble(value);
                 } catch (NumberFormatException e) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(isFloat.key(),
-                                    fieldKey(field, isFloat.fieldKey()),
-                                    isFloat.message(), value));
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.isFloat.key(),
+                                    fieldKey(field, this.isFloat.fieldKey()),
+                                    this.isFloat.message(), value));
                 }
             }
         }
@@ -276,35 +244,27 @@ public class Validators {
 
         public MatchesValidator(Matches matches) {
             this.matches = matches;
-            pattern = Pattern.compile(matches.regexp());
-        }
-
-        @Override
-        @Deprecated
-        public void validate(String value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
+            this.pattern = Pattern.compile(matches.regexp());
         }
 
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(String value, String field, Validation validation, Context context) {
+        public void validate(String value, String field, Context context) {
             if (value != null) {
-                if (!pattern.matcher(value).matches()) {
-                    validation
-                            .addFieldViolation(
-                                    field,
-                                    ConstraintViolation.createForFieldWithDefault(
-                                            matches.key(),
-                                            fieldKey(field, matches.fieldKey()),
-                                            matches.message(),
-                                            matches.regexp(), value));
+                if (!this.pattern.matcher(value).matches()) {
+                    context.getValidation().addFieldViolation(
+                            field,
+                            ConstraintViolation.createForFieldWithDefault(
+                                    this.matches.key(),
+                                    fieldKey(field, this.matches.fieldKey()),
+                                    this.matches.message(),
+                                    this.matches.regexp(), value));
                 }
             }
         }
@@ -323,35 +283,28 @@ public class Validators {
             this.number = number;
         }
 
-        @Override
-        @Deprecated
-        public void validate(Number value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
-        }
-
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(Number value, String field, Validation validation, Context context) {
+        public void validate(Number value, String field, Context context) {
             if (value != null) {
-                if (number.max() != Double.MAX_VALUE
-                        && value.doubleValue() > number.max()) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(number.maxKey(),
-                                    fieldKey(field, number.fieldKey()),
-                                    number.maxMessage(), number.max(), value));
-                } else if (number.min() != -1
-                        && value.doubleValue() < number.min()) {
-                    validation.addFieldViolation(field, ConstraintViolation
-                            .createForFieldWithDefault(number.minKey(),
-                                    fieldKey(field, number.fieldKey()),
-                                    number.minMessage(), number.min(), value));
+                if (this.number.max() != Double.MAX_VALUE
+                        && value.doubleValue() > this.number.max()) {
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.number.maxKey(),
+                                    fieldKey(field, this.number.fieldKey()),
+                                    this.number.maxMessage(), this.number.max(), value));
+                } else if (this.number.min() != -1
+                        && value.doubleValue() < this.number.min()) {
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.number.minKey(),
+                                    fieldKey(field, this.number.fieldKey()),
+                                    this.number.minMessage(), this.number.min(), value));
                 }
             }
         }
@@ -367,29 +320,22 @@ public class Validators {
         private final IsEnum isEnum;
 
         public EnumValidator(IsEnum anEnum) {
-            isEnum = anEnum;
-        }
-
-        @Override
-        @Deprecated
-        public void validate(String value, String field, Validation validation) {
-            this.validate(value, field, validation, null);
+            this.isEnum = anEnum;
         }
 
         /**
          * Validate the given value
          *
-         * @param value      The value, may be null
-         * @param field      The name of the field being validated, if applicable
-         * @param validation The validation context
-         * @param context    The Ninja request context
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
          */
         @Override
-        public void validate(String value, String field, Validation validation, Context context) {
+        public void validate(String value, String field, Context context) {
             if (value != null) {
-                Enum<?>[] values = isEnum.enumClass().getEnumConstants();
+                Enum<?>[] values = this.isEnum.enumClass().getEnumConstants();
                 for (Enum<?> v : values) {
-                    if (isEnum.caseSensitive()) {
+                    if (this.isEnum.caseSensitive()) {
                         if (v.name().equals(value)) {
                             return;
                         }
@@ -400,8 +346,8 @@ public class Validators {
                     }
                 }
 
-                validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
-                        IsEnum.KEY, field, IsEnum.MESSAGE, new Object[]{value, isEnum.enumClass().getName()}));
+                context.getValidation().addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                        IsEnum.KEY, field, IsEnum.MESSAGE, value, this.isEnum.enumClass().getName()));
             }
         }
 


### PR DESCRIPTION
This pull request fix issue on the JSR303 error messages locale (Bug  https://github.com/ninjaframework/ninja/issues/320). Before this patch, JSR used the locale of the running server : _Locale.getDefault()_. Now, the locale is determined by the value of the request's header _Accept-Language_. The determined locale is only apply to the current request (not system wild).
