### PR TITLE
Upgrade archetypes / replace assembly with shade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin
 ninja-demo-application/src/main/java/ninja
 ninja-demo-application/src/main/java/ninjaModuleDemo
 
+#maven-shade-plugin auto-generated files
+dependency-reduced-pom.xml

--- a/ninja-async-machine-beta/pom.xml
+++ b/ninja-async-machine-beta/pom.xml
@@ -98,17 +98,40 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>ninja.standalone.NinjaJetty</mainClass>
-                        </manifest>
-                    </archive>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ninja.standalone.NinjaJetty</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/ninja-async-machine-beta/pom.xml
+++ b/ninja-async-machine-beta/pom.xml
@@ -163,6 +163,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
+            <version>3.3.4</version>
         </dependency>
 
         <dependency>

--- a/ninja-core/src/site/markdown/documentation/deployment/ninja_standalone.md
+++ b/ninja-core/src/site/markdown/documentation/deployment/ninja_standalone.md
@@ -24,37 +24,62 @@ In order to do so you have to first of all add ninja-standalone as dependency to
     &lt;groupId&gt;org.ninjaframework&lt;/groupId&gt;
     &lt;artifactId&gt;ninja-standalone&lt;/artifactId&gt;
     &lt;version&gt;X.X.X&lt;/version&gt;
-&lt;/dependency&gt;   
-</pre>        
+&lt;/dependency&gt;
+</pre>
 
-Packaging the application is done via the maven assembly plugin. Add the following snipplet
+Don't forget to change packaging value from _war_ to _jar_.
+
+<pre class="prettyprint">
+&lt;packaging&gt;jar&lt;/packaging&gt;
+</pre>
+
+Packaging the application is done via the maven shade plugin. Add the following snipplet
 to your pom.xml.
 
 <pre class="prettyprint">
 &lt;plugin&gt;
-    &lt;artifactId&gt;maven-assembly-plugin&lt;/artifactId&gt;
-    &lt;version&gt;2.4&lt;/version&gt;
-    &lt;configuration&gt;
-        &lt;descriptorRefs&gt;
-            &lt;descriptorRef&gt;jar-with-dependencies&lt;/descriptorRef&gt;
-        &lt;/descriptorRefs&gt;
-        &lt;archive&gt;
-            &lt;manifest&gt;
-                &lt;mainClass&gt;ninja.standalone.NinjaJetty&lt;/mainClass&gt;
-            &lt;/manifest&gt;
-        &lt;/archive&gt;
-    &lt;/configuration&gt;
+  &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
+  &lt;artifactId&gt;maven-shade-plugin&lt;/artifactId&gt;
+  &lt;version&gt;2.2&lt;/version&gt;
+  &lt;configuration&gt;
+    &lt;createDependencyReducedPom&gt;true&lt;/createDependencyReducedPom&gt;
+    &lt;filters&gt;
+      &lt;filter&gt;
+        &lt;artifact&gt;*:*&lt;/artifact&gt;
+        &lt;excludes&gt;
+          &lt;exclude&gt;META-INF/*.SF&lt;/exclude&gt;
+          &lt;exclude&gt;META-INF/*.DSA&lt;/exclude&gt;
+          &lt;exclude&gt;META-INF/*.RSA&lt;/exclude&gt;
+        &lt;/excludes&gt;
+      &lt;/filter&gt;
+    &lt;/filters&gt;
+  &lt;/configuration&gt;
+  &lt;executions&gt;
+    &lt;execution&gt;
+      &lt;phase&gt;package&lt;/phase&gt;
+      &lt;goals&gt;
+        &lt;goal&gt;shade&lt;/goal&gt;
+      &lt;/goals&gt;
+      &lt;configuration&gt;
+        &lt;transformers&gt;
+          &lt;transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/&gt;
+          &lt;transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"&gt;
+            &lt;mainClass&gt;ninja.standalone.NinjaJetty&lt;/mainClass&gt;
+          &lt;/transformer&gt;
+        &lt;/transformers&gt;
+      &lt;/configuration&gt;
+    &lt;/execution&gt;
+  &lt;/executions&gt;
 &lt;/plugin&gt;
 </pre>
 
 Whenever you build your application on the command line this will generate a fat jar
 inside your target directory. Usually that file is named roughly MY-APPLICATION-jar-with-dependencies.jar
 
-If you skip the section called "executions" in the maven-assembly-plugin you can generate
-the fat jar by calling
+You can generate the fat jar by calling
 
 <pre class="prettyprint">
-mvn clean compile assembly:single
+mvn clean compile package
 </pre>
 
 Running the fat jar (and your app) is as simple as calling:

--- a/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating/advanced_topics.md
@@ -112,11 +112,11 @@ This would then result in the following output: <code>/assets/css/custom.css</co
 ### webJarsAt(...)
 
 webJarsAt allows you to render webjar contents. For instance
-<code>${webJarsAt("bootstrap/3.0.0/css/bootstrap.min.css")}</code> would render
+<code>${webJarsAt("bootstrap/3.3.4/css/bootstrap.min.css")}</code> would render
 a css file from a webJars jar. The corresponding route could be 
 <code>router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");</code>.
 
-This would then result in the following output: <code>/assets/webjars/bootstrap/3.0.0/css/bootstrap.min.css</code>.
+This would then result in the following output: <code>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</code>.
 
 ### i18n(...)
 

--- a/ninja-core/src/site/markdown/documentation/static_assets.md
+++ b/ninja-core/src/site/markdown/documentation/static_assets.md
@@ -95,7 +95,7 @@ router.GET().route("/webjars/{fileName: .*}").with(AssetsController.class, "serv
 You can reference bootstrap from your html pages via the following url:
 
 <pre class="prettyprint">
-&lt;link href=&quot;/webjars/bootstrap/2.1.1/css/bootstrap.min.css&quot; rel=&quot;stylesheet&quot;&gt;
+&lt;link href=&quot;/webjars/bootstrap/3.3.4/css/bootstrap.min.css&quot; rel=&quot;stylesheet&quot;&gt;
 </pre>
 
 And Bootstrap is only an example. There are a lot more WebJars available at your

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -21,8 +21,8 @@
                     Rock solid, fast and super productive."/>
             <link rel="icon" type="image/png" href="favicon.png" />
 
-            <link href='http://fonts.googleapis.com/css?family=Titillium+Web' rel='stylesheet' type='text/css'/>
-            <link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'/>
+            <link href='//fonts.googleapis.com/css?family=Titillium+Web' rel='stylesheet' type='text/css'/>
+            <link href='//fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'/>
             <link href='//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'/>
 
             <script type="text/javascript">

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.182</version>
+            <version>1.4.186</version>
         </dependency>
         <!-- If you want to deploy to a war please -->
         <!-- comment ninja-standalone dependency and  -->

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -153,11 +153,6 @@
     <dependencies>
         <dependency>
             <groupId>org.webjars</groupId>
-            <artifactId>tinymce-jquery</artifactId>
-            <version>4.0.16</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>3.3.2</version>
         </dependency>

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -4,6 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>${artifactId}</artifactId>
+    <!-- If you want to deploy to a war please -->
+    <!-- replace "jar" with "war" and -->
+    <!-- comment ninja-standalone dependency and  -->
+    <!-- uncomment the dependency for ninja-servlet -->
     <packaging>jar</packaging>
     <groupId>${groupId}</groupId>
     <version>${version}</version>

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>${artifactId}</artifactId>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <groupId>${groupId}</groupId>
     <version>${version}</version>
-    
+
     <url>http://www.ninjaframework.org</url>
-    
+
     <properties>
         <ninja.version>@project.version@</ninja.version>
         <jetty.version>@jetty.version@</jetty.version>
@@ -95,18 +96,40 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>ninja.standalone.NinjaJetty</mainClass>
-                        </manifest>
-                    </archive>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ninja.standalone.NinjaJetty</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>
@@ -142,7 +165,7 @@
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>2.1.3</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
@@ -12,9 +12,9 @@
     <meta name="author" content="">
 
     <!-- Le styles -->
-    <link href="/assets/webjars/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
     <!-- Optional theme -->
-    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.2/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 
     <!-- Latest compiled and minified JavaScript -->
     
@@ -55,7 +55,7 @@
         
     </div> <!-- /container -->
     <script type="text/javascript" src="/assets/webjars/jquery/2.1.3/jquery.js"></script>
-    <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 </body>
 </html>
 </${symbol_pound}macro>

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
@@ -55,7 +55,6 @@
         
     </div> <!-- /container -->
     <script type="text/javascript" src="/assets/webjars/jquery/2.1.3/jquery.js"></script>
-    <script type="text/javascript" src="/assets/webjars/tinymce-jquery/4.0.16/jscripts/tiny_mce/tiny_mce.js" ></script>
     <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -98,17 +98,40 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>ninja.standalone.NinjaJetty</mainClass>
-                        </manifest>
-                    </archive>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ninja.standalone.NinjaJetty</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -163,6 +163,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
+            <version>3.3.4</version>
         </dependency>
 
         <dependency>

--- a/ninja-servlet-integration-test/src/main/java/views/ApplicationController/testReverseRouting.ftl.html
+++ b/ninja-servlet-integration-test/src/main/java/views/ApplicationController/testReverseRouting.ftl.html
@@ -2,10 +2,8 @@
     <body>
         <ul>
             <li>${reverseRoute("controllers.ApplicationController", "userDashboard", "email", email, "id", id)}</li>
-            <li>${webJarsAt("bootstrap/3.0.0/css/bootstrap.min.css")}</li>
+            <li>${webJarsAt("bootstrap/3.3.4/css/bootstrap.min.css")}</li>
             <li>${assetsAt("css/custom.css")}</li>    
         </ul>
-        </body>
+    </body>
 </html>
-
-

--- a/ninja-servlet-integration-test/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-integration-test/src/main/java/views/layout/defaultLayout.ftl.html
@@ -9,9 +9,9 @@
     <meta name="author" content="">
 
     <!-- Le styles -->
-    <link href="${reverseRoute("ninja.AssetsController", "serveWebJars", "fileName", "bootstrap/3.0.0/css/bootstrap.min.css")}" rel="stylesheet">
+    <link href="${reverseRoute("ninja.AssetsController", "serveWebJars", "fileName", "bootstrap/3.3.4/css/bootstrap.min.css")}" rel="stylesheet">
     <!-- Optional theme -->
-    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.0.0/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 
     <!-- Latest compiled and minified JavaScript -->
     
@@ -41,7 +41,7 @@
         
     </div> <!-- /container -->
     <script src="/assets/webjars/jquery/1.9.0/jquery.js"></script>
-    <script src="/assets/webjars/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+    <script src="/assets/webjars/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script src="/assets/js/google-code-prettify/prettify.js"></script>
 </body>
 </html>

--- a/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
@@ -288,7 +288,7 @@ public class ApplicationControllerTest extends NinjaTest {
                 ninjaTestBrowser.makeRequest(getServerAddress() + "/test_reverse_routing");
     
         assertTrue(response.contains("<li>/user/100000/me@me.com/userDashboard</li>"));
-        assertTrue(response.contains("<li>/assets/webjars/bootstrap/3.0.0/css/bootstrap.min.css</li>"));
+        assertTrue(response.contains("<li>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</li>"));
         assertTrue(response.contains("<li>/assets/css/custom.css</li>"));
     }
     

--- a/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
@@ -72,7 +72,7 @@ public class AssetsControllerTest extends NinjaTest {
 
         // /redirect will send a location: redirect in the headers
         HttpResponse httpResponse = ninjaTestBrowser.makeRequestAndGetResponse(
-                getServerAddress() + "assets/webjars/bootstrap/3.0.0/css/bootstrap.min.css", headers);
+                getServerAddress() + "assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css", headers);
 
         assertEquals(200, httpResponse.getStatusLine().getStatusCode());
     }

--- a/ninja-servlet-integration-test/src/test/java/example/ExampleIntegrationTest.java
+++ b/ninja-servlet-integration-test/src/test/java/example/ExampleIntegrationTest.java
@@ -26,7 +26,7 @@ public class ExampleIntegrationTest extends NinjaFluentLeniumTest {
     @Test
     public void testThatStaticAssetsWork() {
 
-        goTo(getServerAddress() + "/assets/webjars/bootstrap/3.0.0/css/bootstrap.min.css");
+        goTo(getServerAddress() + "/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css");
 
         assertTrue(pageSource().contains("Bootstrap"));
 

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>${artifactId}</artifactId>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <groupId>${groupId}</groupId>
     <version>${version}</version>
-    
+
     <url>http://www.ninjaframework.org</url>
-    
+
     <properties>
         <ninja.version>@project.version@</ninja.version>
         <jetty.version>@jetty.version@</jetty.version>
@@ -94,18 +95,40 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>ninja.standalone.NinjaJetty</mainClass>
-                        </manifest>
-                    </archive>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ninja.standalone.NinjaJetty</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>
@@ -136,7 +159,7 @@
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>2.1.3</version>
-        </dependency>         
+        </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -163,12 +163,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.4</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.182</version>
+            <version>1.4.186</version>
         </dependency>
         <!-- If you want to deploy to a war please -->
         <!-- comment ninja-standalone dependency and  -->

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,6 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>${artifactId}</artifactId>
+    <!-- If you want to deploy to a war please -->
+    <!-- replace "jar" with "war" and -->
+    <!-- comment ninja-standalone dependency and  -->
+    <!-- uncomment the dependency for ninja-servlet -->
     <packaging>jar</packaging>
     <groupId>${groupId}</groupId>
     <version>${version}</version>

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
@@ -57,7 +57,7 @@
         
     </div> <!-- /container -->
     <script type="text/javascript" src="/assets/webjars/jquery/2.1.3/jquery.js"></script>
-    <script type="text/javascript" src="/assets/webjars/tinymce-jquery/4.0.16/jscripts/tiny_mce/tiny_mce.js" ></script>
+    <script type="text/javascript" src="/assets/webjars/tinymce-jquery/4.0.16/tinymce.min.js" ></script>
     <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/views/layout/defaultLayout.ftl.html
@@ -12,9 +12,9 @@
     <meta name="author" content="">
 
     <!-- Le styles -->
-    <link href="/assets/webjars/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
     <!-- Optional theme -->
-    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.2/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.4/css/bootstrap-theme.min.css">
     
 
     <!-- Latest compiled and minified JavaScript -->
@@ -58,7 +58,7 @@
     </div> <!-- /container -->
     <script type="text/javascript" src="/assets/webjars/jquery/2.1.3/jquery.js"></script>
     <script type="text/javascript" src="/assets/webjars/tinymce-jquery/4.0.16/tinymce.min.js" ></script>
-    <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/assets/webjars/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 </body>
 </html>
 </${symbol_pound}macro>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -156,8 +156,6 @@
 
     </build>
 
-
-
     <dependencies>
     
         <dependency>
@@ -168,6 +166,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
+			<version>3.3.4</version>
         </dependency>
 
         <dependency>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -24,7 +24,8 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ninja-servlet-jpa-blog-integration-test</artifactId>
@@ -35,7 +36,7 @@
         <artifactId>ninja</artifactId>
         <version>4.0.7-SNAPSHOT</version>
     </parent>
-    
+
     <url>http://www.ninjaframework.org</url>
 
     <build>
@@ -88,7 +89,7 @@
                 <artifactId>ninja-maven-plugin</artifactId>
                 <version>${project.version}</version>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
@@ -96,7 +97,7 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -157,7 +158,7 @@
     </build>
 
     <dependencies>
-    
+
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>tinymce-jquery</artifactId>
@@ -166,19 +167,19 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-			<version>3.3.4</version>
+            <version>3.3.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-servlet</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-test-utilities</artifactId>
@@ -186,7 +187,5 @@
         </dependency>
 
     </dependencies>
-
-
 
 </project>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -98,17 +98,40 @@
             </plugin>
             
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>ninja.standalone.NinjaJetty</mainClass>
-                        </manifest>
-                    </archive>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>ninja.standalone.NinjaJetty</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/ninja-servlet-jpa-blog-integration-test/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/ninja-servlet-jpa-blog-integration-test/src/main/java/views/layout/defaultLayout.ftl.html
@@ -10,9 +10,9 @@
     <meta name="author" content="">
 
     <!-- Le styles -->
-    <link href="/assets/webjars/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
     <!-- Optional theme -->
-    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.0.0/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="/assets/webjars/bootstrap/3.3.4/css/bootstrap-theme.min.css">
     
 
     <!-- Latest compiled and minified JavaScript -->
@@ -56,7 +56,7 @@
     </div> <!-- /container -->
     
     <script type="text/javascript" src="/assets/webjars/tinymce-jquery/3.4.9/jscripts/tiny_mce/tiny_mce.js" ></script>
-    <script src="/assets/webjars/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+    <script src="/assets/webjars/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 </body>
 </html>
 </#macro>

--- a/pom.xml
+++ b/pom.xml
@@ -174,9 +174,10 @@
                 </plugin>
 
                 <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-shade-plugin</artifactId>
+					<version>2.2</version>
+				</plugin>
             
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
             <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>bootstrap</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.4</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Hi,

Here the pull request for the issue #291 .
- Replace maven plugin "assembly" with "shade"
- Upgrade Bootstrap from 3.3.2 to 3.3.4
- Upgrade H2 driver from 1.4.182 to 1.4.186
- Fix 404 error with TinyMCE jquery plugin in "defaultLayout.ftl.html"
- Remove the unneeded TinyMCE dependency in "ninja-servlet-archetype-simple" archetype
