### PR TITLE
JPA archetype: use of deprecated org.hibernate.ejb.HibernatePersistence provider classs

### DIFF
--- a/ninja-core/src/site/markdown/documentation/working_with_relational_dbs/db_migrations.md
+++ b/ninja-core/src/site/markdown/documentation/working_with_relational_dbs/db_migrations.md
@@ -30,11 +30,11 @@ db.connection.password=
 Setting up Flyway
 =================
 
-Flyway itself manages database migration scripts in a directory called db/migrations. You should use
+Flyway itself manages database migration scripts in a directory called <code>src/main/java/db/migrations</code>. You should use
 the following naming convention: <code>V1\_\_.sql</code> is your first script, <code>V2\_\_.sql</code>
 is your second script and so on.
 
-V1__.sql may look like:
+<code>V1__.sql</code> may look like:
 
 <pre class="prettyprint">
 -- Just a simple table

--- a/ninja-core/src/site/markdown/documentation/working_with_relational_dbs/jpa.md
+++ b/ninja-core/src/site/markdown/documentation/working_with_relational_dbs/jpa.md
@@ -17,7 +17,7 @@ mvn archetype:generate -DarchetypeGroupId=org.ninjaframework -DarchetypeArtifact
 and hit
 
 <pre class="prettyprint">
-ninja:run
+mvn ninja:run
 </pre>
 
 

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/META-INF/persistence.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/META-INF/persistence.xml
@@ -28,9 +28,9 @@
 
     <!-- h2 is a simple database - in reality you may want to switch to postgres or so... -->
     <persistence-unit name="h2" transaction-type="RESOURCE_LOCAL">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="javax.persistence.provider" value="org.hibernate.ejb.HibernatePersistence" />
+            <property name="javax.persistence.provider" value="org.hibernate.jpa.HibernatePersistenceProvider" />
             <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
             <!-- you may want to enable the ddl if you do not use migrations. -->

--- a/ninja-servlet-jpa-blog-integration-test/src/main/java/META-INF/persistence.xml
+++ b/ninja-servlet-jpa-blog-integration-test/src/main/java/META-INF/persistence.xml
@@ -25,9 +25,9 @@
 
     <!-- h2 is a simple database - in reality you may want to switch to postgres or so... -->
     <persistence-unit name="h2" transaction-type="RESOURCE_LOCAL">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="javax.persistence.provider" value="org.hibernate.ejb.HibernatePersistence" />
+            <property name="javax.persistence.provider" value="org.hibernate.jpa.HibernatePersistenceProvider" />
             <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
             <!-- you may want to enable the ddl if you do not use migrations. -->


### PR DESCRIPTION
Class org.hibernate.ejb.HibernatePersistence is now deprecated.
Hibernate itself produces this warning:

```
WARN  [org.hibernate.ejb.HibernatePersistence] - HHH015016: Encountered a deprecated javax.persistence.spi.PersistenceProvider [org.hibernate.ejb.HibernatePersistence]; use [org.hibernate.jpa.HibernatePersistenceProvider] instead.
```

New provider class is org.hibernate.jpa.HibernatePersistenceProvider
