### PR TITLE
Official support for Rocker template engine

### DIFF
--- a/ninja-rocker/pom.xml
+++ b/ninja-rocker/pom.xml
@@ -1,0 +1,99 @@
+<!-- Copyright (C) 2012-2015 the original author or authors. Licensed under 
+the Apache License, Version 2.0 (the "License"); you may not use this file 
+except in compliance with the License. You may obtain a copy of the License 
+at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
+law or agreed to in writing, software distributed under the License is distributed 
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+express or implied. See the License for the specific language governing permissions 
+and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ninja-rocker</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.ninjaframework</groupId>
+        <artifactId>ninja</artifactId>
+        <version>5.1.1-SNAPSHOT</version>
+    </parent>
+
+    <url>http://www.ninjaframework.org</url>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.fizzed</groupId>
+                <artifactId>rocker-maven-plugin</artifactId>
+                <version>${rocker.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-rocker-templates</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <javaVersion>${java.version}</javaVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-rocker-templates-for-testing</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <javaVersion>${java.version}</javaVersion>
+                            <templateDirectory>${basedir}/src/test/java</templateDirectory>
+                            <outputDirectory>${basedir}/target/generated-test-sources/rocker</outputDirectory>
+                            <addAsTestSources>true</addAsTestSources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                    <exclude>**/*.rocker.html</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+			<groupId>org.ninjaframework</groupId>
+			<artifactId>ninja-core</artifactId>
+		</dependency>
+        
+        <dependency>
+            <groupId>com.fizzed</groupId>
+            <artifactId>rocker-runtime</artifactId>
+            <version>${rocker.version}</version>
+        </dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+    </dependencies>
+</project>

--- a/ninja-rocker/src/main/java/ninja/rocker/CommonErrorTemplate.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/CommonErrorTemplate.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import ninja.utils.Message;
+
+/**
+ * Common template used across any default system views.
+ * 
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+public interface CommonErrorTemplate {
+    
+    <T> T message(Message message);
+    
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/NinjaRocker.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/NinjaRocker.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import com.fizzed.rocker.RenderingException;
+import com.google.common.base.Optional;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import ninja.AssetsController;
+import ninja.Context;
+import ninja.Result;
+import ninja.i18n.Lang;
+import org.ocpsoft.prettytime.PrettyTime;
+
+/**
+ * Provides all <code>N</code> variables and methods available to templates
+ * when running inside NinjaFramework.  Exposing a new variable or method
+ * can either be done inside this class OR you can extend this and use that
+ * as the default template for your application templates.
+ * 
+ *  @N.isProd()
+ *  @N.assetsAt("css/style.css")
+ * 
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+public class NinjaRocker {
+    
+    // hidden from templates
+    private final NinjaRockerContext ninjaRockerContext;
+    private final Context context;
+    private final Result result;
+    private final Locale locale;
+    private PrettyTime prettyTime;
+    
+    // will be visible to template during rendering process as a property
+    public String lang;
+    public Map<String,String> session;
+    public String contextPath;
+    
+    public NinjaRocker(NinjaRockerContext ninjaRockerContext, Context context, Result result) {
+        this.ninjaRockerContext = ninjaRockerContext;
+        
+         // context & result required for correct i18n method
+        this.context = context;
+        this.result = result;
+        
+        // set language from framework
+        Lang ninjaLang = ninjaRockerContext.getLangProvider().get();
+        Optional<String> language = ninjaLang.getLanguage(context, Optional.of(result));
+        if (language.isPresent()) {
+            lang = language.get();
+        }
+        
+        Optional<String> requestLang = ninjaLang.getLanguage(context, Optional.of(result));
+        this.locale = ninjaLang.getLocaleFromStringOrDefault(requestLang);
+     
+        // put all entries of the session cookie to the map.
+        // You can access the values by their key in the cookie
+        // For eg: @session.get("key")
+        // should we just set to an empty map?
+        if (!context.getSession().isEmpty()) {
+            this.session = context.getSession().getData();
+        }
+        
+        this.contextPath = context.getContextPath();
+    }
+    
+    private Class<?> typeNameToClass(String typeName) {
+        try {
+            return Class.forName(typeName);
+        } catch (ClassNotFoundException ex) {
+            throw new RenderingException("Unable to find class for type name: " + typeName);
+        }
+    }
+    
+    public String reverseRoute(String typeName, String methodName) {
+        return ninjaRockerContext.getRouter().getReverseRoute(
+            typeNameToClass(typeName),
+            methodName);
+    }
+    
+    public String reverseRoute(String typeName, String methodName, Object... params) {
+        return ninjaRockerContext.getRouter().getReverseRoute(
+            typeNameToClass(typeName),
+            methodName,
+            params);
+    }
+    
+    public String reverseRoute(Class<?> type, String methodName) {
+        return ninjaRockerContext.getRouter().getReverseRoute(
+            type,
+            methodName);
+    }
+    
+    public String reverseRoute(Class<?> type, String methodName, Object... params) {
+        return ninjaRockerContext.getRouter().getReverseRoute(
+            type,
+            methodName,
+            params);
+    }
+    
+    public String assetsAt(String file) {
+        return reverseRoute(AssetsController.class, "serveStatic", "fileName", file);
+    }
+    
+    public String webJarsAt(String file) {
+        return reverseRoute(AssetsController.class, "serveWebJars", "fileName", file);
+    }
+    
+    public String i18n(String messageKey) throws RenderingException {
+        String messageValue = ninjaRockerContext.getMessages()
+                .get(messageKey, context, Optional.of(result))
+                .or(messageKey);
+        
+        return messageValue;
+    }
+    
+    public String i18n(String messageKey, Object... params) throws RenderingException {
+        String messageValue = ninjaRockerContext.getMessages()
+                .get(messageKey, context, Optional.of(result), params)
+                .or(messageKey);
+
+        return messageValue;
+    }
+    
+    public String prettyTime(Date d) {
+        if (prettyTime == null) {
+            prettyTime = new PrettyTime(locale);
+        }
+        return prettyTime.format(d);
+    }
+    
+    // other custom stuff useful
+    
+    public boolean isProd() {
+        return this.ninjaRockerContext.getNinjaProperties().isProd();
+    }
+    
+    public boolean isTest() {
+        return this.ninjaRockerContext.getNinjaProperties().isTest();
+    }
+    
+    public boolean isDev() {
+        return this.ninjaRockerContext.getNinjaProperties().isDev();
+    }
+    
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerContext.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerContext.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import com.google.inject.Provider;
+import ninja.Router;
+import ninja.i18n.Lang;
+import ninja.i18n.Messages;
+import ninja.utils.NinjaProperties;
+import org.ocpsoft.prettytime.PrettyTime;
+
+/**
+ *
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+
+public interface NinjaRockerContext {
+    
+    Router getRouter();
+    Messages getMessages();
+    Provider<Lang> getLangProvider();
+    NinjaProperties getNinjaProperties();
+    PrettyTime getPrettyTime();
+    
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerContextImpl.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerContextImpl.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import javax.inject.Singleton;
+import ninja.Router;
+import ninja.i18n.Lang;
+import ninja.i18n.Messages;
+import ninja.utils.NinjaProperties;
+import org.ocpsoft.prettytime.PrettyTime;
+
+/**
+ *
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+
+@Singleton
+public class NinjaRockerContextImpl implements NinjaRockerContext {
+    
+    private final Router router;
+    private final Messages messages;
+    private final Provider<Lang> langProvider;
+    private final NinjaProperties ninjaProperties;
+    private final PrettyTime prettyTime;
+    
+    @Inject
+    public NinjaRockerContextImpl(Router router,
+                                    Messages messages,
+                                    Provider<Lang> langProvider,
+                                    NinjaProperties ninjaProperties,
+                                    PrettyTime prettyTime) {
+        this.router = router;
+        this.messages = messages;
+        this.langProvider = langProvider;
+        this.ninjaProperties = ninjaProperties;
+        this.prettyTime = prettyTime;
+    }
+
+    @Override
+    public Router getRouter() {
+        return this.router;
+    }
+
+    @Override
+    public Messages getMessages() {
+        return this.messages;
+    }
+
+    @Override
+    public Provider<Lang> getLangProvider() {
+        return this.langProvider;
+    }
+
+    @Override
+    public NinjaProperties getNinjaProperties() {
+        return ninjaProperties;
+    }
+
+    @Override
+    public PrettyTime getPrettyTime() {
+        return prettyTime;
+    }
+    
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerModule.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerModule.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import com.google.inject.AbstractModule;
+import ninja.template.TemplateEngine;
+
+/**
+ * 
+ * Bindings for Rocker template engine
+ * 
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+public class NinjaRockerModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(NinjaRockerContext.class).to(NinjaRockerContextImpl.class);
+        bind(TemplateEngine.class).to(TemplateEngineRocker.class);
+    }
+    
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerTemplate.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/NinjaRockerTemplate.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import com.fizzed.rocker.RenderingException;
+import com.fizzed.rocker.RockerOutput;
+import com.fizzed.rocker.runtime.ArrayOfByteArraysOutput;
+import com.fizzed.rocker.runtime.DefaultRockerTemplate;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import ninja.Context;
+import ninja.Result;
+import ninja.exceptions.InternalServerErrorException;
+import ninja.utils.ResponseStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * New base class for all Rocker templates targeted for the Ninja Framework.
+ * Permits templates to be directly used as a <code>Renderable</code> in a
+ * Result. Also adds all <i>implicit</i> variables that Ninja's default
+ * FreeMarker template system includes.
+ * 
+ * @author joelauer
+ * @param <T>
+ * 
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+public abstract class NinjaRockerTemplate<T extends NinjaRockerTemplate> extends DefaultRockerTemplate<T> {
+    static private final Logger log = LoggerFactory.getLogger(NinjaRockerTemplate.class);
+    
+    protected NinjaRocker N;
+    
+    /**
+     * Configure this template from another template.  Most important is that
+     * the "implicit" variables from the other template are copied into this
+     * template.
+     * @param <T>
+     * @param other
+     * @throws RenderingException 
+     */
+    @Override
+    protected <T> void __configure(T other) throws RenderingException {
+        super.__configure(other);
+        if (other instanceof NinjaRockerTemplate) {
+            NinjaRockerTemplate otherTemplate = (NinjaRockerTemplate)other;
+            // share the ninja+rocker context
+            this.N = otherTemplate.N;
+        } else {
+            throw new RenderingException("Unable to configure template (not an instance of " + this.getClass().getName() + ")");
+        }
+    }
+    
+    @Override
+    protected RockerOutput __newOutput() {
+        // output optimized for array of byte arrays...
+        return new ArrayOfByteArraysOutput(__internal.getCharset());
+    }
+    
+    /**
+     * Implements <code>Renderable</code> for Ninja result so that this template
+     * can be directly used in a Result. Not intended to be called by application
+     * directly.
+     * 
+     * @param ninjaRockerContext  The ninja+rocker context
+     * @param context The context of the request
+     * @param result The result we are rendering for
+     */
+    public void ninjaRender(NinjaRockerContext ninjaRockerContext, Context context, Result result) {
+        
+        this.N = new NinjaRocker(ninjaRockerContext, context, result);
+   
+        // set content type if not set
+        if (result.getContentType() == null) {
+            switch (this.__internal.getContentType()) {
+                case HTML:
+                    result.html();
+                    break;
+                case RAW:
+                    result.contentType(Result.APPLICATION_OCTET_STREAM);
+                    break;
+            }
+        }
+        
+        // looks like jetty gives us a single shot to write out the bytes
+        // to the underlying output stream -- chunked results could be more
+        // interesting to look at down the road
+        RockerOutput out = null;
+        
+        try {
+            // try to render output
+            out = this.render();
+        } catch (RenderingException e) {
+            throwRenderingException(context, result, e);
+        }
+        
+        ArrayOfByteArraysOutput abao = (ArrayOfByteArraysOutput)out;
+        
+        // rendering was successful, finalize headers, and write it to output
+        ResponseStreams responseStreams = context.finalizeHeaders(result);
+        
+        try (OutputStream os = responseStreams.getOutputStream()) {
+            os.write(abao.toByteArray());
+            os.flush();
+            os.close();
+        } catch (IOException e) {
+            throw new InternalServerErrorException(e);
+        }
+    }
+    
+    public void throwRenderingException(
+            Context context,
+            Result result,
+            RenderingException cause) {
+        
+        // likely project source code
+        String sourcePath = null;
+        if (this.__internal.getTemplatePackageName() != null
+                && this.__internal.getTemplateName() != null) {
+            sourcePath = this.__internal.getTemplatePackageName().replace(".", File.separator)
+                    + File.separator
+                    + this.__internal.getTemplateName();
+        }
+        
+        throw new ninja.exceptions.RenderingException(
+                cause.getMessage(),
+                cause,
+                result,
+                "Rocker rendering exception",
+                sourcePath,
+                cause.getSourceLine());
+    }
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/TemplateEngineRocker.java
+++ b/ninja-rocker/src/main/java/ninja/rocker/TemplateEngineRocker.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.rocker;
+
+import ninja.rocker.views.common_error;
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.utils.NinjaProperties;
+
+import org.slf4j.Logger;
+
+import com.google.inject.Inject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.HashMap;
+import ninja.template.TemplateEngine;
+import ninja.template.TemplateEngineHelper;
+import ninja.utils.Message;
+import ninja.utils.NinjaConstant;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Template engine for Rocker templates.  See https://github.com/fizzed/rocker
+ * 
+ * @author Fizzed, Inc (http://fizzed.com)
+ * @author joelauer (http://twitter.com/jjlauer)
+ */
+@Singleton
+public class TemplateEngineRocker implements TemplateEngine {
+    static private final Logger log = LoggerFactory.getLogger(TemplateEngineRocker.class);
+    
+    private final String FILE_SUFFIX = ".rocker.html";
+    private final String CONTENT_TYPE = "text/html";
+
+    private final NinjaRockerContext ninjaRockerContext;
+    private final String fileSuffix;
+    private final String contentType;
+    private final Map<String, Class<? extends NinjaRockerTemplate>> commonErrorTemplates;
+    
+    @Inject
+    public TemplateEngineRocker(NinjaRockerContext ninjaRockerContext,
+                                TemplateEngineHelper templateEngineHelper,
+                                NinjaProperties ninjaProperties) throws Exception {
+        this.ninjaRockerContext = ninjaRockerContext;
+        this.fileSuffix = FILE_SUFFIX;
+        this.contentType = CONTENT_TYPE;
+        
+        // setup default error templates
+        this.commonErrorTemplates = new HashMap<>();
+        this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR, common_error.class);
+        this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST, common_error.class);
+        this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN, common_error.class);
+        this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_NOT_FOUND, common_error.class);
+        this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED, common_error.class);
+ 
+        loadCustomErrorTemplates();
+    }
+    
+    public final void loadCustomErrorTemplates() {
+        Class<NinjaRockerTemplate> internalServerErrorClass = getCustomErrorViewClass("views.system.internal_server_error");
+        if (internalServerErrorClass != null) {
+            this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR, internalServerErrorClass);
+        }
+        
+        Class<NinjaRockerTemplate> badRequestClass = getCustomErrorViewClass("views.system.bad_request");
+        if (badRequestClass != null) {
+            this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST, badRequestClass);
+        }
+        
+        Class<NinjaRockerTemplate> forbiddenClass = getCustomErrorViewClass("views.system.forbidden");
+        if (forbiddenClass != null) {
+            this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN, forbiddenClass);
+        }
+        
+        Class<NinjaRockerTemplate> notFoundClass = getCustomErrorViewClass("views.system.not_found");
+        if (notFoundClass != null) {
+            this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_NOT_FOUND, notFoundClass);
+        }
+        
+        Class<NinjaRockerTemplate> unauthorizedClass = getCustomErrorViewClass("views.system.unauthorized");
+        if (unauthorizedClass != null) {
+            this.commonErrorTemplates.put(NinjaConstant.LOCATION_VIEW_FTL_HTML_UNAUTHORIZED, unauthorizedClass);
+        }
+    }
+    
+    public Class<NinjaRockerTemplate> getCustomErrorViewClass(String className) {
+        try {
+            return (Class<NinjaRockerTemplate>)Class.forName(className);
+        } catch (Throwable t) {
+            // do nothing
+            return null;
+        }
+    }
+    
+    @Override
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public String getSuffixOfTemplatingEngine() {
+        return this.fileSuffix;
+    }
+
+    @Override
+    public void invoke(Context context, Result result) {
+        
+        Object object = result.getRenderable();
+        
+        // various types of objects renderable may store
+        Map<String,Object> valueMap = null;
+        Message valueMessage = null;
+        NinjaRockerTemplate rockerTemplate = null;
+        
+        // if the object is null we simply render an empty map...
+        if (object == null) {            
+            valueMap = Collections.EMPTY_MAP;
+        }
+        else if (object instanceof NinjaRockerTemplate) {            
+            rockerTemplate = (NinjaRockerTemplate)object;   
+        }
+        else if (object instanceof Map) {            
+            valueMap = (Map<String,Object>)object;    
+        }
+        else if (object instanceof Message) {
+            valueMessage = (Message)object;
+        }
+        else {
+            log.error("Unable to handle renderable not of type: " + object.getClass());
+            return;
+        } 
+
+        //
+        // until NinjaFramework makes these template names configurable -- these
+        // need to be handled by creating instances of correct Rocker template
+        //
+        if (rockerTemplate == null) {
+            String templateName = result.getTemplate();
+            if (templateName != null && commonErrorTemplates.containsKey(templateName)) {
+                Class<? extends NinjaRockerTemplate> commonErrorType = commonErrorTemplates.get(templateName);
+
+                NinjaRockerTemplate rockerErrorTemplate = null;
+
+                try {
+                    rockerErrorTemplate = commonErrorType.newInstance();
+                } catch (InstantiationException | IllegalAccessException e) {
+                    throw renderingOrRuntimeException("Unable to create template class " + commonErrorType, e);
+                }
+
+                if (rockerErrorTemplate instanceof CommonErrorTemplate) {
+
+                    ((CommonErrorTemplate)rockerErrorTemplate).message(valueMessage);
+
+                }
+
+                rockerTemplate = rockerErrorTemplate;
+            }
+        }
+        
+        if (rockerTemplate != null) {
+            // inject context for ninja into template, then delegate rendering to itself
+            rockerTemplate.ninjaRender(ninjaRockerContext, context, result);
+        }
+        else {
+            throw new RuntimeException("Something really fishy. No idea how to handle this request");
+        }
+    }
+    
+    
+    static public RuntimeException renderingOrRuntimeException(String message, Exception cause) throws RuntimeException {
+        
+        return renderingOrRuntimeException(message, cause, null, null, null, -1);
+        
+    }
+    
+    // this lets us support old versions of Ninja that do not have the new
+    // RenderingException support
+    static public RuntimeException renderingOrRuntimeException(String message,
+                                                        Exception cause,
+                                                        Result result,
+                                                        String title,
+                                                        String sourcePath,
+                                                        int lineOfError) {
+        try {
+            // are we running in Ninja w/ rendering exceptions?
+            Class<?> ninjaRenderingExceptionClass
+                = TemplateEngineRocker.class.getClassLoader().loadClass("ninja.exceptions.RenderingException");
+            
+            Constructor<?> constructor = ninjaRenderingExceptionClass.getDeclaredConstructor(
+                    String.class, Throwable.class, Result.class, String.class, String.class, int.class);
+            
+            return (RuntimeException)constructor.newInstance(cause.getMessage(),
+                                                                cause,
+                                                                result,
+                                                                "Rocker rendering exception",
+                                                                sourcePath,
+                                                                lineOfError);
+        }
+        catch (ClassNotFoundException | NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            log.warn("Unable to throw new ninja.exceptions.RenderingException, falling back to old RuntimeException", e);
+            
+            // throw normal runtime exception, but build useful message
+            String errMessage = new StringBuilder()
+                .append(title)
+                .append(": ")
+                .append(message)
+                .append(" from ")
+                .append(sourcePath)
+                .append(" @line ")
+                .append(lineOfError)
+                .toString();
+            
+            return new RuntimeException(errMessage, cause);
+        }
+    }
+}

--- a/ninja-rocker/src/main/java/ninja/rocker/views/common_error.rocker.html
+++ b/ninja-rocker/src/main/java/ninja/rocker/views/common_error.rocker.html
@@ -1,0 +1,64 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+@option implementsInterface=ninja.rocker.CommonErrorTemplate
+
+@args (Message message)
+<html>
+    <head>
+        <title>@message.text</title>
+        <style type="text/css">
+            .error-code {
+                font-family: "Times New Roman", Times, serif;
+                margin-top: 5%;
+                width: 50%;
+                border: 15px solid black;
+                padding: 50px;
+            }
+            .centered {
+                margin-left: auto;
+                margin-right: auto;
+            }
+            .error-code__smiley {
+                font-family: "Times New Roman", Times, serif;
+                text-align:center; 
+                font-size: 120pt;
+                margin-bottom: 60px;
+            }
+            .error-code__text {
+                font-family: "Times New Roman", Times, serif;
+                text-align:center; 
+                font-size: 18pt;
+                padding-bottom: 10px;
+            }
+            .error-code__link {
+                font-family: "Times New Roman", Times, serif;
+                color: black;
+                text-decoration: none;
+                text-decoration: underline;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="error-code centered">
+            <div class="error-code__smiley">:(</div>
+            <div class="error-code__text">@message.text</div>
+            <div class="error-code__text"><a class="error-code__link" href="@N.contextPath/">Back to homepage</a></div>
+        </div>
+    </body>
+</html>

--- a/ninja-rocker/src/test/java/ninja/rocker/TemplateEngineRockerTest.java
+++ b/ninja-rocker/src/test/java/ninja/rocker/TemplateEngineRockerTest.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (C) 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ninja.rocker;
+
+import static ninja.template.TemplateEngineFreemarker.FREEMARKER_CONFIGURATION_FILE_SUFFIX;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.Results;
+import ninja.Route;
+import ninja.exceptions.RenderingException;
+import ninja.i18n.Lang;
+import ninja.i18n.Messages;
+import ninja.session.FlashScope;
+import ninja.session.Session;
+import ninja.utils.NinjaProperties;
+import ninja.utils.ResponseStreams;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+import com.google.inject.Provider;
+
+import freemarker.template.Configuration;
+import java.io.ByteArrayOutputStream;
+import ninja.AssetsController;
+import ninja.Router;
+import ninja.template.TemplateEngineHelper;
+import ninja.template.TemplateEngineManager;
+import org.junit.Assert;
+import static org.junit.Assert.fail;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TemplateEngineRockerTest {
+
+    @Mock
+    Lang lang;
+
+    @Mock
+    Logger logger;
+
+    @Mock
+    TemplateEngineHelper templateEngineHelper;
+
+    @Mock
+    TemplateEngineManager templateEngineManager;
+
+    @Mock
+    NinjaProperties ninjaProperties;
+
+    @Mock
+    Messages messages;
+
+    @Mock
+    Context context;
+    
+    @Mock
+    Router router;
+    
+    @Mock
+    Route route;
+
+    NinjaRockerContext ninjaRockerContext;
+    
+    TemplateEngineRocker templateEngineRocker;
+
+    ByteArrayOutputStream baos;
+
+    @Before
+    public void before() throws Exception {
+        //Setup that allows to to execute invoke(...) in a very minimal version.
+        //when(ninjaProperties.getWithDefault(FREEMARKER_CONFIGURATION_FILE_SUFFIX, ".ftl.html")).thenReturn(".ftl.html");
+       
+        Provider<Lang> langProvider = new Provider<Lang>() {
+            @Override
+            public Lang get() {
+                return lang;
+            }
+        };
+        
+        ninjaRockerContext
+            = new NinjaRockerContextImpl(
+                router,
+                messages,
+                langProvider,
+                ninjaProperties,
+                null);
+        
+        templateEngineRocker
+            = new TemplateEngineRocker(
+                ninjaRockerContext,
+                templateEngineHelper,
+                ninjaProperties);
+
+        
+        when(lang.getLanguage(any(Context.class), any(Optional.class))).thenReturn(Optional.<String>absent());
+
+        Session session = Mockito.mock(Session.class);
+        when(session.isEmpty()).thenReturn(true);
+        when(context.getSession()).thenReturn(session);
+        when(context.getRoute()).thenReturn(route);
+        when(lang.getLocaleFromStringOrDefault(any(Optional.class))).thenReturn(Locale.ENGLISH);
+
+        FlashScope flashScope = Mockito.mock(FlashScope.class);
+        Map<String, String> flashScopeData = new HashMap<>();
+        when(flashScope.getCurrentFlashCookieData()).thenReturn(flashScopeData);
+        when(context.getFlashScope()).thenReturn(flashScope);
+
+        when(templateEngineHelper.getTemplateForResult(any(Route.class), any(Result.class), Mockito.anyString())).thenReturn("views/template.ftl.html");
+
+        baos = new ByteArrayOutputStream();
+        ResponseStreams responseStreams = mock(ResponseStreams.class);
+        when(context.finalizeHeaders(any(Result.class))).thenReturn(responseStreams);
+        when(responseStreams.getOutputStream()).thenReturn(baos);
+    }
+
+    @Test
+    public void engineHasSingletonAnnotation() {
+        Singleton singleton = TemplateEngineRocker.class.getAnnotation(Singleton.class);
+        assertThat(singleton, notNullValue());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void engineWithNoRenderableThrowsRuntimeException() throws RuntimeException {
+        templateEngineRocker.invoke(context, Results.ok());
+    }
+    
+    @Test
+    public void simpleView() throws Exception {
+        Result r = Results.ok().render(
+            ninja.rocker.views.Simple.template()
+        );
+        
+        templateEngineRocker.invoke(context, r);
+        
+        assertThat(baos.toString("UTF-8"), equalTo("Hello!"));
+    }
+    
+    @Test
+    public void isProdView() throws Exception {
+        when(ninjaProperties.isProd()).thenReturn(true);
+        
+        Result r = Results.ok().render(
+            ninja.rocker.views.IsProd.template()
+        );
+        
+        templateEngineRocker.invoke(context, r);
+        
+        assertThat(baos.toString("UTF-8"), equalTo("PROD"));
+    }
+    
+    @Test
+    public void reverseRouteView() throws Exception {
+        when(router.getReverseRoute(TemplateEngineRockerTest.class, "index")).thenReturn("/this/is/a/test/reverse/route");
+        
+        Result r = Results.ok().render(
+            ninja.rocker.views.ReverseRoute.template()
+        );
+        
+        templateEngineRocker.invoke(context, r);
+        
+        assertThat(baos.toString("UTF-8"), equalTo("/this/is/a/test/reverse/route"));
+    }
+    
+    @Test
+    public void assetsAtView() throws Exception {
+        // assetsAt uses the reverseRoute for AssetsController to do the lookup...
+        when(router.getReverseRoute(AssetsController.class, "serveStatic", "fileName", "test.png")).thenReturn("/assets/test/test.png");
+        
+        Result r = Results.ok().render(
+            ninja.rocker.views.AssetsAt.template()
+        );
+        
+        templateEngineRocker.invoke(context, r);
+        
+        assertThat(baos.toString("UTF-8"), equalTo("/assets/test/test.png"));
+    }
+    
+    @Test
+    public void contextPathView() throws Exception {
+        when(context.getContextPath()).thenReturn("/mycontext");
+        
+        Result r = Results.ok().render(
+            ninja.rocker.views.ContextPath.template()
+        );
+        
+        templateEngineRocker.invoke(context, r);
+        
+        assertThat(baos.toString("UTF-8"), equalTo("/mycontext"));
+    }
+    
+}

--- a/ninja-rocker/src/test/java/ninja/rocker/views/AssetsAt.rocker.html
+++ b/ninja-rocker/src/test/java/ninja/rocker/views/AssetsAt.rocker.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+
+@args ()
+@N.assetsAt("test.png")

--- a/ninja-rocker/src/test/java/ninja/rocker/views/ContextPath.rocker.html
+++ b/ninja-rocker/src/test/java/ninja/rocker/views/ContextPath.rocker.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+
+@args ()
+@N.contextPath

--- a/ninja-rocker/src/test/java/ninja/rocker/views/IsProd.rocker.html
+++ b/ninja-rocker/src/test/java/ninja/rocker/views/IsProd.rocker.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+
+@args ()
+@if (N.isProd()) {PROD} else {NOT PROD}

--- a/ninja-rocker/src/test/java/ninja/rocker/views/ReverseRoute.rocker.html
+++ b/ninja-rocker/src/test/java/ninja/rocker/views/ReverseRoute.rocker.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+
+@args ()
+@N.reverseRoute(ninja.rocker.TemplateEngineRockerTest.class, "index")

--- a/ninja-rocker/src/test/java/ninja/rocker/views/Simple.rocker.html
+++ b/ninja-rocker/src/test/java/ninja/rocker/views/Simple.rocker.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright (C) 2015 Fizzed, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+@import ninja.utils.Message;
+
+@option extendsClass=ninja.rocker.NinjaRockerTemplate
+
+@args ()
+Hello!

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>ninja-core</module>
+        <module>ninja-rocker</module>
         <module>ninja-metrics</module>
         <module>ninja-metrics-graphite</module>
         <module>ninja-metrics-ganglia</module>
@@ -56,6 +57,7 @@
 
     <!-- pin encoding to utf-8 -->
     <properties>
+        <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <siteProjectVersion>${project.version}</siteProjectVersion>
@@ -64,6 +66,7 @@
         <jackson.version>2.5.1</jackson.version>
         <guice.version>4.0-beta5</guice.version>
         <metrics.version>3.1.1</metrics.version>
+        <rocker.version>0.9.0</rocker.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
@@ -97,10 +100,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.2</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <!--


### PR DESCRIPTION
This PR adds Rocker templates (https://github.com/fizzed/rocker) as an officially supported, alternative template engine for Ninja.  By including as a new module, maintainers can make sure it will work long term with future Ninja versions.

I thought I'd clarify a few things:
1. I debated "ninja-rocker" vs. "ninja-template-rocker" as the module name.  Unless we really plan on moving FreeMarker, Json, JsonP to their own modules, I decided to go with "ninja-rocker" for now.
2. This integration does not support Flash messages yet
3. We still need lots of doc updates & probably a 3rd archetype showing how to use Rocker templates.

If this looks good though, it'd be good to get it merged and then I am happy to work on item 3 in future PRs.
