### PR TITLE
Postoffice should not throw generic exception

### DIFF
--- a/ninja-core/src/main/java/ninja/postoffice/Postoffice.java
+++ b/ninja-core/src/main/java/ninja/postoffice/Postoffice.java
@@ -16,6 +16,10 @@
 
 package ninja.postoffice;
 
+import javax.mail.internet.AddressException;
+
+import org.apache.commons.mail.EmailException;
+
 /**
  * Simply takes a Mail and sends it.
  * 
@@ -26,7 +30,5 @@ package ninja.postoffice;
  * 
  */
 public interface Postoffice {
-
-    void send(Mail mail) throws Exception;
-
+    void send(Mail mail) throws EmailException, AddressException;
 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2015-04-07 Changed generic exception in postoffice to specific ones (2) (svenkubiak)
  * 2015-03-31 Improved SuperDevMode (jjlauer)
  * 2015-03-29 Tiny fix for a test that did not work with summertime (ra)
  * 2015-03-27 Upgrade of external libraries to latest versions (ra)


### PR DESCRIPTION
This is a follow-up to PR #290, originally fixed in PR #298, but I can't remember why i closed #298. Anyway, here is the fix.
