### PR TITLE
Updated HTTP-Method Annotation resolving

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2015-04-16 Fixed Bug with HTTP-Method Resolving in JaxyRoutes (lukaseichler)
  * 2015-03-31 Improved SuperDevMode (jjlauer)
  * 2015-03-29 Tiny fix for a test that did not work with summertime (ra)
  * 2015-03-27 Upgrade of external libraries to latest versions (ra)

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -16,6 +16,20 @@
 
 package ninja.jaxy;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -33,20 +47,6 @@ import ninja.application.ApplicationRoutes;
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaMode;
 import ninja.utils.NinjaProperties;
-
-import org.reflections.Reflections;
-import org.reflections.scanners.MethodAnnotationsScanner;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 
 /**
  * Implementation of a JAX-RS style route builder.
@@ -207,7 +207,10 @@ public class JaxyRoutes implements ApplicationRoutes {
         Set<Method> methods = Sets.newLinkedHashSet();
 
         methods.addAll(reflections.getMethodsAnnotatedWith(Path.class));
-        Reflections annotationReflections = new Reflections("", new TypeAnnotationsScanner(), new SubTypesScanner());
+	    Reflections annotationReflections = new Reflections(new ConfigurationBuilder()
+			    .addUrls(ClasspathHelper.forClassLoader())
+			    .setScanners(new TypeAnnotationsScanner(),
+					    new SubTypesScanner()));
         for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
             if (httpMethod.isAnnotation()) {
                 methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));


### PR DESCRIPTION
When using JaxyRoutes as a dependency the HttpMethod-Annotations(GET,POST, etc.) were not discovered and no routes were created for methods using only these annotations. 

This PR widens the search for HttpMethod-Annotation and now the whole classpath is scanned once. 
