### PR TITLE
Add NinjaException.getHttpStatus()

### DIFF
--- a/ninja-core/src/main/java/ninja/exceptions/NinjaException.java
+++ b/ninja-core/src/main/java/ninja/exceptions/NinjaException.java
@@ -40,5 +40,9 @@ public class NinjaException extends RuntimeException {
         super(httpMessage, cause);
         this.httpStatus = httpStatus;
     }
+    
+    public int getHttpStatus() {
+        return this.httpStatus;
+    }
 
 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version 5.1.2
+=============
+
+ * 2015-05-08 Added NinjaException.getHttpStatus() (icoloma)
+ 
 Version 5.1.1
 =============
 


### PR DESCRIPTION
Without a getter method there is no way to retrieve the status code associated to an exception, which seems like a valid concern if anybody wants to make their own subclasses of `NinjaException` (like `InsufficientPermissionsException` or whatever) and customize the JSON error messages returned.
