### PR TITLE
Enforce unix separator for loading webjars

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -111,7 +111,7 @@
         </dependency>
         
         <!-- Afterburner lib optimizes Jackson and improves
-             performance -->
+        performance -->
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
@@ -251,6 +251,16 @@
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>  
 
     </dependencies>
 

--- a/ninja-core/src/main/java/ninja/AssetsController.java
+++ b/ninja-core/src/main/java/ninja/AssetsController.java
@@ -28,7 +28,6 @@ import java.net.URLConnection;
 
 import ninja.utils.HttpCacheToolkit;
 import ninja.utils.MimeTypes;
-import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
 import ninja.utils.ResponseStreams;
 
@@ -36,7 +35,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;

--- a/ninja-core/src/main/java/ninja/AssetsController.java
+++ b/ninja-core/src/main/java/ninja/AssetsController.java
@@ -216,7 +216,7 @@ public class AssetsController {
      */
     private URL getStaticFileFromMetaInfResourcesDir(String fileName) {
         String finalNameWithoutLeadingSlash 
-                = normalizePathWithoutLeadingSlash(fileName);
+                = normalizePathWithoutLeadingSlash(fileName, true);
 
         URL url = null;
         
@@ -241,7 +241,13 @@ public class AssetsController {
      */
     @VisibleForTesting
     protected String normalizePathWithoutLeadingSlash(String fileName) {
-        String fileNameNormalized = FilenameUtils.normalize(fileName);
+        return normalizePathWithoutLeadingSlash(fileName, false);
+    }
+
+    private String normalizePathWithoutLeadingSlash(String fileName, boolean enforceUnixSeparator) {
+        String fileNameNormalized = enforceUnixSeparator
+                ? FilenameUtils.normalize(fileName, true)
+                : FilenameUtils.normalize(fileName);
         return StringUtils.removeStart(fileNameNormalized, "/");
     }
 

--- a/ninja-core/src/main/java/ninja/AssetsController.java
+++ b/ninja-core/src/main/java/ninja/AssetsController.java
@@ -224,7 +224,21 @@ public class AssetsController {
 
         return url;
     }
-    
+
+    /**
+     * This function mirrors legacy behavior of the AssetsController
+     *
+     * @param fileName A potential "fileName"
+     * @see #normalizePathWithoutLeadingSlash(java.lang.String, boolean)
+     * @deprecated This method was replaced and should not be used.
+     * @return A normalized fileName.
+     */
+    @VisibleForTesting
+    @Deprecated
+    protected String normalizePathWithoutLeadingSlash(String fileName) {
+        return normalizePathWithoutLeadingSlash(fileName, false);
+    }
+
     /**
      * If we get - for whatever reason - a relative URL like 
      * assets/../conf/application.conf we expand that to the "real" path.
@@ -237,14 +251,11 @@ public class AssetsController {
      * possible.
      * 
      * @param fileName A potential "fileName"
+     * @param enforceUnixSeparator Forces to normalise unix style
      * @return A normalized fileName.
      */
     @VisibleForTesting
-    protected String normalizePathWithoutLeadingSlash(String fileName) {
-        return normalizePathWithoutLeadingSlash(fileName, false);
-    }
-
-    private String normalizePathWithoutLeadingSlash(String fileName, boolean enforceUnixSeparator) {
+    protected String normalizePathWithoutLeadingSlash(String fileName, boolean enforceUnixSeparator) {
         String fileNameNormalized = enforceUnixSeparator
                 ? FilenameUtils.normalize(fileName, true)
                 : FilenameUtils.normalize(fileName);

--- a/ninja-core/src/test/java/ninja/AssetsControllerTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerTest.java
@@ -31,7 +31,6 @@ import ninja.utils.MimeTypes;
 import ninja.utils.NinjaProperties;
 import ninja.utils.ResponseStreams;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.SystemUtils;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -267,7 +266,7 @@ public class AssetsControllerTest {
         assertEquals(null, assetsController.normalizePathWithoutLeadingSlash(null, true));
         assertEquals("", assetsController.normalizePathWithoutLeadingSlash("", true));
         
-        // enforcing test for unix separator
+        // enforcing test for unix separator | Windows specific
         mockStatic(FilenameUtils.class, Mockito.CALLS_REAL_METHODS);
         
         when(FilenameUtils.normalize(anyString())).then(new Answer<String>() {
@@ -275,12 +274,12 @@ public class AssetsControllerTest {
             public String answer(InvocationOnMock invocation) throws Throwable {
                 Object[] args = invocation.getArguments(); 
                 String file = (String) args[0];
-                return FilenameUtils.normalize(file, false);
+                return FilenameUtils.normalize(file, false); // Choose Windows here, despite we may test on unix
             }
         });
         
-        assertEquals("\\dir1\\test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test", !SystemUtils.IS_OS_WINDOWS));
-        assertNotEquals("\\dir1\\test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test", SystemUtils.IS_OS_WINDOWS));
+        assertEquals("\\dir1\\test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test", false));
+        assertNotEquals("\\dir1\\test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test", true));
         verifyStatic();
     }
 }

--- a/ninja-core/src/test/java/ninja/AssetsControllerTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerTest.java
@@ -249,13 +249,13 @@ public class AssetsControllerTest {
     }
 
     @Test
-    public void testNormalizePathWithoutTrailingSlash() {
-        assertEquals("dir1/test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test"));
-        assertEquals("dir1/test.test", assetsController.normalizePathWithoutLeadingSlash("dir1/test.test"));
-        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash("/../test.test"));
-        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash("../test.test"));
-        assertEquals("dir2/file.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/../dir2/file.test"));
-        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash(null));
-        assertEquals("", assetsController.normalizePathWithoutLeadingSlash(""));
+    public void testNormalizePathWithoutLeadingSlash() {
+        assertEquals("dir1/test.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/test.test", true));
+        assertEquals("dir1/test.test", assetsController.normalizePathWithoutLeadingSlash("dir1/test.test", true));
+        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash("/../test.test", true));
+        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash("../test.test", true));
+        assertEquals("dir2/file.test", assetsController.normalizePathWithoutLeadingSlash("/dir1/../dir2/file.test", true));
+        assertEquals(null, assetsController.normalizePathWithoutLeadingSlash(null, true));
+        assertEquals("", assetsController.normalizePathWithoutLeadingSlash("", true));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <jackson.version>2.5.1</jackson.version>
         <guice.version>4.0</guice.version>
         <metrics.version>3.1.1</metrics.version>
+        <powermock.version>1.5.6</powermock.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
@@ -89,7 +90,7 @@
                         <!-- bump submodule versions automatically -->
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <!-- install next final version in local repo, so that
-                             tests on archetypes work -->
+                        tests on archetypes work -->
                         <preparationGoals>clean install</preparationGoals>
                     </configuration>
                 </plugin>
@@ -174,10 +175,10 @@
                 </plugin>
 
                 <plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-shade-plugin</artifactId>
-					<version>2.2</version>
-				</plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
             
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
@@ -222,8 +223,8 @@
         <url>https://github.com/ninjaframework/ninja</url>
         <connection>scm:git://github.com/ninjaframework/ninja.git</connection>
         <developerConnection>scm:git:git@github.com:ninjaframework/ninja.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <issueManagement>
         <system>GitHub</system>
@@ -383,7 +384,7 @@
             </dependency>
             
             <!-- Afterburner lib optimizes Jackson and improves
-                 performance -->
+            performance -->
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-afterburner</artifactId>
@@ -617,7 +618,7 @@
         
             <!-- Testing -->
             <!-- devbliss doctester should be removed at some point 
-             - superseeded by docterster.org -->
+            - superseeded by docterster.org -->
             <dependency>
                 <groupId>com.devbliss.doctest</groupId>
                 <artifactId>doctest</artifactId>
@@ -653,7 +654,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
             
@@ -683,13 +684,27 @@
                 <version>1.7</version>
             </dependency>
             
-                    <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
-            <scope>provided</scope>
-        </dependency>
-
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>3.4</version>
+                <scope>provided</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+   
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>  
+   
         </dependencies>
         
         


### PR DESCRIPTION
 Fixes loading of webjar assets using windows (introduced with commit 259a4e524d845aa7e1dc3ec9333d5d7c61b25eb1 ). The given filename will turn /foo/bar to foo\bar. Turning the path into "META-INF/resources/webjars/foo\bar", which will not work.

This commit aims to remain compatible with any tests or subclasses, that could possibly exist. Works like a charm for debian and windows 7 alike (as far as i can tell with my tests). 
