### PR TITLE
Add support for Jackson JSON Views (@JsonView)

### DIFF
--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -103,6 +103,8 @@ public class Result {
 
     private int statusCode;
 
+    private Class<?> jsonView;
+
     /* The object that will be rendered. Could be a Java Pojo. Or a map. Or xyz. Will be
      * handled by the TemplateReneringEngine. */
     private Object renderable;
@@ -621,6 +623,22 @@ public class Result {
      */
     public Result template(String template) {
         this.template = template;
+        return this;
+    }
+
+    public Class<?> getJsonView() {
+        return jsonView;
+    }
+
+    /**
+     * Set the Jackson JSON View.
+     * See <a href="http://wiki.fasterxml.com/JacksonJsonViews">http://wiki.fasterxml.com/JacksonJsonViews</a>
+     *
+     * @param jsonView JSON serialization view class to use when rendering
+     * @return The result that you executed the method on for chaining, with JSON view set
+     */
+    public Result jsonView(Class<?> jsonView) {
+        this.jsonView = jsonView;
         return this;
     }
 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
@@ -50,8 +50,14 @@ public class TemplateEngineJson implements TemplateEngine {
         ResponseStreams responseStreams = context.finalizeHeaders(result);
         
         try (OutputStream outputStream  = responseStreams.getOutputStream()) {
-            
-            objectMapper.writeValue(outputStream, result.getRenderable());
+
+            Class<?> jsonView = result.getJsonView();
+            if (jsonView != null) {
+                objectMapper.writerWithView(jsonView).writeValue(outputStream, result.getRenderable());
+            } else {
+                objectMapper.writeValue(outputStream, result.getRenderable());
+            }
+
             
         } catch (IOException e) {
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,6 @@
 Version X.X.X
 =============
-
+ * 2015-07-22 Added support for Jackson's JSON Views (metacity)
  * 2015-07-21 Added properties to override system views location (momiji).
 
 Version 5.1.4

--- a/ninja-core/src/site/markdown/documentation/working_with_json_jsonp.md
+++ b/ninja-core/src/site/markdown/documentation/working_with_json_jsonp.md
@@ -152,3 +152,39 @@ it is actually used, but it is not threadsafe to modify ObjectMapper
 after is has been used to parse or generate Json.
 
 More on Jackson modules: http://wiki.fasterxml.com/JacksonFeatureModules
+
+
+### Jackson JSON Views
+
+Ninja also supports Jackson's JSON View: with `@JsonView` annotations 
+you can easily define which properties of an object you want to include 
+in the JSON output. A simple example where only the "name" field will be
+included:
+
+<pre class="prettyprint">
+public class AppController {
+
+    public Result jsonPerson() {
+        Person person = new Person();
+        person.name = "John Doe";
+        person.age = 56;
+        
+        return Results.json().jsonView(View.Public.class).render(person);
+    }
+    
+    static class Person {
+        @JsonView(View.Public.class)
+        public String name;
+        
+        @JsonView(View.Private.class)
+        public Integer age;
+    }
+    
+    static class View {
+        static class Public {}
+        static class Private {}
+    }
+}
+</pre>
+
+More on Jackson's JSON Views: http://wiki.fasterxml.com/JacksonJsonViews

--- a/ninja-core/src/test/java/ninja/ResultTest.java
+++ b/ninja-core/src/test/java/ninja/ResultTest.java
@@ -141,6 +141,16 @@ public class ResultTest {
     }
 
     @Test
+    public void testSetAndGetJsonView() {
+
+        Result result = new Result(Result.SC_200_OK);
+
+        result.jsonView(TestObject.class);
+
+        assertEquals(TestObject.class, result.getJsonView());
+    }
+
+    @Test
     public void testRedirect() {
 
         Result result = new Result(Result.SC_200_OK);

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineJsonTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineJsonTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.template;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.utils.ResponseStreams;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for application/json render.
+ */
+public class TemplateEngineJsonTest {
+
+    Context context;
+    ResponseStreams responseStreams;
+    Result result;
+    ObjectMapper objectMapper;
+    ByteArrayOutputStream outputStream;
+
+    @Before
+    public void setUp() throws IOException {
+        context = mock(Context.class);
+        responseStreams = mock(ResponseStreams.class);
+        result = mock(Result.class);
+
+        objectMapper = new ObjectMapper();
+        outputStream = new ByteArrayOutputStream();
+
+        TestObject testObj = new TestObject();
+        testObj.field1 = "field_one";
+        testObj.field2 = "field_two";
+
+        when(result.getRenderable()).thenReturn(testObj);
+        when(context.finalizeHeaders(result)).thenReturn(responseStreams);
+        when(responseStreams.getOutputStream()).thenReturn(outputStream);
+    }
+
+    @Test
+    public void testJsonViewWorks() throws IOException {
+        Mockito.<Class<?>>when(result.getJsonView()).thenReturn(View.Public.class);
+
+        TemplateEngineJson jsonEngine = new TemplateEngineJson(objectMapper);
+        jsonEngine.invoke(context, result);
+
+        String json = new String(outputStream.toByteArray(), "UTF-8");
+        assertTrue(json.contains("field_one"));
+        assertFalse(json.contains("field_two"));
+
+        verify(context).finalizeHeaders(result);
+    }
+
+
+    private static class TestObject {
+
+        @JsonView(View.Public.class)
+        public String field1;
+
+        @JsonView(View.Private.class)
+        public String field2;
+    }
+
+
+    private static class View {
+        public static class Public {}
+        public static class Private {}
+    }
+
+}


### PR DESCRIPTION
I also considered a controller method annotation based approach (like in Spring), but the implementation would've been more cumbersome and invasive. JSON view being set in the Result object is also imo more explicit that the view will be used only for serialization. 

Thoughts?
