### PR TITLE
Add charset to error html

### DIFF
--- a/ninja-core/src/main/java/ninja/diagnostics/diagnostic_header.html
+++ b/ninja-core/src/main/java/ninja/diagnostics/diagnostic_header.html
@@ -4,6 +4,7 @@
 <html>
   <head>
     <title>${TITLE}</title>
+    <meta charset="UTF-8">
     <style>
     ${STYLE}
     </style>

--- a/ninja-core/src/main/java/views/system/400badRequest.ftl.html
+++ b/ninja-core/src/main/java/views/system/400badRequest.ftl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>${message.text}</title>
+        <meta charset="UTF-8">
         <style type="text/css">
 
             .error-code {

--- a/ninja-core/src/main/java/views/system/401unauthorized.ftl.html
+++ b/ninja-core/src/main/java/views/system/401unauthorized.ftl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>${message.text}</title>
+        <meta charset="UTF-8">
         <style type="text/css">
 
             .error-code {

--- a/ninja-core/src/main/java/views/system/403forbidden.ftl.html
+++ b/ninja-core/src/main/java/views/system/403forbidden.ftl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>${message.text}</title>
+        <meta charset="UTF-8">
         <style type="text/css">
 
             .error-code {

--- a/ninja-core/src/main/java/views/system/404notFound.ftl.html
+++ b/ninja-core/src/main/java/views/system/404notFound.ftl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>${message.text}</title>
+        <meta charset="UTF-8">
         <style type="text/css">
 
             .error-code {

--- a/ninja-core/src/main/java/views/system/500internalServerError.ftl.html
+++ b/ninja-core/src/main/java/views/system/500internalServerError.ftl.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>${message.text}</title>
+        <meta charset="UTF-8">
         <style type="text/css">
 
             .error-code {

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version X.X.X
+=============
+
+ * 2015-08-23 Added charset to error html files (mallowlabs)
+
 Version 5.1.5
 =============
 


### PR DESCRIPTION
I found that my localized exception messages are garbled in diagnostic page.
I guess that charset should be specified in these files.
