### PR TITLE
Context.getParameterFileItems() now returns Map<String, List<FileItem>>

### DIFF
--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -341,7 +341,7 @@ public interface Context {
      * 
      * @return The parameters, possibly a null map.
      */
-    Map<String, FileItem[]> getParameterFileItems();
+    Map<String, List<FileItem>> getParameterFileItems();
 
     
     /**

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -119,7 +119,7 @@ public class WrappedContext implements Context {
     }
 
     @Override
-    public Map<String, FileItem[]> getParameterFileItems() {
+    public Map<String, List<FileItem>> getParameterFileItems() {
         return wrapped.getParameterFileItems();
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version 5.2.1
+=============
+
+ * 2015-10-16 Context.getParameterFileItems() new returns Map<String, List<FileItem>>
+
 Version 5.2.0
 =============
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,7 @@
 Version 5.2.1
 =============
 
- * 2015-10-16 Context.getParameterFileItems() new returns Map<String, List<FileItem>> (jjlauer)
+ * 2015-10-16 Context.getParameterFileItems() now returns Map<String, List<FileItem>> (jjlauer)
 
 Version 5.2.0
 =============

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,7 @@
 Version 5.2.1
 =============
 
- * 2015-10-16 Context.getParameterFileItems() new returns Map<String, List<FileItem>>
+ * 2015-10-16 Context.getParameterFileItems() new returns Map<String, List<FileItem>> (jjlauer)
 
 Version 5.2.0
 =============

--- a/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
@@ -268,8 +268,8 @@ public class MultipartContextImplMemoryTest {
 
         Assert.assertEquals(2, context.getParameterFileItems().size());
         int count = 0;
-        for (FileItem[] values : context.getParameterFileItems().values()) {
-            count += values.length;
+        for (List<FileItem> values : context.getParameterFileItems().values()) {
+            count += values.size();
         }
         Assert.assertEquals(3, count);
     }

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -502,7 +502,7 @@ public class FakeContext implements Context {
     }
 
     @Override
-    public Map<String, FileItem[]> getParameterFileItems() {
+    public Map<String, List<FileItem>> getParameterFileItems() {
         throw new UnsupportedOperationException("Not supported in fake context");        
     }
 


### PR DESCRIPTION
Aligns the new FileItem feature with the rest of Context by using a List<> rather than an array.  Better to adjust this quickly before too many rely on the new interface.
