### PR TITLE
Add new mongodb module

### DIFF
--- a/ninja-core/src/site/markdown/documentation/modules.md
+++ b/ninja-core/src/site/markdown/documentation/modules.md
@@ -42,6 +42,10 @@ Rocker templates
 Hazelcast Cache Implementation
 
  * https://github.com/raptaml/ninja-hazelcast-embedded
+ 
+MongoDB/Morphia Integration
+
+ * https://github.com/bihe/ninja-mongodb
 
 <div class="alert alert-info">
 Please feel free to add your modules to this page as pull request 


### PR DESCRIPTION
Unfortunately svenkubiak's mongodb module is no longer available, because of his own framework https://github.com/svenkubiak/mangooio (ninja-spin off).

Recreation of the module including simple unit-tests with embedded mongodb (https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo). 
Travis build support with
- openjdk7
- oraclejdk7
- oraclejdk8
