### PR TITLE
Code Quality fix - Constructors should only call non-overridable methods

### DIFF
--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -100,7 +100,7 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
 
     }
 
-    protected void logBodyParserEngines() {
+    protected final void logBodyParserEngines() {
         List<String> outputTypes = Lists.newArrayList(getContentTypes());
         Collections.sort(outputTypes);
 

--- a/ninja-core/src/main/java/ninja/i18n/LangImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/LangImpl.java
@@ -198,9 +198,8 @@ public class LangImpl implements Lang {
         } 
 
     }
-    
-    
-    String getDefaultLanguage(NinjaProperties ninjaProperties) {
+
+    final String getDefaultLanguage(NinjaProperties ninjaProperties) {
     
         String [] applicationLanguages 
                 = ninjaProperties.getStringArray(NinjaConstant.applicationLanguages);

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -103,7 +103,7 @@ public class TemplateEngineManagerImpl implements TemplateEngineManager {
         }
     }
 
-    protected void logTemplateEngines() {
+    protected final void logTemplateEngines() {
         List<String> outputTypes = Lists.newArrayList(getContentTypes());
         Collections.sort(outputTypes);
 

--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -293,7 +293,7 @@ public class NinjaPropertiesImpl implements NinjaProperties {
     }
 
     @Override
-    public boolean isProd() {
+    public final boolean isProd() {
         return (ninjaMode.equals(NinjaMode.prod));
     }
 


### PR DESCRIPTION
DevFactory is committed to improving code quality and advancing open source. Our team contributes their time to researching and identifying areas for code quality improvement in open source projects. We identified a fix for ninja-framework. 

This pull request is focused on resolving  occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699?layout=true

Please let me know if you have any questions. There is more to come.

Javed Kansi
DevFactory - Code Cleanup Team
