### PR TITLE
Fix garbled parameters in multipart requests

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2015-11-13 Fixed garbled parameters in multipart requests (mallowlabs)
  * 2015-10-18 Added Session.setExpiryTime() to control session expiry (watsonmw)
  * 2015-10-18 OptionalBinder for ObjectMapper and XmlMapper, so that users can easily override
               the default types for both of them. (amit2103/jjlauer)

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
@@ -537,9 +537,17 @@ public class NinjaServletContext extends AbstractContext {
                 FileItemStream item = fileItemIterator.next();
 
                 if (item.isFormField()) {
+
+                    String charset = NinjaConstant.UTF_8;
+
+                    String contentType = item.getContentType();
+
+                    if (contentType != null) {
+                        charset = HttpHeaderUtils.getCharsetOfContentTypeOrUtf8(contentType);
+                    }
                     
                     // save the form field for later use from getParameter
-                    String value = Streams.asString(item.openStream());
+                    String value = Streams.asString(item.openStream(), charset);
                     formMap.put(item.getFieldName(), value);
 
                 } else {


### PR DESCRIPTION
I found that `Context#getParameter` returns garbled texts in multipart requests from v5.2.0.
Because `Streams#asString()` reads stream with the platform encoding.
I fixed this problem.

Environment:

```
$ mvn --version
Apache Maven 3.2.5 (12a6b3acb947671f09b81f49094c53f426d8cea1; 2014-12-15T02:29:23+09:00)
Maven home: C:\usr\apache-maven-3.2.5\bin\..
Java version: 1.8.0_65, vendor: Oracle Corporation
Java home: C:\Program Files\Java\jdk1.8.0_65\jre
Default locale: ja_JP, platform encoding: MS932
OS name: "windows 10", version: "10.0", arch: "amd64", family: "dos"
```
