### PR TITLE
Code Quality fix - Exception handlers should preserve the original exception

### DIFF
--- a/ninja-core/src/main/java/ninja/NinjaDefault.java
+++ b/ninja-core/src/main/java/ninja/NinjaDefault.java
@@ -426,7 +426,7 @@ public class NinjaDefault implements Ninja {
         
         } catch (Exception e) {
             //this should not happen. Never.
-            throw new RuntimeErrorException(new Error("Something is wrong with your build. Cannot find resource " + LOCATION_OF_NINJA_BUILTIN_PROPERTIES));
+            throw new RuntimeErrorException(new Error("Something is wrong with your build. Cannot find resource " + LOCATION_OF_NINJA_BUILTIN_PROPERTIES, e));
         }
         
         return ninjaVersion;

--- a/ninja-core/src/main/java/ninja/cache/CacheEhCacheImpl.java
+++ b/ninja-core/src/main/java/ninja/cache/CacheEhCacheImpl.java
@@ -130,6 +130,7 @@ public class CacheEhCacheImpl implements Cache {
             add(key, value, expiration);
             return true;
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             return false;
         }
     }

--- a/ninja-core/src/main/java/ninja/cache/CacheMemcachedImpl.java
+++ b/ninja-core/src/main/java/ninja/cache/CacheMemcachedImpl.java
@@ -143,6 +143,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return null;
@@ -161,6 +162,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return Collections.<String, Object>emptyMap();
@@ -183,6 +185,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return false;
@@ -193,6 +196,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return false;
@@ -203,6 +207,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return false;
@@ -213,6 +218,7 @@ public class CacheMemcachedImpl implements Cache {
         try {
             return future.get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             future.cancel(false);
         }
         return false;

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerReverseRouteHelper.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerReverseRouteHelper.java
@@ -77,7 +77,7 @@ public class TemplateEngineFreemarkerReverseRouteHelper {
 
                 return new SimpleScalar(reverseRoute);
             } catch (ClassNotFoundException ex) {
-                throw new TemplateModelException("Error. Cannot find class for String: " + strings.get(0));
+                throw new TemplateModelException("Error. Cannot find class for String: " + strings.get(0), ex);
             }
         }
 

--- a/ninja-core/src/main/java/ninja/utils/SwissKnife.java
+++ b/ninja-core/src/main/java/ninja/utils/SwissKnife.java
@@ -95,7 +95,7 @@ public class SwissKnife {
         } catch (ConfigurationException e) {
 
             logger.info("Could not load file " + fileOrUrlOrClasspathUrl
-                    + " (not a bad thing necessarily, but I am returing null)");
+                    + " (not a bad thing necessarily, but I am returing null)", e);
 
             return null;
         }
@@ -144,6 +144,7 @@ public class SwissKnife {
         try {
             result = (T[]) Array.newInstance(to, from.length);
         } catch (ClassCastException e) {
+            logger.trace(e.getMessage(), e);
             return null;
         }
         for (int i = 0; i < from.length; i++) {

--- a/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/ContextImpl.java
@@ -270,6 +270,7 @@ public class ContextImpl implements Context.Impl {
         try {
             return SwissKnife.convert(parameter, clazz);
         } catch (Exception e) {
+            logger.trace(e.getMessage(), e);
             return defaultValue;
         }
     }
@@ -462,6 +463,7 @@ public class ContextImpl implements Context.Impl {
                 // If ip4/6 address string handed over, simply does pattern validation.
                 InetAddress.getByName(remoteAddr);
             } catch (UnknownHostException e) {
+                logger.trace(e.getMessage(), e);
                 remoteAddr = httpServletRequest.getRemoteAddr();
             }
         } else {
@@ -750,7 +752,7 @@ public class ContextImpl implements Context.Impl {
         try {
             httpServletRequest.setCharacterEncoding(charset);
         } catch (UnsupportedEncodingException e) {
-            logger.error("Server does not support charset of content type: " + contentType);
+            logger.error("Server does not support charset of content type: " + contentType, e);
         }
 
     }

--- a/ninja-standalone/src/main/java/ninja/standalone/NinjaJetty.java
+++ b/ninja-standalone/src/main/java/ninja/standalone/NinjaJetty.java
@@ -312,7 +312,7 @@ public class NinjaJetty {
             port = Integer.parseInt(portAsString);
         
         } catch (Exception e) {
-
+            logger.trace(e.getMessage(), e);
             return DEFAULT_PORT;
         }
 
@@ -329,7 +329,7 @@ public class NinjaJetty {
             idleTimeout = Long.parseLong(idleTimeoutAsString);
             
         } catch(Exception e) {
-            
+            logger.trace(e.getMessage(), e);
             return DEFAULT_IDLE_TIMEOUT;
         }
         
@@ -343,7 +343,7 @@ public class NinjaJetty {
             return System.getProperty(COMMAND_LINE_PARAMETER_NINJA_CONTEXT);
 
         } catch (Exception e) {
-
+            logger.trace(e.getMessage(), e);
             return null;
         }
     }


### PR DESCRIPTION
DevFactory is committed to improving code quality and advancing open source. Our team contributes their time to researching and identifying areas for code quality improvement in open source projects. We identified a fix for ninja-framework. 

This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - “Exception handlers should preserve the original exception”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1166

Please let me know if you have any questions. There is more to come.

Javed
DevFactory - Code Cleanup Team
