### PR TITLE
Code Quality fix - Loggers should be "private static final"

### DIFF
--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -41,7 +41,7 @@ import com.google.common.collect.Maps;
 
 public class Result {
     
-    private final Logger logger = LoggerFactory.getLogger(Result.class);
+    private static final Logger logger = LoggerFactory.getLogger(Result.class);
 
     // /////////////////////////////////////////////////////////////////////////
     // HTTP Status codes (for convenience)
@@ -383,7 +383,7 @@ public class Result {
                     writer.write(string);
                     
                 } catch (IOException ioException) {
-                
+
                     logger.error(
                             "Error rendering raw String via renderRaw(...)", 
                             ioException);

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -40,7 +40,7 @@ public class RouterImpl implements Router {
 
     private final NinjaProperties ninjaProperties;
 
-    private final Logger logger = LoggerFactory.getLogger(RouterImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(RouterImpl.class);
 
     private final List<RouteBuilderImpl> allRouteBuilders = new ArrayList<>();
     private final Injector injector;
@@ -387,7 +387,7 @@ public class RouterImpl implements Router {
 
             } else {
 
-              logger.info("{} {}", route.getHttpMethod(), route.getUri());
+                logger.info("{} {}", route.getHttpMethod(), route.getUri());
 
             }
 

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -39,7 +39,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
 
-    private final Logger logger = LoggerFactory.getLogger(BodyParserEngineManagerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(BodyParserEngineManagerImpl.class);
 
     // Keep a reference of providers rather than instances, so body parser engines
     // don't have to be singleton if they don't want

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -35,7 +35,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class BodyParserEnginePost implements BodyParserEngine {
 
-    private final Logger logger = LoggerFactory.getLogger(BodyParserEnginePost.class);
+    private static final Logger logger = LoggerFactory.getLogger(BodyParserEnginePost.class);
 
     @Override
     public <T> T invoke(Context context, Class<T> classOfT) {

--- a/ninja-core/src/main/java/ninja/i18n/LangImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/LangImpl.java
@@ -35,7 +35,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class LangImpl implements Lang {
 
-    private static Logger logger = LoggerFactory.getLogger(LangImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(LangImpl.class);
     
     private final String applicationCookiePrefix;
     

--- a/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
@@ -43,7 +43,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class MessagesImpl implements Messages {
 
-    private static Logger logger = LoggerFactory.getLogger(MessagesImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(MessagesImpl.class);
 
     private final Map<String, Configuration> langToKeyAndValuesMapping;
 

--- a/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
+++ b/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
@@ -47,7 +47,7 @@ public class FlashScopeImpl implements FlashScope {
 
     private String applicationCookiePrefix;
     
-    private static Logger logger = LoggerFactory.getLogger(FlashScopeImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(FlashScopeImpl.class);
 
     @Inject
     public FlashScopeImpl(NinjaProperties ninjaProperties) {

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
@@ -37,7 +37,7 @@ import freemarker.template.TemplateModelException;
 public class TemplateEngineFreemarkerI18nMethod implements
         TemplateMethodModelEx {
     
-    public final static Logger logger 
+    private final static Logger logger
             = LoggerFactory.getLogger(TemplateEngineFreemarkerAssetsAtMethod.class);
 
     final Messages messages;

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerPrettyTimeMethod.java
@@ -39,7 +39,7 @@ import freemarker.template.TemplateModelException;
 public class TemplateEngineFreemarkerPrettyTimeMethod implements
         TemplateMethodModelEx {
 
-    public final static Logger logger = LoggerFactory
+    private static final Logger logger = LoggerFactory
             .getLogger(TemplateEngineFreemarkerPrettyTimeMethod.class);
 
     private final PrettyTime prettyTime;

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineJson.java
@@ -33,7 +33,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class TemplateEngineJson implements TemplateEngine {
 
-    private final Logger logger = LoggerFactory.getLogger(TemplateEngineJson.class);
+    private static final Logger logger = LoggerFactory.getLogger(TemplateEngineJson.class);
 
     private final ObjectMapper objectMapper;
 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineJsonP.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineJsonP.java
@@ -49,7 +49,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class TemplateEngineJsonP implements TemplateEngine {
 
-    private final Logger logger = LoggerFactory.getLogger(TemplateEngineJsonP.class);
+    private static final Logger logger = LoggerFactory.getLogger(TemplateEngineJsonP.class);
 
     static final String DEFAULT_CALLBACK_PARAMETER_NAME = "callback";
 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineManagerImpl.java
@@ -39,7 +39,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class TemplateEngineManagerImpl implements TemplateEngineManager {
 
-    private final Logger logger = LoggerFactory.getLogger(TemplateEngineManagerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(TemplateEngineManagerImpl.class);
 
     // Keep a reference of providers rather than instances, so template engines
     // don't have

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineText.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineText.java
@@ -32,7 +32,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class TemplateEngineText implements TemplateEngine {
 
-    private final Logger logger = LoggerFactory.getLogger(TemplateEngineText.class);
+    private static final Logger logger = LoggerFactory.getLogger(TemplateEngineText.class);
 
     @Inject
     public TemplateEngineText() {

--- a/ninja-core/src/main/java/ninja/utils/MimeTypes.java
+++ b/ninja-core/src/main/java/ninja/utils/MimeTypes.java
@@ -35,7 +35,7 @@ import com.google.inject.Singleton;
  */
 @Singleton
 public class MimeTypes {
-    private final Logger logger = LoggerFactory.getLogger(MimeTypes.class);
+    private static final Logger logger = LoggerFactory.getLogger(MimeTypes.class);
 
     private final String PROPERTY_MIMETYPE_PREFIX = "mimetype.";
     private final String DEFAULT_MIMET_TYPE_LOCATIONS = "ninja/utils/mime-types.properties";

--- a/ninja-core/src/main/java/ninja/utils/NinjaModeHelper.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaModeHelper.java
@@ -23,7 +23,7 @@ import com.google.common.base.Optional;
 
 public class NinjaModeHelper {
     
-    static Logger logger = LoggerFactory.getLogger(NinjaModeHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(NinjaModeHelper.class);
     
     /**
      * returns an empty Optional<NinjaMode> if no mode is set. Or the valid mode

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -57,7 +57,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class JaxyRoutes implements ApplicationRoutes {
 
-    final static Logger logger = LoggerFactory.getLogger(JaxyRoutes.class);
+    private final static Logger logger = LoggerFactory.getLogger(JaxyRoutes.class);
 
     final NinjaProperties ninjaProperties;
 

--- a/ninja-jaxy-routes/src/test/java/testapplication/conf/Routes.java
+++ b/ninja-jaxy-routes/src/test/java/testapplication/conf/Routes.java
@@ -27,7 +27,7 @@ import com.google.inject.Inject;
 
 public class Routes implements ApplicationRoutes {
 
-    Logger logger = LoggerFactory.getLogger(Routes.class);
+    private static final Logger logger = LoggerFactory.getLogger(Routes.class);
 
     private NinjaProperties ninjaProperties;
 

--- a/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
+++ b/ninja-metrics-ganglia/src/main/java/ninja/metrics/ganglia/NinjaGanglia.java
@@ -43,7 +43,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class NinjaGanglia {
 
-    private final Logger log = LoggerFactory.getLogger(NinjaGanglia.class);
+    private static final Logger log = LoggerFactory.getLogger(NinjaGanglia.class);
 
     private final NinjaProperties ninjaProperties;
 

--- a/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
+++ b/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
@@ -44,7 +44,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class NinjaGraphite {
 
-    private final Logger log = LoggerFactory.getLogger(NinjaGraphite.class);
+    private static final Logger log = LoggerFactory.getLogger(NinjaGraphite.class);
 
     private final NinjaProperties ninjaProperties;
 

--- a/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
+++ b/ninja-metrics-influxdb/src/main/java/ninja/metrics/influxdb/NinjaInfluxDB.java
@@ -41,7 +41,7 @@ import metrics_influxdb.InfluxdbHttp;
 @Singleton
 public class NinjaInfluxDB {
 
-    private final Logger log = LoggerFactory.getLogger(NinjaInfluxDB.class);
+    private static final Logger log = LoggerFactory.getLogger(NinjaInfluxDB.class);
 
     private final NinjaProperties ninjaProperties;
 

--- a/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
+++ b/ninja-metrics-librato/src/main/java/ninja/metrics/librato/NinjaLibrato.java
@@ -39,7 +39,7 @@ import com.librato.metrics.LibratoReporter;
 @Singleton
 public class NinjaLibrato {
 
-    private final Logger log = LoggerFactory.getLogger(NinjaLibrato.class);
+    private static final Logger log = LoggerFactory.getLogger(NinjaLibrato.class);
 
     private final NinjaProperties ninjaProperties;
 

--- a/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
+++ b/ninja-metrics/src/main/java/ninja/metrics/MetricsServiceImpl.java
@@ -55,7 +55,7 @@ import com.google.inject.Singleton;
 @Singleton
 public class MetricsServiceImpl implements MetricsService {
 
-    private final Logger log = LoggerFactory.getLogger(MetricsService.class);
+    private static final Logger log = LoggerFactory.getLogger(MetricsService.class);
     private final NinjaProperties ninjaProps;
     private final MetricRegistry metricRegistry;
     private final List<Closeable> reporters;

--- a/ninja-test-utilities/src/main/java/ninja/NinjaRunner.java
+++ b/ninja-test-utilities/src/main/java/ninja/NinjaRunner.java
@@ -64,7 +64,7 @@ import com.google.inject.Injector;
  */
 public class NinjaRunner extends BlockJUnit4ClassRunner {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(BlockJUnit4ClassRunner.class);
 
     private Injector injector = null;
 

--- a/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
@@ -50,7 +50,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.collect.Maps;
 
 public class NinjaTestBrowser {
-    private final Logger LOG = LoggerFactory.getLogger(NinjaTestBrowser.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NinjaTestBrowser.class);
     private final DefaultHttpClient httpClient;
 
     public NinjaTestBrowser() {


### PR DESCRIPTION
Hello @jjlauer, this pull request is about making the declaration of logger consistent across the entire application. We found a number of occurrences where the loggers were not private static final and tried to fix all such occurrences. Some of the classes are declared as singleton and declaring the logger as static won't give any performance benefit but it doesn't cause any harm either and I think its a good practice to follow this convention in all places. If you don't agree with declaring logger as static in singleton class, let me know and I'll revert changes in singleton classes.

Thanks,
Javed.
