### PR TITLE
Allow DTOs to work with multipart requests.

### DIFF
--- a/ninja-core/src/main/java/ninja/ContentTypes.java
+++ b/ninja-core/src/main/java/ninja/ContentTypes.java
@@ -17,12 +17,11 @@
 package ninja;
 
 public interface ContentTypes {
-
     String TEXT_HTML = "text/html";
     String APPLICATION_JSON = "application/json";
     String APPLICATION_JSONP = "application/javascript";
     String APPLICATION_POST_FORM = "application/x-www-form-urlencoded";
+    String MULTIPART_FORM_DATA = "multipart/form-data";
     String APPLICATION_XML = "application/xml";
     String TEXT_CSS = "text/css";
-
 }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineManagerImpl.java
@@ -47,6 +47,7 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
 
     @Inject
     public BodyParserEngineManagerImpl(Provider<BodyParserEnginePost> bodyParserEnginePost,
+                                       Provider<BodyParserEngineMultipart> bodyParserEngineMultipart,
                                        Provider<BodyParserEngineJson> bodyParserEngineJson,
                                        Provider<BodyParserEngineXml> bodyParserEngineXml,
                                        Injector injector) {
@@ -58,6 +59,8 @@ public class BodyParserEngineManagerImpl implements BodyParserEngineManager {
         // custom bindings
         map.put(bodyParserEnginePost.get().getContentType(),
                 bodyParserEnginePost);
+        map.put(bodyParserEngineMultipart.get().getContentType(),
+                bodyParserEngineMultipart);
         map.put(bodyParserEngineJson.get().getContentType(),
                 bodyParserEngineJson);
         map.put(bodyParserEngineXml.get().getContentType(),

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipart.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipart.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package ninja.uploads;
+package ninja.bodyparser;
 
-import org.apache.commons.fileupload.FileItemStream;
+import ninja.ContentTypes;
 
-/**
- * {@link FileItemProvider} default's implementation, to indicate to not handle uploaded files, and
- * let the users deal with the request by themselves
- * 
- * @author Christian Bourgeois
- */
-public class NoFileItemProvider implements FileItemProvider {
+import com.google.inject.Singleton;
 
+@Singleton
+public class BodyParserEngineMultipart extends BodyParserEnginePost {
     @Override
-    public FileItem create(FileItemStream item) {
-        throw new UnsupportedOperationException("Not supported in NoFileItemProvider");
+    public String getContentType() {
+        return ContentTypes.MULTIPART_FORM_DATA;
     }
-    
 }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -92,6 +92,7 @@ public class BodyParserEnginePost implements BodyParserEngine {
             }
 
         }
+
         return t;
     }
 

--- a/ninja-core/src/main/java/ninja/uploads/FileItemProvider.java
+++ b/ninja-core/src/main/java/ninja/uploads/FileItemProvider.java
@@ -27,9 +27,7 @@ import com.google.inject.ImplementedBy;
  * 
  * @author Christian Bourgeois
  */
-@ImplementedBy(NoFileItemProvider.class)
+@ImplementedBy(MemoryFileItemProvider.class)
 public interface FileItemProvider {
-    
     FileItem create(FileItemStream item);
-
 }

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
@@ -46,7 +46,7 @@ public class BodyParserEngineManagerImplTest {
         List<String> types = Lists.newArrayList(createBodyParserEngineManager().getContentTypes());
         Collections.sort(types);
         assertThat(types.toString(),
-                equalTo("[application/json, application/x-www-form-urlencoded, application/xml]"));
+                equalTo("[application/json, application/x-www-form-urlencoded, application/xml, multipart/form-data]"));
     }
 
     private BodyParserEngineManager createBodyParserEngineManager(final Class<?>... toBind) {

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
@@ -44,7 +44,6 @@ import ninja.session.Session;
 import ninja.uploads.FileItem;
 import ninja.uploads.FileItemProvider;
 import ninja.uploads.FileProvider;
-import ninja.uploads.NoFileItemProvider;
 import ninja.utils.HttpHeaderUtils;
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
@@ -230,7 +229,9 @@ public class NinjaServletContext extends AbstractContext {
 
     @Override
     public Map<String, String[]> getParameters() {
-        if (!formFieldsProcessed) processFormFields();
+        if (!formFieldsProcessed) {
+            processFormFields();
+        }
         if (formFieldsMap == null) {
             return httpServletRequest.getParameterMap();
         } else {
@@ -504,9 +505,7 @@ public class NinjaServletContext extends AbstractContext {
         // call classic getFileItemIterator() by himself
         FileProvider fileProvider = null;
         if (route != null) {
-            if (fileProvider == null) {
-                fileProvider = route.getControllerMethod().getAnnotation(FileProvider.class);
-            }
+            fileProvider = route.getControllerMethod().getAnnotation(FileProvider.class);
             if (fileProvider == null) {
                 fileProvider = route.getControllerClass().getAnnotation(FileProvider.class);
             }
@@ -519,8 +518,6 @@ public class NinjaServletContext extends AbstractContext {
         } else {
             fileItemProvider = injector.getInstance(fileProvider.value());
         }
-        
-        if (fileItemProvider instanceof NoFileItemProvider) return;
         
         // Initialize maps and other constants
         ArrayListMultimap<String, String> formMap = ArrayListMultimap.create();
@@ -551,8 +548,8 @@ public class NinjaServletContext extends AbstractContext {
                     formMap.put(item.getFieldName(), value);
 
                 } else {
-                    
-                    // process file as input stream and save for later use in getParameterAsFile or getParameterAsInputStream
+                    // process file as input stream and save for later use in getParameterAsFile
+                    // or getParameterAsInputStream
                     FileItem fileItem = fileItemProvider.create(item);
                     fileMap.put(item.getFieldName(), fileItem);
                 }


### PR DESCRIPTION
I noticed I had some user agents / client's making multipart POST requests instead of x-form POST requests to controller methods I was using Dtos on, so the following wasn't working (dto was null):

```
public class Dto {
  String param1; 
  String param2;
}

public class MyController {
    public void post(Dto dto) {
       // null for multipart requests, not null for application/x-form requests
    }
}
```

This patch allows non multipart and multipart POSTs to work similarly.  You can still handle the multipart body in a streaming fashion, by specifying only a "Context" parameter or nothing at all for the controller method arguments.

I should mention I couldn't find a reason for NoFileItemProvider to exist, it was just causing some early out logic when calling the Context.get_Paramater_() methods with multipart requests, requiring a FileItemProvider annotation for controller methods that didn't even use files.
