### PR TITLE
Travis tests on OpenJDK 7 and Oracle 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+jdk:
+  - oraclejdk8
+  - openjdk7


### PR DESCRIPTION
Specify jdks to run travis with (reliance on current travis defaults is brittle)
