### PR TITLE
Unit tests improved for compat with non-servlet standalones

### DIFF
--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -19,9 +19,6 @@ package controllers;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import models.FormObject;
 import ninja.Context;
 import ninja.Result;
@@ -34,8 +31,6 @@ import ninja.i18n.Messages;
 import ninja.metrics.Timed;
 import ninja.params.Param;
 import ninja.params.PathParam;
-import ninja.servlet.util.Request;
-import ninja.servlet.util.Response;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.utils.NinjaProperties;
@@ -45,7 +40,6 @@ import ninja.validation.Validation;
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -77,22 +71,14 @@ public class ApplicationController {
     NinjaProperties ninjaProperties;
 
     @Timed
-    public Result index(@Request HttpServletRequest httpServletRequest,
-                           @Response HttpServletResponse httpServletResponse,
-                           Context context) {
-        
+    public Result index(Context context) {
         logger.info("In index ");
         logger.info("nc: " + ninjaProperties.getContextPath());
         logger.info("co: " + context.getContextPath());
         
-        // test that the injected httpservlet request and response are not null
-        Preconditions.checkNotNull(httpServletRequest);
-        Preconditions.checkNotNull(httpServletResponse);
-        
         // Default rendering is simple by convention
         // This renders the page in views/ApplicationController/index.ftl.html
         return Results.html();
-
     }
 
     @Timed

--- a/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
@@ -26,7 +26,9 @@ import org.apache.http.HttpResponse;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
+import static org.hamcrest.CoreMatchers.is;
 import org.junit.Assert;
+import static org.junit.Assert.assertThat;
 
 public class AssetsControllerTest extends NinjaTest {
 
@@ -42,13 +44,10 @@ public class AssetsControllerTest extends NinjaTest {
                 headers);
 
         // this is a mimetype nobody knows of...
-        // but it is listetd in the ninja mimetypes... therefore it will be
-        // found:
-        // default charset is always utf-8 by convention.
-        assertEquals(
-                "application/dxf; charset=UTF-8", 
-                httpResponse.getHeaders("Content-Type")[0].getValue());
-
+        // but it is listetd in the ninja mimetypes... therefore it will be found:
+        // case insensitivity makes test realistic
+        String contentType = httpResponse.getHeaders("Content-Type")[0].getValue();
+        assertThat("application/dxf; charset=UTF-8".equalsIgnoreCase(contentType), is(true));
     }
     
     @Test


### PR DESCRIPTION
I've been working on undertow support and the ninja-servlet-integration-test module is really the best "ninja-integration-test" module.  I thought about renaming the module, but wanted to keep this PR simple. There were just a couple very minor changes required to make it a great integration test for a non-servlet standalone such as undertow.
