### PR TITLE
Session and flash data save to Context instead of Result

### DIFF
--- a/ninja-core/src/main/java/ninja/session/FlashScope.java
+++ b/ninja-core/src/main/java/ninja/session/FlashScope.java
@@ -36,7 +36,7 @@ public interface FlashScope {
 
     void init(Context context);
 
-    void save(Context context, Result result);
+    void save(Context context);
 
     void put(String key, String value);
 

--- a/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
+++ b/ninja-core/src/main/java/ninja/session/FlashScopeImpl.java
@@ -74,25 +74,23 @@ public class FlashScopeImpl implements FlashScope {
     }
 
     @Override
-    public void save(Context context, Result result) {
+    public void save(Context context) {
 
         if (outgoingFlashCookieData.isEmpty()) {
 
             if (context.hasCookie(applicationCookiePrefix
                     + ninja.utils.NinjaConstant.FLASH_SUFFIX)) {
 
+                // build empty flash cookie
                 Cookie.Builder cookie = Cookie.builder(applicationCookiePrefix
                     + NinjaConstant.FLASH_SUFFIX, "");
                 cookie.setPath(context.getContextPath() + "/");
                 cookie.setSecure(false);
                 cookie.setMaxAge(0);
 
-                result.addCookie(cookie.build());
+                context.addCookie(cookie.build());
 
             }
-
-            return;
-
         }
 
         else {
@@ -108,7 +106,7 @@ public class FlashScopeImpl implements FlashScope {
                 // => Cookie will live as long as the browser is open theoretically
                 cookie.setMaxAge(-1);
 
-                result.addCookie(cookie.build());
+                context.addCookie(cookie.build());
 
             } catch (Exception e) {
                 logger.error("Encoding exception - this must not happen", e);

--- a/ninja-core/src/main/java/ninja/session/Session.java
+++ b/ninja-core/src/main/java/ninja/session/Session.java
@@ -60,9 +60,8 @@ public interface Session {
      * It basically serializes the session into the header of the response.
      * 
      * @param context The context from where to deduct a potentially existing session.
-     * @param result The result where to add the session.
      */
-	public void save(Context context, Result result);
+	public void save(Context context);
 
     /**
      * Puts key / value into the session. 

--- a/ninja-core/src/main/java/ninja/session/SessionImpl.java
+++ b/ninja-core/src/main/java/ninja/session/SessionImpl.java
@@ -209,7 +209,7 @@ public class SessionImpl implements Session {
     }
 
     @Override
-    public void save(Context context, Result result) {
+    public void save(Context context) {
 
         // Don't save the cookie nothing has changed, and if we're not expiring or
         // we are expiring but we're only updating if the session changes
@@ -229,7 +229,7 @@ public class SessionImpl implements Session {
                 expiredSessionCookie.setPath(context.getContextPath() + "/");
                 expiredSessionCookie.setMaxAge(0);
 
-                result.addCookie(expiredSessionCookie.build());
+                context.addCookie(expiredSessionCookie.build());
 
             }
             return;
@@ -267,7 +267,7 @@ public class SessionImpl implements Session {
                 cookie.setHttpOnly(sessionHttpOnly);
             }
 
-            result.addCookie(cookie.build());
+            context.addCookie(cookie.build());
 
         } catch (UnsupportedEncodingException unsupportedEncodingException) {
             logger.error("Encoding exception - this must not happen", unsupportedEncodingException);

--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -302,17 +302,18 @@ abstract public class AbstractContext implements Context.Impl {
     }
 
     protected ResponseStreams finalizeHeaders(Result result, Boolean handleFlashAndSessionCookie) {
-        // copy ninja cookies / flash and session
+        // copy ninja flash and session data directory to this context
         if (handleFlashAndSessionCookie) {
-            flashScope.save(this, result);
-            session.save(this, result);
+            flashScope.save(this);
+            session.save(this);
         }
-
-        // copy cookies from result
+        
+        // copy any cookies from result
         for (ninja.Cookie cookie : result.getCookies()) {
             addCookie(cookie);
         }
         
+        // subclasses responsible for creating the ResponseStreams instance
         return null;
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 5.X.X
 =============
 
+ * 2016-01-29 Security: session and flash data save to Context instead of Result (jjlauer)
  * 2016-01-16 Module.java of Ninja applications can now get NinjaProperties injected optionally. (jlannoy)
  * 2015-12-01 Added more documentation about Freemarker templates. (jlannoy)
 

--- a/ninja-core/src/test/java/ninja/session/FlashScopeTest.java
+++ b/ninja-core/src/test/java/ninja/session/FlashScopeTest.java
@@ -71,10 +71,10 @@ public class FlashScopeTest {
 
         // put nothing => intentionally to check if no flash cookie will be
         // saved
-        flashCookie.save(context, result);
+        flashCookie.save(context);
 
         // no cookie should be set as the flash scope is empty...:
-        verify(result, never()).addCookie(Matchers.any(Cookie.class));
+        verify(context, never()).addCookie(Matchers.any(Cookie.class));
     }
 
     @Test
@@ -88,10 +88,10 @@ public class FlashScopeTest {
 
         // put nothing => intentionally to check if no flash cookie will be
         // saved
-        flashCookie.save(context, result);
+        flashCookie.save(context);
 
         // a cookie will be set => hello:flashScope
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals("NINJA_FLASH", cookieCaptor.getValue().getName());
@@ -123,10 +123,10 @@ public class FlashScopeTest {
         flashCookie.put("another message", "is there...");
         flashCookie.put("yet another message", "is there...");
 
-        flashCookie.save(context, result);
+        flashCookie.save(context);
 
         // a cookie will be set => hello:flashScope
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals("NINJA_FLASH", cookieCaptor.getValue().getName());
@@ -239,9 +239,9 @@ public class FlashScopeTest {
         FlashScope flashScope = new FlashScopeImpl(ninjaProperties);
         flashScope.put("anykey", "anyvalue");
         flashScope.init(context);
-        flashScope.save(context, result);
+        flashScope.save(context);
 
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
         Cookie cookie = cookieCaptor.getValue();
         Assert.assertThat(cookie.getPath(), CoreMatchers.equalTo("/my_context/"));
     }

--- a/ninja-core/src/test/java/ninja/session/SessionImplTest.java
+++ b/ninja-core/src/test/java/ninja/session/SessionImplTest.java
@@ -129,10 +129,10 @@ public class SessionImplTest {
 
         // put nothing => empty session will not be sent as we send only changed
         // stuff...
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // no cookie should be set as the flash scope is empty...:
-        verify(result, never()).addCookie(Matchers.any(Cookie.class));
+        verify(context, never()).addCookie(Matchers.any(Cookie.class));
     }
 
     @Test
@@ -146,10 +146,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals("NINJA_SESSION", cookieCaptor.getValue().getName());
@@ -183,10 +183,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals(true, cookieCaptor.getValue().isSecure());
@@ -209,10 +209,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals(false, cookieCaptor.getValue().isSecure());
@@ -230,10 +230,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals(true, cookieCaptor.getValue().isHttpOnly());
@@ -255,10 +255,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // verify some stuff on the set cookie
         assertEquals(false, cookieCaptor.getValue().isHttpOnly());
@@ -278,10 +278,10 @@ public class SessionImplTest {
 
         // put nothing => intentionally to check if no session cookie will be
         // saved
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // a cookie will be set
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         // now we simulate a new request => the session storage will generate a
         // new cookie:
@@ -377,9 +377,9 @@ public class SessionImplTest {
         sessionCookie.init(context);
         sessionCookie.put("anykey", "anyvalue");
 
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
         Cookie cookie = cookieCaptor.getValue();
         assertThat(cookie.getPath(), CoreMatchers.equalTo("/my_context/"));
     }
@@ -397,7 +397,7 @@ public class SessionImplTest {
 
         assertThat(sessionCookie1.get("a"), CoreMatchers.equalTo("2"));
 
-        sessionCookie1.save(context, result);
+        sessionCookie1.save(context);
 
         Session sessionCookie2 = roundTrip(sessionCookie1);
 
@@ -444,10 +444,10 @@ public class SessionImplTest {
     }
 
     private Session roundTrip(Session sessionCookie1) {
-        sessionCookie1.save(context, result);
+        sessionCookie1.save(context);
 
         // Get the cookie ...
-        verify(result, atLeastOnce()).addCookie(cookieCaptor.capture());
+        verify(context, atLeastOnce()).addCookie(cookieCaptor.capture());
 
         when(context.getCookie("NINJA_SESSION")).thenReturn(cookieCaptor.getValue());
 
@@ -462,10 +462,10 @@ public class SessionImplTest {
     }
 
     private String captureFinalCookie(Session sessionCookie) {
-        sessionCookie.save(context, result);
+        sessionCookie.save(context);
 
         // SessionImpl should set the cookie
-        verify(result).addCookie(cookieCaptor.capture());
+        verify(context).addCookie(cookieCaptor.capture());
 
         String cookieValue = cookieCaptor.getValue().getValue();
         String cookieValueWithoutSign = cookieValue.substring(cookieValue.indexOf("-") + 1);

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -289,8 +289,8 @@ public class AbstractContextTest {
         // abstract finalizeHeaders does not return anything
         assertThat(streams, is(nullValue()));
 
-        verify(flashCookie, times(1)).save(context, result);
-        verify(sessionCookie, times(1)).save(context, result);
+        verify(flashCookie, times(1)).save(context);
+        verify(sessionCookie, times(1)).save(context);
         verify(context, times(1)).addCookie(cookie);
     }
 


### PR DESCRIPTION
Based on issue #450 it was uncovered that session and flash data was being saved to the Result then copied to the Context then written to the underlying response stream.  This is not a problem except in the case where a user accidentally/intentionally reuses a Result object across requests.  In that case the session and context data had a race condition / security hole.

This PR skips writing the session and flash data to the Result and instead directly saves it to the Context.     It also saves a few bytes of ram by eliminating an unnecessary extra array copy.  The Result has been entirely eliminated from the session and flash interfaces to prevent future changes to it.
