### PR TITLE
Fixing minor typo in the docs

### DIFF
--- a/ninja-core/src/site/markdown/documentation/static_assets.md
+++ b/ninja-core/src/site/markdown/documentation/static_assets.md
@@ -12,7 +12,7 @@ It provides support for ETags and caching out of the box.
 
 <div class="alert alert-info"><code>AssetsController</code> will serve all assets
 below your src/main/java/assets folder. Therefore you have to make sure
-that no sensible information is available in that folder and its subfolders.</div>
+that no sensitive information is available in that folder and its subfolders.</div>
 
 Serving static assets from a subdirectory
 -----------------------------------------


### PR DESCRIPTION
I just thought that I would fix a minor typo in the documentation. I think that it is a typo.
