### PR TITLE
IllegalArgumentException in ninja.utils.AbstractContext.java

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -15,8 +15,10 @@
  */
 package ninja.utils;
 
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.UnknownHostException;
 
 import ninja.bodyparser.BodyParserEngine;
@@ -188,7 +190,22 @@ abstract public class AbstractContext implements Context.Impl {
         if (encodedParameter == null) {
             return null;
         } else {
-            return URI.create(encodedParameter).getPath();
+        	try {
+        		return URI.create(encodedParameter).getPath();
+        	} catch (IllegalArgumentException e) {
+        		StringBuilder sb = new StringBuilder();
+        		for (String part : encodedParameter.split("/")) {
+        			try {
+						sb.append(URLEncoder.encode(part, "UTF-8")).append("/");
+					} catch (UnsupportedEncodingException e1) {
+						// TODO: catch
+					}
+        		}
+        		if(sb.length() > 0 && !encodedParameter.substring(encodedParameter.length()-1).equals("/")) {
+        			sb.setLength(sb.length()-1);
+        		}
+        		return sb.toString();
+        	}
         }
     }
 


### PR DESCRIPTION
The goal of this pull request is to catch an IllegalArgumentException in  ninja.utils.AbstractContext.java.

An invalid URI (e.g. http://www.example.com/search/berlin|t3843egel372f) causes an uncatchable exception in getPathParameter(String key).

```
ERROR [qtp3447021-53] n.NinjaDefault [NinjaDefault.java:232] Emitting bad request 500. Something really wrong when calling route: /search/berlin|t3843egel372f/26 (class: class 
controllers.SearchController method: public ninja.Result controllers.SearchController.ergebnis(java.lang.String,int))
java.lang.IllegalArgumentException: Illegal character in path at index 6: berlin|t3843egel372f
        at java.net.URI.create(URI.java:852) ~[na:1.8.0_72]
        at ninja.utils.AbstractContext.getPathParameter(AbstractContext.java:191) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.params.ArgumentExtractors$PathParamExtractor.extract(ArgumentExtractors.java:130) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.params.ArgumentExtractors$PathParamExtractor.extract(ArgumentExtractors.java:121) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.params.ControllerMethodInvoker.invoke(ControllerMethodInvoker.java:54) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.FilterChainEnd.next(FilterChainEnd.java:49) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.NinjaDefault.onRouteRequest(NinjaDefault.java:102) ~[www-1.0-SNAPSHOT.jar:na]
        at ninja.servlet.NinjaServletDispatcher.service(NinjaServletDispatcher.java:86) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.ServletDefinition.doServiceImpl(ServletDefinition.java:287) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:277) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:182) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:91) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:85) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:119) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.GuiceFilter$1.call(GuiceFilter.java:133) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.GuiceFilter$1.call(GuiceFilter.java:130) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.GuiceFilter$Context.call(GuiceFilter.java:203) [www-1.0-SNAPSHOT.jar:na]
        at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:130) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.Server.handle(Server.java:497) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635) [www-1.0-SNAPSHOT.jar:na]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555) [www-1.0-SNAPSHOT.jar:na]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_72]
Caused by: java.net.URISyntaxException: Illegal character in path at index 6: berlin|t3843egel372f
        at java.net.URI$Parser.fail(URI.java:2848) ~[na:1.8.0_72]
        at java.net.URI$Parser.checkChars(URI.java:3021) ~[na:1.8.0_72]
        at java.net.URI$Parser.parseHierarchical(URI.java:3105) ~[na:1.8.0_72]
        at java.net.URI$Parser.parse(URI.java:3063) ~[na:1.8.0_72]
        at java.net.URI.<init>(URI.java:588) ~[na:1.8.0_72]
        at java.net.URI.create(URI.java:850) ~[na:1.8.0_72]
```
