### PR TITLE
Add ninja undertow module to docs

### DIFF
--- a/ninja-core/src/site/markdown/documentation/modules.md
+++ b/ninja-core/src/site/markdown/documentation/modules.md
@@ -5,6 +5,10 @@ Ninja can easily be extended by modules. This page contains popular modules
 available for Ninja. Usually the linked pages contain
 a short description how to setup stuff:
 
+Undertow standalone - alternative to Jetty
+
+ * https://github.com/fizzed/ninja-undertow
+
 
 Activity support - light-weight workflow and Business Process Management (BPM)
 


### PR DESCRIPTION
Standalone implementation for the using Undertow.  Ninja-undertow does _not use servlets_ under-the-hood -- therefore it bypasses a significant amount of code that Ninja's default Jetty-based standalone uses.  Ninja-undertow can fully replace Ninja's Jetty-based standalone.

Based on this [benchmark](src/test/java/ninja/undertow/Benchmarker.java) ninja-undertow is 15.5% faster than ninja-jetty for standard GET requests and 7.6% faster than ninja-jetty for POST requests w/ JSON.  Future optimizations and tuning should only improve performance.
