### PR TITLE
Added RecycledNinjaServerTester for speedy unit tests

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,9 @@
+
 Version X.X.X
 =============
 
  * 2016-02-26 Removed ninja-core dependency on org.mindrot:bcrypt (it was unused) (jjlauer)
+ * 2016-02-25 New RecycledNinjaServerTester in ninja-test-utilities to speed up your unit tests (jjlauer)
  * 2016-01-08 Fix Cookie domain is not set when clearing session #462
 
 Version 5.3.1

--- a/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_recycled_tester.md
+++ b/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_recycled_tester.md
@@ -1,0 +1,35 @@
+RecycledNinjaServerTester
+=========================
+
+Introduction
+------------
+
+RecycledNinjaServerTester provides much of the same functionality as NinjaTest,
+but starts up a single Ninja test server for all tests in a Junit test class.
+
+If you're unit tests do not rely on a fresh server then this approach will
+dramatically increase the speed of your unit tests.
+
+<pre class="prettyprint">
+public class MyControllerTest extends RecycledNinjaServerTester {
+
+    @Test
+    public void testThatHomepageWorks() {
+        NinjaTestBrowser ninjaTestBrowser = new NinjaTestBrowser();
+
+        // redirect will send a location: redirect in the headers
+        String result = ninjaTestBrowser.makeRequest(withBaseUrl("/"));
+
+        // If the redirect has worked we must see the following text
+        // from the index screen:
+        assertTrue(result.contains("Hello to the blog example!"));
+        assertTrue(result.contains("My second post"));
+    }
+ 
+}
+</pre>
+
+If you want to revert back to a single Ninja test server for each test method,
+you can simply extend your class from FreshNinjaServerTester.
+
+</pre>

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -123,6 +123,7 @@
                 <item name="Ninja Test" href="./documentation/testing_your_application/ninja_test.html"/>
                 <item name="Ninja DocTester" href="./documentation/testing_your_application/ninja_doctester.html"/>
                 <item name="Ninja FluentLenium Test" href="./documentation/testing_your_application/ninja_fluentlenium_test.html"/>
+                <item name="Ninja Recycled Tester" href="./documentation/testing_your_application/ninja_recycled_tester.html"/>
                 <item name="Advanced" href="./documentation/testing_your_application/advanced.html"/>
             </item>
 

--- a/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import models.FormObject;
-import ninja.NinjaTest;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.cookie.Cookie;
@@ -31,17 +30,26 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import ninja.RecycledNinjaServerTester;
+import ninja.utils.NinjaTestBrowser;
+import org.junit.Before;
 
-public class ApplicationControllerTest extends NinjaTest {
+public class ApplicationControllerTest extends RecycledNinjaServerTester {
 
+    private NinjaTestBrowser ninjaTestBrowser;
+    
+    @Before
+    public void freshNinjaTestBrowser() {
+        this.ninjaTestBrowser = new NinjaTestBrowser();
+    }
+    
     @Test
     public void testThatRedirectWorks() {
-
         // Some empty headers for now...
         Map<String, String> headers = Maps.newHashMap();
 
         // /redirect will send a location: redirect in the headers
-        String result = ninjaTestBrowser.makeRequest(getServerAddress() + "/redirect", headers);
+        String result = ninjaTestBrowser.makeRequest(withBaseUrl("/redirect"), headers);
 
         // If the redirect has worked we must see the following text
         // from the index screen:
@@ -59,7 +67,7 @@ public class ApplicationControllerTest extends NinjaTest {
 
         // /redirect will send a location: redirect in the headers
 
-        String result = ninjaTestBrowser.makeRequest(getServerAddress() + "htmlEscaping", headers);
+        String result = ninjaTestBrowser.makeRequest(withBaseUrl("/htmlEscaping"), headers);
 
         // If the redirect has worked we must see the following text
         // from the index screen:
@@ -75,7 +83,7 @@ public class ApplicationControllerTest extends NinjaTest {
 
         // redirect will send a location: redirect in the headers
         HttpResponse httpResponse =
-                ninjaTestBrowser.makeRequestAndGetResponse(getServerAddress() + "session", headers);
+                ninjaTestBrowser.makeRequestAndGetResponse(withBaseUrl("/session"), headers);
 
         // Test that cookies get transported to consumer:
         assertEquals(1, ninjaTestBrowser.getCookies().size());
@@ -100,8 +108,7 @@ public class ApplicationControllerTest extends NinjaTest {
 
         // do the request
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress()
-                        + "user/12345/john@example.com/userDashboard", headers);
+                ninjaTestBrowser.makeRequest(withBaseUrl("/user/12345/john@example.com/userDashboard"), headers);
 
         // And assert that stuff is visible on page:
         assertTrue(response.contains("john@example.com"));
@@ -117,13 +124,12 @@ public class ApplicationControllerTest extends NinjaTest {
         Map<String, String> headers = Maps.newHashMap();
 
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress()
-                        + "validation?email=john@example.com");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/validation?email=john@example.com"));
 
         // And assert that stuff is visible on page:
         assertEquals(response, "\"john@example.com\"");
 
-        response = ninjaTestBrowser.makeRequest(getServerAddress() + "validation");
+        response = ninjaTestBrowser.makeRequest(withBaseUrl("/validation"));
 
         // And assert that stuff is visible on page:
         assertEquals(
@@ -168,7 +174,7 @@ public class ApplicationControllerTest extends NinjaTest {
 
         String response =
                 ninjaTestBrowser.makePostRequestWithFormParameters(
-                        getServerAddress() + "/form",
+                        withBaseUrl("/form"),
                         headers,
                         formParameters);
         
@@ -207,7 +213,7 @@ public class ApplicationControllerTest extends NinjaTest {
     @Test
     public void testDirectObjectRenderingWorks() {
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/direct_rendering");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/direct_rendering"));
         
         // And assert that object values are visible on page:
         assertTrue(response.contains("test_name"));
@@ -219,7 +225,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testFlashSuccessWorks() {
 
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_success");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/flash_success"));
 
         // And assert that stuff is visible on page:
         assertTrue(response.contains("This is a flashed success - with placeholder: PLACEHOLDER"));
@@ -230,7 +236,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testFlashErrorWorks() {
 
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_error");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/flash_error"));
 
         // And assert that stuff is visible on page:
         assertTrue(response.contains("This is a flashed error - with placeholder: PLACEHOLDER"));
@@ -241,7 +247,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testFlashAnyWorks() {
 
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/flash_any");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/flash_any"));
 
         // And assert that stuff is visible on page:
         assertTrue(response.contains("This is an arbitrary message as flash message - with placeholder: PLACEHOLDER"));
@@ -253,14 +259,14 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testCachingWorks() {
 
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/test_caching");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/test_caching"));
 
         // First request => no caching
         assertTrue(response.contains("No cache key set."));
         
         
         response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/test_caching");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/test_caching"));
 
         // Second request hits cache:
         assertTrue(response.contains("Cache key is: cacheKeyValue"));
@@ -270,14 +276,14 @@ public class ApplicationControllerTest extends NinjaTest {
     @Test
     public void testJsonPWorks() {
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/jsonp?callback=App.callback");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/jsonp?callback=App.callback"));
         assertEquals("App.callback({\"object\":\"value\"})", response);
     }
     
     @Test
     public void testThatBadRequestWorks() {
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/bad_request");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/bad_request"));
         assertTrue(response.contains("bad request"));
     }
     
@@ -285,7 +291,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testThatReverseRoutingWorks() {
         
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/test_reverse_routing");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/test_reverse_routing"));
     
         assertTrue(response.contains("<li>/user/100000/me@me.com/userDashboard</li>"));
         assertTrue(response.contains("<li>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</li>"));
@@ -296,7 +302,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void testGetContextPathWorks() {
         
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/test_get_context_path_works");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/test_get_context_path_works"));
     
         // both should be blank. We make sure we don't get any strange "/" delimiters or so...
         assertTrue(response.contains("<li>ninjaProperties.getContextPath(): </li>"));
@@ -307,7 +313,7 @@ public class ApplicationControllerTest extends NinjaTest {
     public void test_that_freemarker_emits_400_when_template_not_found() {
         
         String response =
-                ninjaTestBrowser.makeRequest(getServerAddress() + "/test_that_freemarker_emits_400_when_template_not_found");
+                ninjaTestBrowser.makeRequest(withBaseUrl("/test_that_freemarker_emits_400_when_template_not_found"));
     
         // both should be blank. We make sure we don't get any strange "/" delimiters or so...
         assertTrue(response.contains("<title>400 - Bad Request.</title>"));

--- a/ninja-test-utilities/src/main/java/ninja/BaseNinjaServerTester.java
+++ b/ninja-test-utilities/src/main/java/ninja/BaseNinjaServerTester.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Fizzed Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import com.google.inject.Injector;
+import ninja.utils.NinjaTestServer;
+
+abstract public class BaseNinjaServerTester {
+    
+    abstract public NinjaTestServer getNinjaTestServer();
+
+    public String baseUrl() {
+        return getNinjaTestServer().getBaseUrl();
+    }
+    
+    public String withBaseUrl(String path) {
+        return getNinjaTestServer().getBaseUrl() + path;
+    }
+    
+    public Injector getInjector() {
+        return getNinjaTestServer().getInjector();
+    }
+    
+}

--- a/ninja-test-utilities/src/main/java/ninja/FreshNinjaServerTester.java
+++ b/ninja-test-utilities/src/main/java/ninja/FreshNinjaServerTester.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright (C) 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,49 +13,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package ninja;
 
 import ninja.utils.NinjaTestServer;
-
-import org.doctester.DocTester;
-import org.doctester.testbrowser.Url;
 import org.junit.After;
 import org.junit.Before;
 
-import com.google.inject.Injector;
-
 /**
- * Superclass for doctests that require a running server. Uses {@link NinjaTest} for the server
- * stuff.
+ * Creates a fresh <code>NinjaTestServer</code> for each unit test in your
+ * junit test class. Unless you really need a fresh server for each unit test,
+ * please note that its fairly expensive to start/stop a ninja test server 
+ * for each unit test.
  * 
- * @author hschuetz
+ * <code>
+ * public class MyControllerTest extends FreshNinjaServerTester {
  * 
+ *     @Test
+ *     public void usersIndex() {
+ *         String url = withBaseUrl("/users");
+ *         // do rest of test...
+ *     }
+ * 
+ * }
+ * </code>
+ * 
+ * @see RecycledNinjaServerTester
  */
-public abstract class NinjaDocTester extends DocTester {
+public class FreshNinjaServerTester extends BaseNinjaServerTester {
+    
     private NinjaTestServer ninjaTestServer;
-
-    public NinjaDocTester() {
-    }
-
+    
     @Before
-    public void startServerInTestMode() {
+    public void startNinjaServer() {
         ninjaTestServer = new NinjaTestServer();
     }
 
     @After
-    public void shutdownServer() {
+    public void shutdownNinjaServer() {
         ninjaTestServer.shutdown();
     }
 
     @Override
-    public Url testServerUrl() {
-        // v5.1.5+ includes configured context path
-        return Url.host(ninjaTestServer.getBaseUrl());
-    }
-    
-    public Injector getInjector() {
-        return ninjaTestServer.getInjector();
+    public NinjaTestServer getNinjaTestServer() {
+        return ninjaTestServer;
     }
 
 }

--- a/ninja-test-utilities/src/main/java/ninja/RecycledNinjaServerTester.java
+++ b/ninja-test-utilities/src/main/java/ninja/RecycledNinjaServerTester.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaTestServer;
+import org.junit.ClassRule;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Uses a single <code>NinjaTestServer</code> per junit test class.  The server
+ * is started a single time when the class loads and used across all tests.
+ * If you're unit tests do not rely on a fresh server then this approach will
+ * dramatically increase the speed of your unit tests -- by not starting up
+ * and shutting down a ninja test server for each unit test.
+ * 
+ * <code>
+ * public class MyControllerTest extends RecycledNinjaServerTester {
+ * 
+ *     @Test
+ *     public void usersIndex() {
+ *         String url = withBaseUrl("/users");
+ *         // do rest of test...
+ *     }
+ * 
+ * }
+ * </code>
+ * 
+ * @see FreshNinjaServerTester
+ */
+public class RecycledNinjaServerTester extends BaseNinjaServerTester {
+    
+    static private NinjaTestServer ninjaTestServer;
+    
+    @ClassRule
+    static public ExternalResource ninjaTestServerResource = new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            ninjaTestServer = new NinjaTestServer(NinjaMode.test);
+        }
+
+        @Override
+        protected void after() {
+            ninjaTestServer.shutdown();
+            ninjaTestServer = null;
+        }
+    };
+
+    @Override
+    public NinjaTestServer getNinjaTestServer() {
+        return ninjaTestServer;
+    }
+    
+}


### PR DESCRIPTION
Added support for new junit testers -- most notable is the RecycledNinjaServerTester which uses a single Ninja server across all unit tests in a class.  If you have any number of unit tests in a class, using this approach can help speed up your unit tests by an order of magnitude.  For example, updated Controller test in servlet-integration runs 4x faster than before.
