### PR TITLE
Removed ninja-core dependency on org.mindrot:bcrypt (it was unused)

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -135,12 +135,6 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
 
-        <!-- Enrcyption library providing support for blowfish -->
-        <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-        </dependency>
-
         <!-- Logback is the successor of log4j. We use it: -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version X.X.X
 =============
 
+ * 2016-02-26 Removed ninja-core dependency on org.mindrot:bcrypt (it was unused) (jjlauer)
  * 2016-01-08 Fix Cookie domain is not set when clearing session #462
 
 Version 5.3.1

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -161,7 +161,11 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.4</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This dependency was sneaking its way into ninja-core even though its not used.  It is only used in the servlet integration test -- which had this dependency added.
