### PR TITLE
Remove ehcache type use in generic ninja cache interface

### DIFF
--- a/ninja-core/src/main/java/ninja/cache/CacheException.java
+++ b/ninja-core/src/main/java/ninja/cache/CacheException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.cache;
+
+public class CacheException extends RuntimeException {
+
+    public CacheException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+}

--- a/ninja-core/src/main/java/ninja/cache/NinjaCache.java
+++ b/ninja-core/src/main/java/ninja/cache/NinjaCache.java
@@ -20,14 +20,13 @@ import java.io.NotSerializableException;
 import java.io.Serializable;
 import java.util.Map;
 
-import net.sf.ehcache.CacheException;
 import ninja.utils.TimeUtil;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 /**
- * A convenience class to access the underlaying cache implementation.
+ * A convenience class to access the underlying cache implementation.
  * 
  * Makes getting and setting of objects a lot simpler.
  * 

--- a/ninja-core/src/test/java/ninja/cache/NinjaCacheTest.java
+++ b/ninja-core/src/test/java/ninja/cache/NinjaCacheTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import net.sf.ehcache.CacheException;
 import ninja.utils.TimeUtil;
 
 import org.junit.Test;


### PR DESCRIPTION
I was trying to remove my dependency of ehcache the other day and found out I couldn't.  Turns out NinjaCache accidentally was using an ehcache CacheException to throw a simple exception.
