### PR TITLE
New AutoStandalone class to find a standalone for running and unit tests

### DIFF
--- a/ninja-core/src/main/java/ninja/standalone/AutoStandalone.java
+++ b/ninja-core/src/main/java/ninja/standalone/AutoStandalone.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.standalone;
+
+/**
+ * Automatically finds a standalone to start a Ninja app. Order of preference
+ * for which standalone is used taps uses the rules established in
+ * ninja.standalone.StandaloneHelper.
+ * 
+ * @see StandaloneHelper#resolveStandaloneClass()
+ */
+public class AutoStandalone {
+    
+    static public void main(String[] args) throws Exception {
+        // either returns class or throws exception
+        Class<? extends Standalone> standaloneClass
+            = StandaloneHelper.resolveStandaloneClass();
+        
+        // instantiate and run it!
+        StandaloneHelper.create(standaloneClass).run();
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/standalone/StandaloneHelper.java
+++ b/ninja-core/src/main/java/ninja/standalone/StandaloneHelper.java
@@ -22,11 +22,14 @@ import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
+import java.util.Iterator;
+import java.util.ServiceLoader;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import ninja.utils.ForwardingServiceLoader;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,12 +61,58 @@ public class StandaloneHelper {
      * @return The resolved standalone class to use
      */
     static public Class<? extends Standalone> resolveStandaloneClass() {
-        String standaloneClassName = System.getProperty(Standalone.KEY_NINJA_STANDALONE_CLASS, Standalone.DEFAULT_STANDALONE_CLASS);
-        try {
-            return (Class<Standalone>)Class.forName(standaloneClassName);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to find standalone class '" + standaloneClassName + "' (class does not exist)");
+        return resolveStandaloneClass(
+            System.getProperty(Standalone.KEY_NINJA_STANDALONE_CLASS),
+            ForwardingServiceLoader.loadWithSystemServiceLoader(Standalone.class),
+            Standalone.DEFAULT_STANDALONE_CLASS
+        );
+    }
+    
+    // used for testing (so we can inject mocks of system static methods)
+    static Class<? extends Standalone> resolveStandaloneClass(String standaloneClassNameSystemProperty,
+                                                              ForwardingServiceLoader<Standalone> standaloneServiceLoader,
+                                                              String standaloneClassNameDefaultValue) {
+        Class<? extends Standalone> resolvedStandaloneClass = null;
+        
+        // 1. System property for 'ninja.standalone.class'
+        if (standaloneClassNameSystemProperty != null) {
+            try {
+                resolvedStandaloneClass
+                    = (Class<Standalone>)Class.forName(standaloneClassNameSystemProperty);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to find standalone class '" + standaloneClassNameSystemProperty + "' (class does not exist)");
+            }
         }
+        
+        // 2. Implementation on classpath that's registered as service?
+        if (resolvedStandaloneClass == null) {
+            try {
+                Iterator<Standalone> standaloneIterator = standaloneServiceLoader.iterator();
+                // first one wins
+                if (standaloneIterator.hasNext()) {
+                    resolvedStandaloneClass = standaloneIterator.next().getClass();
+                }
+                // more than one triggers warning
+                if (standaloneIterator.hasNext()) {
+                    log.warn("More than one implementation of {} on classpath! Using {} which was the first", Standalone.class, resolvedStandaloneClass);
+                }
+            } finally {
+                // always kill cache (since ServiceLoader actually instantiates an instance)
+                standaloneServiceLoader.reload();
+            }
+        }
+        
+        // 3. Fallback to ninja default
+        if (resolvedStandaloneClass == null) {
+            try {
+                resolvedStandaloneClass
+                    = (Class<Standalone>)Class.forName(standaloneClassNameDefaultValue);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to find standalone class '" + standaloneClassNameDefaultValue + "' (class does not exist)");
+            }
+        }
+        
+        return resolvedStandaloneClass;
     }
     
     static public Standalone create(Class<? extends Standalone> standaloneClass) {

--- a/ninja-core/src/main/java/ninja/utils/ForwardingServiceLoader.java
+++ b/ninja-core/src/main/java/ninja/utils/ForwardingServiceLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.utils;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * Forwards method calls to an underlying java.util.ServiceLoader -- mainly to
+ * allow participating and mocking in unit tests.  Designed to be a drop-in
+ * replacement at the source-code level since java.util.ServiceLoader is final.
+ */
+public class ForwardingServiceLoader<T> {
+    
+    private final ServiceLoader<T> serviceLoader;
+
+    public ForwardingServiceLoader(ServiceLoader<T> serviceLoader) {
+        this.serviceLoader = serviceLoader;
+    }
+    
+    public Iterator<T> iterator() {
+        return this.serviceLoader.iterator();
+    }
+    
+    public void reload() {
+        this.serviceLoader.reload();
+    }
+    
+    static public <T> ForwardingServiceLoader<T> loadWithSystemServiceLoader(Class<T> service) {
+        return new ForwardingServiceLoader<>(
+            ServiceLoader.load(service)
+        );
+    }
+    
+    static public <T> ForwardingServiceLoader<T> loadWithSystemServiceLoader(Class<T> service, ClassLoader classLoader) {
+        return new ForwardingServiceLoader<>(
+            ServiceLoader.load(service, classLoader)
+        );
+    }
+    
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -3,6 +3,8 @@ Version X.X.X
 =============
 
  * 2016-02-26 Removed ninja-core dependency on org.mindrot:bcrypt (it was unused) (jjlauer)
+ * 2016-02-29 New ninja.standalone.AutoStandalone class locates standalone to use based on
+              System property, then META-INF/services, then default value of Jetty (jjlauer)
  * 2016-02-25 New RecycledNinjaServerTester in ninja-test-utilities to speed up your unit tests (jjlauer)
  * 2016-01-08 Fix Cookie domain is not set when clearing session #462
 

--- a/ninja-core/src/test/java/ninja/standalone/AbstractStandaloneTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/AbstractStandaloneTest.java
@@ -28,6 +28,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class AbstractStandaloneTest {
 
@@ -35,7 +40,7 @@ public class AbstractStandaloneTest {
     public void ninjaModeOnConstructor() {
         System.setProperty(NinjaConstant.MODE_KEY_NAME, "dev");
         
-        FakeStandalone standalone = new FakeStandalone();
+        MockStandalone standalone = new MockStandalone();
         
         assertThat(standalone.getNinjaMode(), is(NinjaMode.dev));
     }
@@ -43,7 +48,7 @@ public class AbstractStandaloneTest {
     @Test
     public void manuallySetExternalConfiguration() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .externalConfigurationPath("conf/standalone.conf");
         
         // port is still null (before configuration)
@@ -58,9 +63,9 @@ public class AbstractStandaloneTest {
     @Test
     public void configurationPropertyPriority() throws Exception {
         
-        FakeStandalone standalone;
+        MockStandalone standalone;
         
-        standalone = new FakeStandalone()
+        standalone = new MockStandalone()
                 .configure();
         
         // defaultValue
@@ -73,7 +78,7 @@ public class AbstractStandaloneTest {
 
         
         // configProperty > defaultValue
-        standalone = new FakeStandalone()
+        standalone = new MockStandalone()
                 .externalConfigurationPath("conf/standalone.conf")
                 .configure();
         
@@ -93,7 +98,7 @@ public class AbstractStandaloneTest {
         System.setProperty(Standalone.KEY_NINJA_IDLE_TIMEOUT, "80000");
         
         try {
-            standalone = new FakeStandalone()
+            standalone = new MockStandalone()
                     .externalConfigurationPath("conf/standalone.conf")
                     .configure();
             
@@ -107,7 +112,7 @@ public class AbstractStandaloneTest {
             
             
             // currentValue > systemProperty
-            standalone = new FakeStandalone()
+            standalone = new MockStandalone()
                 .externalConfigurationPath("conf/standalone.conf")
                 .host("3.3.3.3")
                 .port(9002)
@@ -136,7 +141,7 @@ public class AbstractStandaloneTest {
     @Test
     public void ninjaPropertiesThrowsExceptionUntilConfigured() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .externalConfigurationPath("conf/standalone.conf");
         
         try {
@@ -155,7 +160,7 @@ public class AbstractStandaloneTest {
     @Test
     public void urlUsesLocalhostInLieuOfNull() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .configure();
         
         assertThat(standalone.getServerUrls().get(0), is("http://localhost:8080"));
@@ -165,7 +170,7 @@ public class AbstractStandaloneTest {
     @Test
     public void urlIncludesContext() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .host("1.1.1.1")
                 .contextPath("/mycontext")
                 .configure();
@@ -177,7 +182,7 @@ public class AbstractStandaloneTest {
     @Test
     public void urlExcludesWellKnownPorts() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .host("1.1.1.1")
                 .port(80)
                 .contextPath("/mycontext")
@@ -190,7 +195,7 @@ public class AbstractStandaloneTest {
     @Test
     public void ninjaPropertiesServerNameSetAfterConfigure() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .host("1.1.1.1")
                 .configure();
         
@@ -201,7 +206,7 @@ public class AbstractStandaloneTest {
     @Test
     public void ninjaPropertiesServerNameSetButOnlyIfNotInConfigFile() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .externalConfigurationPath("conf/standalone.with.servername.conf")
                 .host("1.1.1.1")
                 .configure();
@@ -213,7 +218,7 @@ public class AbstractStandaloneTest {
     @Test
     public void injectorOnlyAvailableAfterStart() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone();
+        MockStandalone standalone = new MockStandalone();
         
         try {
             standalone.getInjector();
@@ -230,7 +235,7 @@ public class AbstractStandaloneTest {
     @Test
     public void validateContextPath() throws Exception {
         
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
             .externalConfigurationPath("conf/standalone.with.badcontext.conf");
         
         try {
@@ -246,7 +251,7 @@ public class AbstractStandaloneTest {
     @Test
     public void noPortsEnabled() throws Exception {
         try {
-            FakeStandalone standalone = new FakeStandalone()
+            MockStandalone standalone = new MockStandalone()
                     .port(-1)
                     .configure();
             fail("exception expected");
@@ -257,7 +262,7 @@ public class AbstractStandaloneTest {
     
     @Test
     public void randomPortAssigned() throws Exception {
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .port(0)
                 .configure();
         
@@ -268,7 +273,7 @@ public class AbstractStandaloneTest {
     
     @Test
     public void sslRandomPortAssigned() throws Exception {
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .port(-1)
                 .sslPort(0)
                 .configure();
@@ -278,7 +283,7 @@ public class AbstractStandaloneTest {
     
     @Test
     public void sslConfiguration() throws Exception {
-        FakeStandalone standalone = new FakeStandalone()
+        MockStandalone standalone = new MockStandalone()
                 .port(-1)
                 .sslPort(8443)
                 .start();

--- a/ninja-core/src/test/java/ninja/standalone/MockStandalone.java
+++ b/ninja-core/src/test/java/ninja/standalone/MockStandalone.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.mock;
 /**
  * Fake standalone for unit testing.
  */
-public class FakeStandalone extends AbstractStandalone<FakeStandalone> {
+public class MockStandalone extends AbstractStandalone<MockStandalone> {
 
-    public FakeStandalone() {
+    public MockStandalone() {
         super("FakeStandalone");
     }
 

--- a/ninja-core/src/test/java/ninja/standalone/StandaloneHelperTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/StandaloneHelperTest.java
@@ -18,10 +18,7 @@ package ninja.standalone;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.ServiceLoader;
-import static java.util.function.Predicate.isEqual;
 import javax.net.ssl.SSLContext;
 import ninja.utils.ForwardingServiceLoader;
 import static org.hamcrest.CoreMatchers.containsString;

--- a/ninja-core/src/test/java/ninja/standalone/StandaloneHelperTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/StandaloneHelperTest.java
@@ -17,12 +17,23 @@
 package ninja.standalone;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
+import static java.util.function.Predicate.isEqual;
 import javax.net.ssl.SSLContext;
+import ninja.utils.ForwardingServiceLoader;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StandaloneHelperTest {
 
@@ -53,6 +64,42 @@ public class StandaloneHelperTest {
             = StandaloneHelper.createSSLContext(keystoreUri, keystorePassword, truststoreUri, truststorePassword);
         
         assertThat(sslContext, is(not(nullValue())));
+    }
+    
+    @Test
+    public void resolveStandaloneClass() throws Exception {
+        Class<? extends Standalone> resolvedStandaloneClass;
+        
+        try {
+            // try to resolve system property
+            StandaloneHelper.resolveStandaloneClass("sys_prop_does_not_exist", null, null);
+            fail();
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("sys_prop_does_not_exist"));
+        }
+        
+        // try to find using META-INF/services
+        // mock the service loader
+        ForwardingServiceLoader<Standalone> serviceLoader
+            = mock(ForwardingServiceLoader.class);
+
+        List<Standalone> standalones = new ArrayList<>();
+        standalones.add(new MockStandalone());
+        when(serviceLoader.iterator()).thenReturn(standalones.iterator());
+
+        resolvedStandaloneClass = StandaloneHelper.resolveStandaloneClass(null, serviceLoader, "default_does_not_exist");
+       
+        assertThat(resolvedStandaloneClass.newInstance(), instanceOf(MockStandalone.class));
+        
+        try {
+            // try to resolve using default
+            when(serviceLoader.iterator()).thenReturn(new ArrayList<Standalone>().iterator());
+            StandaloneHelper.resolveStandaloneClass(null, serviceLoader, "default_does_not_exist");
+            fail();
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("default_does_not_exist"));
+        }
+        
     }
     
 }

--- a/ninja-maven-plugin/src/main/java/ninja/maven/NinjaRunMojo.java
+++ b/ninja-maven-plugin/src/main/java/ninja/maven/NinjaRunMojo.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import ninja.build.ArgumentTokenizer;
 
 import ninja.standalone.NinjaJetty;
+import ninja.standalone.AutoStandalone;
 import ninja.standalone.Standalone;
 import ninja.utils.NinjaConstant;
 
@@ -159,7 +160,7 @@ public class NinjaRunMojo extends AbstractMojo {
     
     /**
      * Main class to run in SuperDevMode. Defaults to default standalone class
-     * in Ninja (ninja.standalone.NinjaJetty)
+     * in Ninja.
      */
     @Parameter(property = "ninja.mainClass", required = false)
     protected String mainClass;
@@ -264,7 +265,7 @@ public class NinjaRunMojo extends AbstractMojo {
         }
         
         // which standalone (works with -Dninja.standalone to maven OR in pom.xml)
-        String mainClassToRun = (mainClass != null ? mainClass : Standalone.DEFAULT_STANDALONE_CLASS);
+        String mainClassToRun = (mainClass != null ? mainClass : AutoStandalone.class.getCanonicalName());
         
         getLog().info("------------------------------------------------------------------------");
         
@@ -367,19 +368,19 @@ public class NinjaRunMojo extends AbstractMojo {
 
         if (port != null) {
             String portSelection
-                    = "-D" + NinjaJetty.KEY_NINJA_PORT + "=" + port;
+                    = "-D" + Standalone.KEY_NINJA_PORT + "=" + port;
             jvmArguments.add(portSelection);
         }
         
         if (sslPort != null) {
             String sslPortSelection
-                    = "-D" + NinjaJetty.KEY_NINJA_SSL_PORT + "=" + sslPort;
+                    = "-D" + Standalone.KEY_NINJA_SSL_PORT + "=" + sslPort;
             jvmArguments.add(sslPortSelection);
         }
         
         if (getContextPath() != null) {
             String contextPathSelection
-                    = "-D" + NinjaJetty.KEY_NINJA_CONTEXT_PATH + "=" + getContextPath();
+                    = "-D" + Standalone.KEY_NINJA_CONTEXT_PATH + "=" + getContextPath();
             jvmArguments.add(contextPathSelection);
         }
         


### PR DESCRIPTION
With my work on [Ninja-Undertow](https://github.com/fizzed/ninja-undertow), I've been finding it a bit repetitious to become the default standalone in my projects.  Thus, `AutoStandalone` is a new feature where Ninja will find the standalone to use based on a few rules.  First, the current method of system property 'ninja.standalone.class' still is the first preference.  Then, META-INF/services via java.util.ServiceLoader will be used.  Finally, it'll fallback to jetty.

With this change, to pickup undertow (or any external standalone, its as simple as adding it to the classpath.  The caveat is that multiple META-INF/services on the classpath will mean the first one wins, but that's still workable since the user can explicitly then set a system property.  NinjaJetty does not have a META-INF/services since it's still the default.
