### PR TITLE
Faster reverse routing; support for new MethodReference type

### DIFF
--- a/ninja-core/src/main/java/ninja/RouteBuilder.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilder.java
@@ -16,11 +16,16 @@
 
 package ninja;
 
+import ninja.utils.MethodReference;
+
 public interface RouteBuilder {
 
     RouteBuilder route(String uri);
 
     void with(Class controller, String controllerMethod);
 
+    void with(MethodReference controllerMethodRef);
+    
     void with(Result result);
+    
 }

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Injector;
+import ninja.utils.MethodReference;
 
 public class RouteBuilderImpl implements RouteBuilder {
 
@@ -80,6 +81,11 @@ public class RouteBuilderImpl implements RouteBuilder {
         this.controller = controller;
         this.controllerMethod = verifyThatControllerAndMethodExists(controller,
                 controllerMethod);
+    }
+
+    @Override
+    public void with(MethodReference controllerMethodRef) {
+        with(controllerMethodRef.getDeclaringClass(), controllerMethodRef.getMethodName());
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Optional;
+import ninja.utils.MethodReference;
 
 public interface Router {
 
@@ -102,6 +103,15 @@ public interface Router {
                                  String controllerMethodName,
                                  Optional<Map<String, Object>> parameterMap);
         
+    
+    public String getReverseRoute(MethodReference controllerMethodRef);
+    
+    public String getReverseRoute(MethodReference controllerMethodRef, Map<String, Object> parameterMap);
+    
+    public String getReverseRoute(MethodReference controllerMethodRef, Object ... parameterMap);
+    
+    public String getReverseRoute(MethodReference controllerMethodRef, Optional<Map<String, Object>> parameterMap);
+    
     /**
      * Compile all the routes that have been registered with the router. This
      * should be called once, during initialization, before the application

--- a/ninja-core/src/main/java/ninja/standalone/StandaloneHelper.java
+++ b/ninja-core/src/main/java/ninja/standalone/StandaloneHelper.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.net.URL;
 import java.security.KeyStore;
 import java.util.Iterator;
-import java.util.ServiceLoader;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/ninja-core/src/main/java/ninja/utils/MethodReference.java
+++ b/ninja-core/src/main/java/ninja/utils/MethodReference.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.utils;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Compound key of a Class and the name of a method in it. Primarily used for
+ * reverse route lookups.
+ */
+public class MethodReference {
+    
+    private final Class declaringClass;
+    private final String methodName;
+
+    public MethodReference(Class declaringClass, String methodName) {
+        this.declaringClass = declaringClass;
+        this.methodName = methodName;
+    }
+    
+    public MethodReference(Method method) {
+        this(method.getDeclaringClass(), method.getName());
+    }
+
+    public Class getDeclaringClass() {
+        return declaringClass;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 83 * hash + Objects.hashCode(this.declaringClass);
+        hash = 83 * hash + Objects.hashCode(this.methodName);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final MethodReference other = (MethodReference) obj;
+        if (!Objects.equals(this.methodName, other.methodName)) {
+            return false;
+        }
+        return Objects.equals(this.declaringClass, other.declaringClass);
+    }
+    
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -2,6 +2,9 @@
 Version X.X.X
 =============
 
+ * 2016-02-29 New ninja.standalone.AutoStandalone class locates standalone to use based on
+              System property, then META-INF/services, then default value of Jetty (jjlauer)
+ * 2016-02-29 Reverse routing is now O(1) from O(N) by using a pre-calculated hashmap (jjlauer)
  * 2016-02-28 More flexible Ninja guice configuration! Your `conf.Module` can optionally extend 
               `ninja.conf.FrameworkModule` to skip Ninja's default guice bindings
               for its "classic" stack of Freemarker, Jackson, Cache, etc. (jjlauer)
@@ -12,8 +15,6 @@ Version X.X.X
  * 2016-02-28 New `utils.ImplFromPropertiesFactory` to aid in loading your
               implementations from NinjaProperties. (jjlauer)
  * 2016-02-26 Removed ninja-core dependency on org.mindrot:bcrypt (it was unused) (jjlauer)
- * 2016-02-29 New ninja.standalone.AutoStandalone class locates standalone to use based on
-              System property, then META-INF/services, then default value of Jetty (jjlauer)
  * 2016-02-25 New RecycledNinjaServerTester in ninja-test-utilities to speed up your unit tests (jjlauer)
  * 2016-01-08 Fix Cookie domain is not set when clearing session #462
 

--- a/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
@@ -28,11 +28,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.inject.Injector;
-import static java.util.function.Predicate.isEqual;
 import ninja.utils.MethodReference;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
@@ -28,6 +28,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.inject.Injector;
+import static java.util.function.Predicate.isEqual;
+import ninja.utils.MethodReference;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RouteBuilderImplTest {
@@ -356,6 +362,17 @@ public class RouteBuilderImplTest {
         } catch (Exception e) {
             assertTrue(e instanceof IllegalStateException);
         }
+    }
+    
+    @Test
+    public void testRouteWithMethodReference() throws Exception {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/method_reference").with(new MethodReference(MockController.class, "execute"));
+
+        Route route = routeBuilder.buildRoute(injector);
+        assertTrue(route.matches("GET", "/method_reference"));
+
+        assertThat(route.getControllerClass().newInstance(), instanceOf(MockController.class));
     }
 
     private Route buildRoute(RouteBuilderImpl builder) {

--- a/ninja-core/src/test/java/ninja/RouterImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouterImplTest.java
@@ -60,7 +60,9 @@ public class RouterImplTest {
         router.GET().route("/testroute").with(TestController.class, "index");
         router.GET().route("/user/{email}/{id: .*}").with(TestController.class, "user");
         router.GET().route("/u{userId: .*}/entries/{entryId: .*}").with(TestController.class, "entry");
-
+        // second route to index should not break reverse routing matching the first
+        router.GET().route("/testroute/another_url_by_index").with(TestController.class, "index");
+        
         router.compileRoutes();
     }
 

--- a/ninja-core/src/test/java/ninja/RouterImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouterImplTest.java
@@ -30,6 +30,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import ninja.utils.MethodReference;
+import static org.hamcrest.CoreMatchers.is;
 
 /**
  * => Most tests are done via class RoutesTest in project
@@ -62,6 +64,7 @@ public class RouterImplTest {
         router.GET().route("/u{userId: .*}/entries/{entryId: .*}").with(TestController.class, "entry");
         // second route to index should not break reverse routing matching the first
         router.GET().route("/testroute/another_url_by_index").with(TestController.class, "index");
+        router.GET().route("/ref").with(new MethodReference(TestController.class, "ref"));
         
         router.compileRoutes();
     }
@@ -139,6 +142,20 @@ public class RouterImplTest {
         assertThat(route, equalTo("/u1/entries/100"));
 
     }
+    
+    @Test
+    public void testGetReverseRouteWithMethodReference() {
+
+        String contextPath = "";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = router.getReverseRoute(TestController.class, "ref");
+        
+        String route2 = router.getReverseRoute(new MethodReference(TestController.class, "ref"));
+
+        assertThat(route, is("/ref"));
+        assertThat(route2, is("/ref"));
+    }
 
     // Just a dummy TestController for mocking...
     public static class TestController {
@@ -156,6 +173,12 @@ public class RouterImplTest {
         }
 
         public Result entry() {
+
+            return Results.ok();
+
+        }
+        
+        public Result ref() {
 
             return Results.ok();
 


### PR DESCRIPTION
This PR implements two main changes:
- Reverse routing now uses a pre-calculated hashmap for O(1) reverse lookups vs. the current O(N) complexity of iterating thru routes
- RouteBuilder and Router accept a new `ninja.utils.MethodReference` type -- which simply includes a Class and method name.  This is not only used for the reverse routing key in the hashmap, but it also will enable [ninja-java8](https://github.com/fizzed/ninja-java8) to supply compile-time checked routes!  Even refactoring controller or method names in your IDE will change them for routing too :-)  Once this PR is accepted, I'll be able to modify my ninja-java8 code to support something like the following.

```
router.GET().route("/index").with(methodRef(Application::Index));
```

methodRef could be a static method that returns a type of `ninja.utils.MethodReference`
