### PR TITLE
Added to modules.md a Pebble module

### DIFF
--- a/ninja-core/src/site/markdown/documentation/modules.md
+++ b/ninja-core/src/site/markdown/documentation/modules.md
@@ -43,6 +43,10 @@ Rocker templates
 
  * https://github.com/fizzed/ninja-rocker
  
+Pebble templates
+
+ * https://github.com/jjfidalgo/ninja-pebble
+ 
 Hazelcast Cache Implementation
 
  * https://github.com/raptaml/ninja-hazelcast-embedded


### PR DESCRIPTION
Hello, 

I've developed a Ninja module to integrate Pebble template engine with Ninja.

The module is already fully functional and the Maven artifacts have been already deployed to Maven central,

```
 https://repo.maven.apache.org/maven2/com/github/jjfidalgo
```

I've added to modules.md the link to this Pebble module.

If you think is worth to include this link in your modules.md can you please review and if everything is OK accept the pull request.

Thank you very much in advance.

Kind regards
-Juan Fidalgo
