### PR TITLE
Improve usability in Google AppEngine environment

### DIFF
--- a/ninja-core/src/main/java/ninja/Bootstrap.java
+++ b/ninja-core/src/main/java/ninja/Bootstrap.java
@@ -244,8 +244,7 @@ public class Bootstrap {
             logger.info("Successfully configured Logback.");
              // It is available
         } catch (ClassNotFoundException exception) {
-            logger.info(
-                    "Logback is not on classpath (you are probably using slf4j-jdk14). I did not configure anything. It's up to you now...", exception);
+            logger.info("Ninja did not configure any logging because Logback is not on the classpath (you are probably using slf4j-jdk14).");
         }
     }
     

--- a/ninja-core/src/main/java/ninja/diagnostics/SourceSnippetHelper.java
+++ b/ninja-core/src/main/java/ninja/diagnostics/SourceSnippetHelper.java
@@ -16,6 +16,8 @@
 
 package ninja.diagnostics;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,8 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,10 +43,12 @@ public class SourceSnippetHelper {
                                                                     int lineTo) throws IOException {
         // try to find source template as local file
         if (baseDirectory != null) {
-            Path templatePath = baseDirectory.toPath()
-                .resolve(packageName.replace(".", File.separator))
-                .resolve(fileName);
-            File templateFile = templatePath.toFile();
+            File templateFile = new File(
+                baseDirectory.getAbsolutePath() 
+                + File.separator 
+                + packageName.replace(".", File.separator)
+                + File.separator 
+                + fileName);
             return readFromFile(templateFile, lineFrom, lineTo);
         }
         
@@ -109,7 +111,7 @@ public class SourceSnippetHelper {
         }
         
         BufferedReader in = new BufferedReader(
-                new InputStreamReader(is, StandardCharsets.UTF_8));
+                new InputStreamReader(is, Charsets.UTF_8));
         
         List<String> lines = new ArrayList<>();
   

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,8 @@
 Version 5.X.X
 =============
 
+
+ * 2016-04-05 Improve Ninja usability in Google AppEngine Environment (ra).
  * 2016-04-04 Flyway version bump to 4.0 (nate-kingsley).
  * 2016-03-18 Improved javadoc of Cache interface (ra).
 


### PR DESCRIPTION
This PR removes the nasty logging of a bogus
exception (when logging is configured via jdk logging
as needed eg in AppEngine).

The PR also removed the usage of nio.Path in dev 
mode because it is an AppEngine restricted class 
(Rewritten with File which works just fine).
