### PR TITLE
Fix another glitch to improve Ninja usability in Google AppEngine Environment

### DIFF
--- a/ninja-core/src/main/java/ninja/diagnostics/SourceSnippetHelper.java
+++ b/ninja-core/src/main/java/ninja/diagnostics/SourceSnippetHelper.java
@@ -61,8 +61,9 @@ public class SourceSnippetHelper {
                                                             int lineTo) throws IOException {
         // try to find source template as local file
         if (baseDirectory != null && templateRelativePath != null) {
-            File templateFile = baseDirectory.toPath()
-                .resolve(templateRelativePath).toFile();
+            File templateFile = new File(baseDirectory.getAbsolutePath()
+                    + File.separator
+                    + templateRelativePath);
             return readFromFile(templateFile, lineFrom, lineTo);
         }
         

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version 5.X.X
+=============
+
+ * 2016-04-08 Fixed another glitch to improve Ninja usability in Google AppEngine Environment (ra).
+
+
 Version 5.5.0
 =============
 


### PR DESCRIPTION
yea. another usage of path which is one of the prohibited classes in AppEngine. Improves usability. Just a rewrite with other classes - changes no functionality.
