### PR TITLE
fix issue #497

### DIFF
--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -171,7 +171,12 @@ public class Route {
      */
     protected static String convertRawUriToRegex(String rawUri) {
 
-        Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(rawUri);
+        // convert capturing groups in route regex to non-capturing groups
+        // this is to avoid count mismatch of path params and groups in uri regex
+        Matcher groupMatcher = Pattern.compile("\\((.*)\\)").matcher(rawUri);
+        String converted = groupMatcher.replaceAll("\\(?:$1\\)");
+
+        Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(converted);
 
         StringBuffer stringBuffer = new StringBuffer();
 

--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -173,7 +173,7 @@ public class Route {
 
         // convert capturing groups in route regex to non-capturing groups
         // this is to avoid count mismatch of path params and groups in uri regex
-        Matcher groupMatcher = Pattern.compile("\\((.*)\\)").matcher(rawUri);
+        Matcher groupMatcher = Pattern.compile("\\(([^?].*)\\)").matcher(rawUri);
         String converted = groupMatcher.replaceAll("\\(?:$1\\)");
 
         Matcher matcher = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(converted);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version X.Y.Z
+=============
+
+ * 2016-04-08 Fixed issue #497. Capturing groups in route regex. (bazi).
+
+
 Version 5.5.0
 =============
 

--- a/ninja-core/src/test/java/ninja/RouteTest.java
+++ b/ninja-core/src/test/java/ninja/RouteTest.java
@@ -48,6 +48,14 @@ public class RouteTest {
         assertThat(
                 Route.convertRawUriToRegex("/me/{id: \\d+}"),
                 CoreMatchers.equalTo("/me/(\\d+)"));
+
+        // check regex with groups, they should be converted to non-capturing groups
+        // people may want to have both "/users/mike" and "/mike" in one route
+        // https://github.com/ninjaframework/ninja/issues/497
+        assertThat(
+                Route.convertRawUriToRegex("(/users)?/{user}"),
+                CoreMatchers.equalTo("(?:/users)?/([^/]*)")
+        );
     }
     
 }


### PR DESCRIPTION
Fixes issue #497 

Capturing groups in routes cause mismatch of variable parts and groups in route regex.
To avoid such cases, all groups in a route are converted to non-capturing groups.
