### PR TITLE
Enhanced parsing of input values (post or parameters)

### DIFF
--- a/ninja-core/src/main/java/ninja/Bootstrap.java
+++ b/ninja-core/src/main/java/ninja/Bootstrap.java
@@ -209,7 +209,6 @@ public class Bootstrap {
             @Override
             protected void configure() {
                 bind(Ninja.class).to(ninjaClass).in(Singleton.class);
-                Multibinder.newSetBinder(binder(), ParamParser.class);
             }
         });
     }

--- a/ninja-core/src/main/java/ninja/Bootstrap.java
+++ b/ninja-core/src/main/java/ninja/Bootstrap.java
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import ninja.application.ApplicationRoutes;
-import ninja.lifecycle.LifecycleSupport;
 import ninja.logging.LogbackConfigurator;
-import ninja.scheduler.SchedulerSupport;
+import ninja.params.ParamParser;
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
 import ninja.utils.NinjaPropertiesImpl;
@@ -38,6 +37,8 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
+import com.google.inject.multibindings.Multibinder;
+
 import ninja.conf.FrameworkModule;
 import ninja.conf.NinjaBaseModule;
 import ninja.conf.NinjaClassicModule;
@@ -208,6 +209,7 @@ public class Bootstrap {
             @Override
             protected void configure() {
                 bind(Ninja.class).to(ninjaClass).in(Singleton.class);
+                Multibinder.newSetBinder(binder(), ParamParser.class);
             }
         });
     }

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -65,7 +65,7 @@ public class BodyParserEnginePost implements BodyParserEngine {
             return null;
         }
 
-        for(String declaredField : getAllDeclaredFieldsAsStringSet(classOfT)) {
+        for (String declaredField : getAllDeclaredFieldsAsStringSet(classOfT)) {
 
             try {
 
@@ -109,7 +109,7 @@ public class BodyParserEnginePost implements BodyParserEngine {
                 } else {
                     
                     // Check if we have a parameter key corresponding to inner attributes of this field
-                    for(String parameter : context.getParameters().keySet()) {
+                    for (String parameter : context.getParameters().keySet()) {
                         if(parameter.startsWith(paramPrefix + declaredField + ".")) {
                             field.set(t, invoke(context, fieldType, paramPrefix + declaredField + "."));
                             break;

--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -19,17 +19,21 @@ package ninja.bodyparser;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
-import java.util.Map.Entry;
+import java.util.List;
 import java.util.Set;
 
 import ninja.ContentTypes;
 import ninja.Context;
-import ninja.utils.SwissKnife;
+import ninja.params.ParamParser;
+import ninja.params.ParamParsers;
+import ninja.params.ParamParsers.ArrayParamParser;
+import ninja.params.ParamParsers.ListParamParser;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
@@ -37,8 +41,20 @@ public class BodyParserEnginePost implements BodyParserEngine {
 
     private final Logger logger = LoggerFactory.getLogger(BodyParserEnginePost.class);
 
+    private final ParamParsers paramParsers;
+
+    @Inject
+    public BodyParserEnginePost(ParamParsers paramParsers) {
+        this.paramParsers = paramParsers;
+    }
+    
     @Override
     public <T> T invoke(Context context, Class<T> classOfT) {
+        return invoke(context, classOfT, "");
+    }
+    
+    // Allows to instantiate inner objects with a prefix for each parameter key
+    private <T> T invoke(Context context, Class<T> classOfT, String paramPrefix) {
         
         T t = null;
 
@@ -49,46 +65,67 @@ public class BodyParserEnginePost implements BodyParserEngine {
             return null;
         }
 
-        Set<String> declaredFields = getAllDeclaredFieldsAsStringSet(classOfT);
+        for(String declaredField : getAllDeclaredFieldsAsStringSet(classOfT)) {
 
-        for (Entry<String, String[]> ent : context.getParameters().entrySet()) {
+            try {
 
-            if (declaredFields.contains(ent.getKey())) {
+                Field field = classOfT.getDeclaredField(declaredField);
+                Class<?> fieldType = field.getType();
+                field.setAccessible(true);
 
-                try {
+                if (context.getParameters().containsKey(paramPrefix + declaredField)) {
+                    
+                    String[] values = context.getParameters().get(paramPrefix + declaredField);
 
-                    Field field = classOfT.getDeclaredField(ent.getKey());
-                    Class<?> fieldType = field.getType();
-                    field.setAccessible(true);
+                    if (Collection.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
 
-                    String[] values = ent.getValue();
-                    Object convertedValue;
+                        ListParamParser<?> parser = (ListParamParser<?>) paramParsers.getListParser(getGenericType(field));
+                        if (parser == null) {
+                            logger.warn("No parser defined for a collection of type {}", getGenericType(field).getCanonicalName());
+                        } else {
+                            field.set(t, parser.parseParameter(field.getName(), values, context.getValidation()));
+                        }
 
-                    // convert the values based on the field type,
-                    // supported types are collections, arrays and boxed primities
-
-                    if (Collection.class.isAssignableFrom(fieldType)) {
-                        convertedValue = SwissKnife.convertCollection(values, getGenericType(field));
                     } else if (fieldType.isArray()) {
-                        convertedValue = SwissKnife.convertArray(values, fieldType.getComponentType());
+
+                        ArrayParamParser<?> parser = paramParsers.getArrayParser(fieldType);
+                        if (parser == null) {
+                            logger.warn("No parser defined for an array of type {}", fieldType.getComponentType().getCanonicalName());
+                        } else {
+                            field.set(t, parser.parseParameter(field.getName(), values, context.getValidation()));
+                        }
+
                     } else {
-                        convertedValue = SwissKnife.convert(values[0], fieldType);
+
+                        ParamParser<?> parser = (ParamParser<?>) paramParsers.getParamParser(fieldType);
+                        if (parser == null) {
+                            logger.warn("No parser defined for type {}", fieldType.getCanonicalName());
+                        } else {
+                            field.set(t, parser.parseParameter(field.getName(), values[0], context.getValidation()));
+                        }
+
                     }
 
-                    if (convertedValue != null) {
-                        field.set(t, convertedValue);
+                } else {
+                    
+                    // Check if we have a parameter key corresponding to inner attributes of this field
+                    for(String parameter : context.getParameters().keySet()) {
+                        if(parameter.startsWith(paramPrefix + declaredField + ".")) {
+                            field.set(t, invoke(context, fieldType, paramPrefix + declaredField + "."));
+                            break;
+                        }
                     }
-
-                } catch (NoSuchFieldException 
-                        | SecurityException 
-                        | IllegalArgumentException 
-                        | IllegalAccessException e) {
-
-                    logger.warn(
-                            "Error parsing incoming Post request into class {}. Key {} and value {}.", 
-                            classOfT.getName(), ent.getKey(), ent.getValue(), e);
+                    
                 }
 
+            } catch (NoSuchFieldException 
+                    | SecurityException 
+                    | IllegalArgumentException 
+                    | IllegalAccessException e) {
+
+                logger.warn(
+                        "Error parsing incoming Post request into class {}. Key {} and value {}.", 
+                        classOfT.getName(), paramPrefix + declaredField, context.getParameters().get(paramPrefix + declaredField), e);
             }
 
         }

--- a/ninja-core/src/main/java/ninja/conf/NinjaBaseModule.java
+++ b/ninja-core/src/main/java/ninja/conf/NinjaBaseModule.java
@@ -25,7 +25,10 @@ import org.slf4j.Logger;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+
 import ninja.lifecycle.LifecycleSupport;
+import ninja.params.ParamParser;
 import ninja.scheduler.SchedulerSupport;
 
 /**
@@ -50,6 +53,7 @@ public class NinjaBaseModule extends AbstractModule {
         install(SchedulerSupport.getModule());
         
         // Routing
+        Multibinder.newSetBinder(binder(), ParamParser.class);
         bind(RouteBuilder.class).to(RouteBuilderImpl.class);
         bind(Router.class).to(RouterImpl.class).in(Singleton.class);
 

--- a/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
+++ b/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
@@ -200,7 +200,7 @@ public class ControllerMethodInvoker {
             if (extractor.getFieldName() != null) {
                 if (String.class.isAssignableFrom(extractor.getExtractedType())) {
                     // Look up a parser for a single-valued parameter
-                    ParamParser<?> parser = ParamParsers.getParamParser(paramType);
+                    ParamParser<?> parser = injector.getInstance(ParamParsers.class).getParamParser(paramType);
                     if (parser == null) {
                         throw new RoutingException("Can't find parameter parser for type "
                                 + extractor.getExtractedType() + " on field "
@@ -211,7 +211,7 @@ public class ControllerMethodInvoker {
                     }
                 } else if (String[].class.isAssignableFrom(extractor.getExtractedType())) {
                     // Look up a parser for a multi-valued parameter
-                    ArrayParamParser<?> parser = ParamParsers.getArrayParser(paramType);
+                    ArrayParamParser<?> parser = injector.getInstance(ParamParsers.class).getArrayParser(paramType);
                     if (parser == null) {
                         throw new RoutingException("Can't find parameter array parser for type "
                                 + extractor.getExtractedType() + " on field "

--- a/ninja-core/src/main/java/ninja/params/ParamParsers.java
+++ b/ninja-core/src/main/java/ninja/params/ParamParsers.java
@@ -506,15 +506,6 @@ public class ParamParsers {
             if (parameterValue == null || parameterValue.isEmpty() || validation.hasFieldViolation(field)) {
                 return null;
             } else {
-//                try {
-//                    return Enum.valueOf(targetType, parameterValue);
-//                }
-//                catch(IllegalArgumentException e) {
-//                    validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
-//                            IsEnum.KEY, field, IsEnum.MESSAGE, new Object[] {parameterValue, getParsedType().getName()}));
-//                    return null;
-//                }
-                
                 // Equals ignore case will keep backward compatibility                
                 for (E value : getParsedType().getEnumConstants()) {
                     if (value.name().equalsIgnoreCase(parameterValue)) {

--- a/ninja-core/src/main/java/ninja/validation/IsDate.java
+++ b/ninja-core/src/main/java/ninja/validation/IsDate.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that the field is a date. Only needed if you want
+ * to customise the validation messages.
+ * 
+ * @author James Roper
+ */
+@WithValidator(Validators.DateValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface IsDate {
+    /**
+     * The key for the violation message
+     * 
+     * @return The key of the violation message
+     */
+    String key() default KEY;
+
+    /**
+     * Default message if the key isn't found
+     * 
+     * @return The default message
+     */
+    String message() default MESSAGE;
+
+    /**
+     * The key for formatting the field
+     * 
+     * @return The key
+     */
+    String fieldKey() default "";
+
+    public static final String KEY = "validation.is.date.violation";
+    public static final String MESSAGE = "{0} must be a valid date";
+}

--- a/ninja-core/src/main/java/ninja/validation/Validation.java
+++ b/ninja-core/src/main/java/ninja/validation/Validation.java
@@ -138,4 +138,12 @@ public interface Validation {
      */
     List<FieldViolation> getBeanViolations();
 
+    /**
+     * Get a complete list of bean violations for a specified field. This list DOES NOT contain
+     * general violations
+     * (use getGeneralViolations() instead).
+     * 
+     * @return A List of FieldViolation-objects
+     */
+    List<FieldViolation> getBeanViolations(String fieldName);
 }

--- a/ninja-core/src/main/java/ninja/validation/ValidationImpl.java
+++ b/ninja-core/src/main/java/ninja/validation/ValidationImpl.java
@@ -16,20 +16,24 @@
 
 package ninja.validation;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  * Validation object
  *
  * @author James Roper
  * @author Philip Sommer
+ * @author Jonathan Lannoy
  */
 public class ValidationImpl implements Validation {
 
-    private final List<FieldViolation> fieldViolations = new ArrayList<FieldViolation>();
-    private final List<ConstraintViolation> generalViolations = new ArrayList<ConstraintViolation>();
-    private final List<FieldViolation> beanViolations = new ArrayList<FieldViolation>();
+    private final Map<String, List<FieldViolation>> fieldViolations = Maps.newHashMap();
+    private final List<ConstraintViolation> generalViolations = Lists.newArrayList();
+    private final Map<String, List<FieldViolation>> beanViolations = Maps.newHashMap();
 
     @Override
     public boolean hasViolations() {
@@ -42,7 +46,10 @@ public class ValidationImpl implements Validation {
         if (fieldViolation.field == null) {
             this.generalViolations.add(fieldViolation.constraintViolation);
         } else {
-            this.fieldViolations.add(fieldViolation);
+            if(!this.fieldViolations.containsKey(fieldViolation.field)) {
+                this.fieldViolations.put(fieldViolation.field, Lists.<FieldViolation>newArrayList());
+            }
+            this.fieldViolations.get(fieldViolation.field).add(fieldViolation);
         }
     }
 
@@ -53,43 +60,34 @@ public class ValidationImpl implements Validation {
 
     @Override
     public boolean hasFieldViolation(String field) {
-        for (FieldViolation fieldViolation : this.fieldViolations) {
-            if (fieldViolation.field.contentEquals(field)) {
-                return true;
-            }
-        }
-        return false;
+        return this.fieldViolations.containsKey(field);
     }
 
     @Override
     public List<FieldViolation> getFieldViolations() {
-        return this.fieldViolations;
+        List<FieldViolation> sumViolations = Lists.newArrayList();
+        for(List<FieldViolation> fieldViolation : this.fieldViolations.values()) {
+            sumViolations.addAll(fieldViolation);
+        }
+        return sumViolations;
     }
 
     @Override
     public List<FieldViolation> getFieldViolations(String field) {
-        List<FieldViolation> violationsForThisField = new ArrayList<FieldViolation>();
-        for (FieldViolation fieldViolation : this.fieldViolations) {
-            if (fieldViolation.field.contentEquals(field)) {
-                violationsForThisField.add(fieldViolation);
-            }
-        }
-        return violationsForThisField;
+        return this.fieldViolations.get(field);
     }
 
     @Override
     public void addBeanViolation(FieldViolation fieldViolation) {
-        this.beanViolations.add(fieldViolation);
+        if(!this.beanViolations.containsKey(fieldViolation.field)) {
+            this.beanViolations.put(fieldViolation.field, Lists.<FieldViolation>newArrayList());
+        }
+        this.beanViolations.get(fieldViolation.field).add(fieldViolation);
     }
 
     @Override
     public boolean hasBeanViolation(String field) {
-        for (FieldViolation beanViolation : this.beanViolations) {
-            if (beanViolation.field.contentEquals(field)) {
-                return true;
-            }
-        }
-        return false;
+        return this.beanViolations.containsKey(field);
     }
 
     @Override
@@ -99,7 +97,16 @@ public class ValidationImpl implements Validation {
 
     @Override
     public List<FieldViolation> getBeanViolations() {
-        return this.beanViolations;
+        List<FieldViolation> sumViolations = Lists.newArrayList();
+        for(List<FieldViolation> fieldViolation : this.beanViolations.values()) {
+            sumViolations.addAll(fieldViolation);
+        }
+        return sumViolations;
+    }
+    
+    @Override
+    public List<FieldViolation> getBeanViolations(String field) {
+        return this.beanViolations.get(field);
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/validation/Validators.java
+++ b/ninja-core/src/main/java/ninja/validation/Validators.java
@@ -266,6 +266,41 @@ public class Validators {
         }
     }
 
+    public static class DateValidator implements Validator<String> {
+
+        private final IsDate isDate;
+
+        public DateValidator(IsDate aDate) {
+            this.isDate = aDate;
+        }
+
+        /**
+         * Validate the given value
+         *
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
+         */
+        @Override
+        public void validate(String value, String field, Context context) {
+            if (value != null) {
+                try {
+                    Double.parseDouble(value);
+                } catch (NumberFormatException e) {
+                    context.getValidation().addFieldViolation(field, ConstraintViolation
+                            .createForFieldWithDefault(this.isDate.key(),
+                                    fieldKey(field, this.isDate.fieldKey()),
+                                    this.isDate.message(), value));
+                }
+            }
+        }
+
+        @Override
+        public Class<String> getValidatedType() {
+            return String.class;
+        }
+    }
+    
     public static class MatchesValidator implements Validator<String> {
 
         private final Matches matches;

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,9 @@
 Version X.Y.Z
 =============
 
+ * 2016-04-15 Documentation for Validation enhanced (jlannoy)
+ * 2016-04-15 SwissKnife converters replaced by usage of ParamParsers in BodyPostEngine (jlannoy)
+ * 2016-04-15 Support for enumeration value (registration deprecated), custom types parsing and POST objects parsing (jlannoy)
  * 2016-04-08 Fixed issue #497. Capturing groups in route regex. (bazi).
  * 2016-04-08 Fixed another glitch to improve Ninja usability in Google AppEngine Environment (ra).
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
@@ -27,13 +27,25 @@ This allows you to process a request, extract things
 - Long (long)
 - Float (float)
 - Double (double)
-- Enum *requires runtime class registration in your conf.Module*
+- Enum (any)
 - Arrays of all these types (e.g. String[], int[], Enum[])
 
-**NOTE:**
-Collections and generics are not supported for parameter injection.  Types
-must be explicitly declared and basic arrays must be used to ensure runtime
-type-safety.
+**NOTES:**
+Enums do not require anymore a registration in conf.Module. Values are 
+converted automatically, ignoring case. Collections and generics are not 
+supported for parameter injection. Types must be explicitly declared 
+and basic arrays must be used to ensure runtime type-safety.
+
+### Custom Parameter Types
+
+You can also add your own supported type to Ninja, or override and existing one, 
+simply by implementing the <code>ParamParser</code> interface and binding it 
+with Guice in your conf.Module <code>configure()</code> method:
+
+<pre class="prettyprint">
+Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+parsersBinder.addBinding().to(MyParamParser.class);
+</pre>
  
 
 How to write an argument extractor

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
@@ -120,15 +120,31 @@ request - parameters, headers and so on...
 
 Even better: Ninja will parse an arbitrary object given in the method.
 In the above case MyObject will be automatically parsed by Ninja. The way
-it will parsed (JSON, XML, PostForm) will be determined via the "Content-Type" request header.
+it will parsed (JSON, XML, POST form) will be determined via the "Content-Type" request header.
+
+If you are using the POST form way, this object can contains any parameter type listed in the 
+<a href="http://www.ninjaframework.org/documentation/basic_concepts/argument_extractors.html">Argument extractors</a> 
+chapter (or custom ones, as described in the same chapter). Custom objects contained in this 
+arbitrary object can also be parsed if they have a constructor without arguments.
+
+<pre class="prettyprint">
+public class Address {
+    String street;
+}
+
+public class User {
+    Address address;
+}
+</pre>
+
+Assuming your controller method want to receive a User object, your HTML form can send a field 
+value for the key <code>address.street</code>.
+
 If your custom object has a date/timestamp field, first make sure that you use the 
 <a href="http://docs.oracle.com/javase/7/docs/api/java/util/Date.html">java.util.Date</a> 
 type and when you pass some date to the controller pass in the 
-<a href="http://joda-time.sourceforge.net/api-release/org/joda/time/format/ISODateTimeFormat.html#localDateOptionalTimeParser%28%29">format</a> 
-accepted by Joda Time library.
-
-Therefore you don't have to worry if
-input is for instance XML or JSON. You simply get a parsed object.
+<a href="http://joda-time.sourceforge.net/api-release/org/joda/time/format/ISODateTimeFormat.html#localDateOptionalTimeParser%28%29">format</a> accepted by Joda Time library, or implement your own 
+<code>ParamParser</code> for a java.util.Date.
 
 
 ## Ninja and content negotiation

--- a/ninja-core/src/site/markdown/documentation/validation.md
+++ b/ninja-core/src/site/markdown/documentation/validation.md
@@ -1,8 +1,25 @@
 Validation
 =========
 
-Introduction
-------------
+Parameters validation
+---------------------
+
+When using a parameter either as controller method argument or as a DTO field value, 
+if you're using one of the default supported type (see the Argument Extractors chapter 
+for more information), it may produce a conversion error. For example when you are 
+expecting an integer for your field but the given value contains characters.
+
+In such cases, conversion issues are available in the
+<code>validation</code>-parameter by calling the 
+<code>validation.hasFieldViolations()</code>-method in your 
+controller which gives you a <code>true</code> or <code>false</code>.
+You have the ability to check which parameters
+caused the violations by using the <code>getFieldViolations()</code> method.
+Note that these violations must still be translated by using the <code>messageKey</code> 
+attribute of each violation object.
+
+Bean validation
+---------------
 
 Ninja uses Hibernate's implementation of the <code>javax.validation</code> feature. 
 This means that all JSR303-defined annotations work in your 
@@ -46,13 +63,13 @@ controller which gives you a <code>true</code> or <code>false</code>.
 You have the ability to check which field(s) inside your Dto
 caused the violations by using the <code>getBeanViolations()</code> 
 method which gives you a complete list of all occured violations in your Dto.
-
-Conclusion
-----------
+With bean violations, the <code>messageKey</code> of each violation represents 
+an interpolated message using the current locale.
 
 JSR303 based validation is a generic approach that allows you to check 
 the validity of submitted objects. These objects can be sent to your application
-via HTTP form submission, JSON or XML.
+via HTTP form submission, JSON or XML. The only important part is that your DTO 
+objects contain valid JSR303 validation annotation which Ninja can evaluate.
 
 The only important part is that your DTO objects contain valid JSR303 validation
 annotation which Ninja can evaluate.

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEngineManagerImplTest.java
@@ -26,6 +26,7 @@ import ninja.Router;
 import ninja.RouterImpl;
 import ninja.i18n.Lang;
 import ninja.i18n.LangImpl;
+import ninja.params.ParamParser;
 import ninja.utils.LoggerProvider;
 import ninja.utils.NinjaMode;
 import ninja.utils.NinjaProperties;
@@ -38,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
 
 public class BodyParserEngineManagerImplTest {
 
@@ -60,6 +62,8 @@ public class BodyParserEngineManagerImplTest {
 
                 bind(Logger.class).toProvider(LoggerProvider.class);
                 bind(Lang.class).to(LangImpl.class);
+                
+                Multibinder.newSetBinder(binder(), ParamParser.class);
                 bind(Router.class).to(RouterImpl.class);
 
                 bind(BodyParserEnginePost.class);

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEnginePostTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEnginePostTest.java
@@ -17,21 +17,46 @@
 package ninja.bodyparser;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.constraints.NotNull;
+
 import ninja.Context;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaProperties;
+import ninja.utils.NinjaPropertiesImpl;
+import ninja.params.ControllerMethodInvokerTest.Dep;
+import ninja.params.ControllerMethodInvokerTest.NeedingInjectionParamParser;
+import ninja.params.ParamParser;
+import ninja.validation.FieldViolation;
+import ninja.validation.IsDate;
+import ninja.validation.IsFloat;
+import ninja.validation.IsInteger;
+import ninja.validation.Validation;
+import ninja.validation.ValidationImpl;
 
 import org.hamcrest.CoreMatchers;
 import org.joda.time.LocalDateTime;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
 
 /**
  *
@@ -41,7 +66,29 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class BodyParserEnginePostTest {
     
     @Mock
-    Context context; 
+    Context context;
+    
+    Validation validation;
+    
+    BodyParserEnginePost bodyParserEnginePost; 
+    
+    @Before
+    public void setUp() {
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(NinjaProperties.class).toInstance(new NinjaPropertiesImpl(NinjaMode.test));
+                
+                Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+                parsersBinder.addBinding().to(NeedingInjectionParamParser.class);
+            }
+        });
+        
+        validation = new ValidationImpl();
+        Mockito.when(this.context.getValidation()).thenReturn(this.validation);
+        
+        bodyParserEnginePost = injector.getInstance(BodyParserEnginePost.class);
+    }
 
     @Test
     public void testBodyParser() {
@@ -51,24 +98,100 @@ public class BodyParserEnginePostTest {
         String dateTimeString = "2014-10-10T20:09:10";
 
         Map<String, String[]> map = new HashMap<>();
-        map.put("integer", new String [] {"1000"});
+        map.put("integerPrimitive", new String [] {"1000"});
+        map.put("integerObject", new String [] {"2000"});
+        map.put("longPrimitive", new String [] {"3000"});
+        map.put("longObject", new String [] {"4000"});
+        map.put("floatPrimitive", new String [] {"1.234"});
+        map.put("floatObject", new String [] {"2.345"});
+        map.put("doublePrimitive", new String [] {"3.456"});
+        map.put("doubleObject", new String [] {"4.567"});
         map.put("string", new String [] {"aString"});
+        map.put("characterPrimitive", new String [] {"a"});
+        map.put("characterObject", new String [] {"b"});
         map.put("date", new String[]{dateString});
         map.put("timestamp", new String[]{dateTimeString});
         map.put("somethingElseWhatShouldBeSkipped", new String [] {"somethingElseWhatShouldBeSkipped"});
 
         Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
 
         // do
-        BodyParserEnginePost bodyParserEnginePost = new BodyParserEnginePost();       
         TestObject testObject = bodyParserEnginePost.invoke(context, TestObject.class);
         
         // and test:
+        assertThat(testObject.integerPrimitive, CoreMatchers.equalTo(1000));
+        assertThat(testObject.integerObject, CoreMatchers.equalTo(2000));
+        assertThat(testObject.longPrimitive, CoreMatchers.equalTo(3000L));
+        assertThat(testObject.longObject, CoreMatchers.equalTo(4000L));
+        assertThat(testObject.floatPrimitive, CoreMatchers.equalTo(1.234F));
+        assertThat(testObject.floatObject, CoreMatchers.equalTo(2.345F));
+        assertThat(testObject.doublePrimitive, CoreMatchers.equalTo(3.456D));
+        assertThat(testObject.doubleObject, CoreMatchers.equalTo(4.567D));
         assertThat(testObject.string, equalTo("aString"));
-        assertThat(testObject.integer, CoreMatchers.equalTo(1000));
+        assertThat(testObject.characterPrimitive, equalTo('a'));
+        assertThat(testObject.characterObject, equalTo('b'));
         assertThat(testObject.date, CoreMatchers.equalTo(new LocalDateTime(dateString).toDate()));
         assertThat(testObject.timestamp, CoreMatchers.equalTo(new LocalDateTime(dateTimeString).toDate()));
         
+        assertFalse(validation.hasViolations());
+        
+    }
+    
+    @Test
+    public void testBodyParserWithValidationErrors() {
+
+        // some setup for this method:
+        Map<String, String[]> map = new HashMap<>();
+        map.put("integerPrimitive", new String [] {"a"});
+        map.put("integerObject", new String [] {"b"});
+        map.put("longPrimitive", new String [] {"c"});
+        map.put("longObject", new String [] {"d"});
+        map.put("floatPrimitive", new String [] {"e"});
+        map.put("floatObject", new String [] {"f"});
+        map.put("doublePrimitive", new String [] {"g"});
+        map.put("doubleObject", new String [] {"h"});
+        map.put("characterPrimitive", new String [] {null});
+        map.put("characterObject", new String [] {null});
+        map.put("date", new String[]{"cc"});
+        map.put("timestamp", new String[]{"dd"});
+        map.put("somethingElseWhatShouldBeSkipped", new String [] {"somethingElseWhatShouldBeSkipped"});
+
+        Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
+
+        // do
+        TestObject testObject = bodyParserEnginePost.invoke(context, TestObject.class);
+        
+        // and test:
+        assertTrue(validation.hasViolations());
+        assertViolation("integerPrimitive", IsInteger.KEY);
+        assertThat(testObject.integerPrimitive, equalTo(0));
+        assertViolation("integerObject", IsInteger.KEY);
+        assertNull(testObject.integerObject);
+        assertViolation("longPrimitive", IsInteger.KEY);
+        assertThat(testObject.longPrimitive, equalTo(0L));
+        assertViolation("longObject", IsInteger.KEY);
+        assertNull(testObject.longObject);
+        assertViolation("floatPrimitive", IsFloat.KEY);
+        assertThat(testObject.floatPrimitive, equalTo(0F));
+        assertViolation("floatObject", IsFloat.KEY);
+        assertNull(testObject.floatObject);
+        assertViolation("doublePrimitive", IsFloat.KEY);
+        assertThat(testObject.doublePrimitive, equalTo(0D));
+        assertViolation("doubleObject", IsFloat.KEY);
+        assertNull(testObject.doubleObject);
+        
+        assertViolation("date", IsDate.KEY);
+        assertNull(testObject.date);
+        assertViolation("timestamp", IsDate.KEY);
+        assertNull(testObject.timestamp);
+        
+        assertNull(testObject.string);
+        assertThat(testObject.characterPrimitive, equalTo('\0'));
+        assertNull(testObject.characterObject);
+        
+        assertNull(testObject.string);
     }
     
     @Test
@@ -81,9 +204,9 @@ public class BodyParserEnginePostTest {
         map.put("longs", new String[] {"1", "2"});
         
         Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
 
         // do
-        BodyParserEnginePost bodyParserEnginePost = new BodyParserEnginePost();       
         TestObjectWithUnsupportedFields testObject = bodyParserEnginePost.invoke(context, TestObjectWithUnsupportedFields.class);
         
         // and test:
@@ -101,9 +224,9 @@ public class BodyParserEnginePostTest {
         map.put("strings", new String[] {"hello", "world"});
 
         Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
 
         // do
-        BodyParserEnginePost bodyParserEnginePost = new BodyParserEnginePost();
         TestObjectWithArraysAndCollections testObject = bodyParserEnginePost.invoke(context, TestObjectWithArraysAndCollections.class);
 
         // and test:
@@ -114,17 +237,117 @@ public class BodyParserEnginePostTest {
         assertThat(testObject.strings.size(), equalTo(2));
         assertThat(testObject.strings.get(0), equalTo("hello"));
         assertThat(testObject.strings.get(1), equalTo("world"));
+        
+        assertFalse(validation.hasViolations());
+        
     }
 
+    @Test
+    public void testBodyParserWithEnumerations() {
+
+        // some setup for this method:
+        Map<String, String[]> map = new HashMap<>();
+        map.put("enum1", new String[] {MyEnum.VALUE_A.name()});
+        map.put("enum2", new String[] {new String("value_b")});
+
+        Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
+
+        // do
+        TestObjectWithEnum testObject = bodyParserEnginePost.invoke(context, TestObjectWithEnum.class);
+        
+        // and test:
+        assertThat(testObject.enum1, equalTo(MyEnum.VALUE_A));
+        assertThat(testObject.enum2, equalTo(MyEnum.VALUE_B));
+        assertFalse(validation.hasViolations());
+        
+    }
     
+    @Test
+    public void testBodyParserWithCustomNeedingInjectionParamParser() {
+        // some setup for this method:
+        Map<String, String[]> map = new HashMap<>();
+        map.put("dep", new String[] {"dep1"});
+        map.put("depArray", new String[] {"depArray1", "depArray2"});
+        map.put("depList", new String[] {"depList1", "depList2"});
+        
+        Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
+
+        // do
+        TestObjectWithCustomType testObject = bodyParserEnginePost.invoke(context, TestObjectWithCustomType.class);
+        
+        // and test:
+        assertThat(testObject.dep, equalTo(new Dep("hello_dep1")));
+        
+        assertNotNull(testObject.depArray);
+        assertThat(testObject.depArray.length, equalTo(2));
+        assertThat(testObject.depArray[0], equalTo(new Dep("hello_depArray1")));
+        assertThat(testObject.depArray[1], equalTo(new Dep("hello_depArray2")));
+        
+        assertNotNull(testObject.depList);
+        assertThat(testObject.depList.size(), equalTo(2));
+        assertThat(testObject.depList.get(0), equalTo(new Dep("hello_depList1")));
+        assertThat(testObject.depList.get(1), equalTo(new Dep("hello_depList2")));
+        
+        assertFalse(validation.hasViolations());
+    }
     
+    @Test
+    public void testBodyParserWithInnerObjects() {
+        // some setup for this method:
+        Map<String, String[]> map = new HashMap<>();
+        map.put("object1.integerPrimitive", new String [] {"1000"});
+        map.put("object1.integerObject", new String [] {"2000"});
+        map.put("object2.integerPrimitive", new String [] {"3000"});
+        map.put("object2.integerObject", new String [] {"4000"});
+        
+        Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
+
+        // do
+        TestObjectWithInnerObjects testObject = bodyParserEnginePost.invoke(context, TestObjectWithInnerObjects.class);
+        
+        // and test:
+        assertNotNull(testObject.object1);
+        assertThat(testObject.object1.integerPrimitive, equalTo(1000));
+        assertThat(testObject.object1.integerObject, equalTo(2000));
+        
+        assertNotNull(testObject.object2);
+        assertThat(testObject.object2.integerPrimitive, equalTo(3000));
+        assertThat(testObject.object2.integerObject, equalTo(4000));
+        
+        assertFalse(validation.hasViolations());
+    }
+    
+    private <T> void assertViolation(String fieldName, String violationMessage) {
+        assertTrue(validation.hasFieldViolation(fieldName));
+        assertFalse(validation.getFieldViolations().isEmpty());
+        assertThat(validation.getFieldViolations(fieldName).size(), equalTo(1));
+        FieldViolation violation = validation.getFieldViolations(fieldName).get(0);
+        assertThat(violation.field, equalTo(fieldName));
+        assertNotNull(violation.constraintViolation);
+        assertThat(violation.constraintViolation.getFieldKey(), equalTo(fieldName));
+        assertThat(violation.constraintViolation.getMessageKey(), equalTo(violationMessage));
+    }
     
     public static class TestObject {
     
-        public int integer;
+        public int integerPrimitive;
+        public Integer integerObject;
+        public long longPrimitive;
+        public Long longObject;
+        public float floatPrimitive;
+        public Float floatObject;
+        public double doublePrimitive;
+        public Double doubleObject;
         public String string;
-        public java.util.Date date;
-        public java.util.Date timestamp;
+        public char characterPrimitive;
+        public Character characterObject;
+        public Date date;
+        public Date timestamp;
+        @NotNull
+        public Object requiredObject;
 
     }
     
@@ -140,6 +363,32 @@ public class BodyParserEnginePostTest {
 
         public Integer[] integers;
         public List<String> strings;
+
+    }
+    
+    public static enum MyEnum {
+        VALUE_A, VALUE_B, VALUE_C
+    }
+    
+    public static class TestObjectWithEnum {
+        
+        public MyEnum enum1;
+        public MyEnum enum2;
+
+    }
+    
+    public static class TestObjectWithCustomType {
+        
+        public Dep dep;
+        public Dep[] depArray;
+        public List<Dep> depList;
+
+    }
+    
+    public static class TestObjectWithInnerObjects {
+        
+        public TestObject object1;
+        public TestObject object2;
 
     }
     

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -19,6 +19,8 @@ package ninja.params;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.multibindings.Multibinder;
+
 import ninja.Context;
 import ninja.Result;
 import ninja.RoutingException;
@@ -30,6 +32,8 @@ import ninja.utils.NinjaMode;
 import ninja.utils.NinjaProperties;
 import ninja.utils.NinjaPropertiesImpl;
 import ninja.validation.*;
+
+import org.joda.time.LocalDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,8 +49,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
@@ -499,126 +506,135 @@ public class ControllerMethodInvokerTest {
 
     @Test
     public void enumParamShouldBeParsedToEnumCaseSensitive() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameter("param1")).thenReturn("Red");
         create("enumParam").invoke(mockController, context);
         verify(mockController).enumParam(Rainbow.Red);
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumParamShouldBeParsedToEnumCaseInsensitive() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class, false);
         when(context.getParameter("param1")).thenReturn("red");
         create("enumParam").invoke(mockController, context);
         verify(mockController).enumParam(Rainbow.Red);
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumParamShouldHandleNull() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         create("enumParam").invoke(mockController, context);
         verify(mockController).enumParam(null);
         assertFalse(validation.hasViolations());
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumParamValidationShouldWork() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameter("param1")).thenReturn("blah");
         create("enumParam").invoke(mockController, context);
         verify(mockController).enumParam(null);
         assertTrue(validation.hasFieldViolation("param1"));
-        ParamParsers.unregisterEnum(Rainbow.class);
-    }
-
-    @Test
-    public void enumParamUnregisteredShouldFail() throws Exception {
-        try {
-            when(context.getParameter("param1")).thenReturn("red");
-            create("enumParam").invoke(mockController, context);
-            assertTrue("Enum was unregistered! This should have failed.", false);
-        } catch (Exception e) {
-            assertTrue(e instanceof RoutingException);
-        }
     }
 
     @Test
     public void enumCsvParamSingleShouldBeParsed() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameter("param1")).thenReturn("Red");
         create("enumCsvParam").invoke(mockController, context);
         verify(mockController).enumCsvParam(new Rainbow[]{Rainbow.Red});
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumCsvParamMultipleShouldBeParsed() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameter("param1")).thenReturn("Red,Orange,Yellow");
         create("enumCsvParam").invoke(mockController, context);
         verify(mockController).enumCsvParam(new Rainbow[]{Rainbow.Red, Rainbow.Orange, Rainbow.Yellow});
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumCsvParamShouldReturnNull() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameter("param1")).thenReturn("");
         create("enumCsvParam").invoke(mockController, context);
         verify(mockController).enumCsvParam(null);
         assertFalse(validation.hasFieldViolation("param1"));
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumCsvParamValidationShouldWork() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
-        when(context.getParameter("param1")).thenReturn("red,orange,yellow");
+        when(context.getParameter("param1")).thenReturn("White,Black");
         create("enumCsvParam").invoke(mockController, context);
         verify(mockController).enumCsvParam(null);
         assertTrue(validation.hasFieldViolation("param1"));
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumArrayParamSingleShouldBeParsed() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameterValues("param1")).thenReturn(Arrays.asList("Blue"));
         create("enumArrayParam").invoke(mockController, context);
         verify(mockController).enumArrayParam(new Rainbow[]{Rainbow.Blue});
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumArrayParamMultipleShouldBeParsed() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameterValues("param1")).thenReturn(Arrays.asList("Blue", "Indigo", "Violet"));
         create("enumArrayParam").invoke(mockController, context);
         verify(mockController).enumArrayParam(new Rainbow[]{Rainbow.Blue, Rainbow.Indigo, Rainbow.Violet});
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumArrayParamShouldReturnNull() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
         when(context.getParameterValues("param1")).thenReturn(new ArrayList<String>());
         create("enumArrayParam").invoke(mockController, context);
         verify(mockController).enumArrayParam(null);
         assertFalse(validation.hasFieldViolation("param1"));
-        ParamParsers.unregisterEnum(Rainbow.class);
     }
 
     @Test
     public void enumArrayParamValidationShouldWork() throws Exception {
-        ParamParsers.registerEnum(Rainbow.class);
-        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("blue", "indigo", "violet"));
+        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("White", "Black"));
         create("enumArrayParam").invoke(mockController, context);
         verify(mockController).enumArrayParam(null);
         assertTrue(validation.hasFieldViolation("param1"));
-        ParamParsers.unregisterEnum(Rainbow.class);
+    }
+    
+    
+    @Test
+    public void customDateFormatParamShouldBeParsedToDate() throws Exception {
+        when(context.getParameter("param1")).thenReturn("15/01/2015");
+        create("dateParam", ninjaProperties, DateParamParser.class).invoke(mockController, context);
+        verify(mockController).dateParam(new LocalDateTime(2015, 1, 15, 0, 0).toDate());
+    }
+
+    @Test
+    public void customDateFormatParamShouldHandleNull() throws Exception {
+        create("dateParam", ninjaProperties, DateParamParser.class).invoke(mockController, context);
+        verify(mockController).dateParam(null);
+        assertFalse(validation.hasViolations());
+    }
+
+    @Test
+    public void customDateFormatValidationShouldWork() throws Exception {
+        when(context.getParameter("param1")).thenReturn("blah");
+        create("dateParam", ninjaProperties, DateParamParser.class).invoke(mockController, context);
+        verify(mockController).dateParam(null);
+        assertTrue(validation.hasFieldViolation("param1"));
+    }
+    
+    @Test(expected = RoutingException.class)
+    public void needingInjectionParamParserNotBinded() throws Exception {
+        when(context.getParameter("param1")).thenReturn("hello");
+        create("needingInjectionParamParser", ninjaProperties).invoke(mockController, context);
+        verify(mockController).needingInjectionParamParser(new Dep("hello_hello"));
+    }
+    
+    @Test
+    public void needingInjectionParamParser() throws Exception {
+        when(context.getParameter("param1")).thenReturn("hello");
+        create("needingInjectionParamParser", ninjaProperties, NeedingInjectionParamParser.class).invoke(mockController, context);
+        verify(mockController).needingInjectionParamParser(new Dep("hello_hello"));
+    }
+    
+    @Test
+    public void needingInjectionParamParserArray() throws Exception {
+        when(context.getParameterValues("param1")).thenReturn(Arrays.asList("hello1", "hello2"));
+        create("needingInjectionParamParserArray", ninjaProperties, NeedingInjectionParamParser.class).invoke(mockController, context);
+        verify(mockController).needingInjectionParamParserArray(new Dep[] { new Dep("hello_hello1"), new Dep("hello_hello2") });
     }
 
     @Test
@@ -838,8 +854,14 @@ public class ControllerMethodInvokerTest {
         return ControllerMethodInvoker.build(method, Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
+                Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+                
                 for (Object o : toBind) {
-                    bind((Class<Object>) o.getClass()).toInstance(o);
+                    if(o instanceof Class && ParamParser.class.isAssignableFrom((Class) o)) {
+                        parsersBinder.addBinding().to((Class<? extends ParamParser>) o);
+                    } else {
+                        bind((Class<Object>) o.getClass()).toInstance(o);
+                    }
                 }
             }
         }));
@@ -932,6 +954,12 @@ public class ControllerMethodInvokerTest {
         public Result JSR303Validation(@JSR303Validation Dto dto, Validation validation);
 
         public Result JSR303ValidationWithRequired(@Required @JSR303Validation Dto dto, Validation validation);
+        
+        public Result dateParam(@Param("param1") Date param1);
+        
+        public Result needingInjectionParamParser(@Param("param1") Dep param1);
+        
+        public Result needingInjectionParamParserArray(@Params("param1") Dep[] paramsArray);
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -992,6 +1020,51 @@ public class ControllerMethodInvokerTest {
             return null;
         }
     }
+    
+
+    public static class DateParamParser implements ParamParser<Date> {
+
+        public static final String DATE_FORMAT = "dd/MM/yyyy";
+        
+        public static final String KEY = "validation.is.date.violation";
+        
+        public static final String MESSAGE = "{0} must be a valid date";
+        
+        @Override
+        public Date parseParameter(String field, String parameterValue, Validation validation) {
+            try {
+                return parameterValue == null ? null : new SimpleDateFormat(DATE_FORMAT).parse(parameterValue);
+            } catch(ParseException e) {
+                validation.addFieldViolation(field, ConstraintViolation.createForFieldWithDefault(
+                        KEY, field, MESSAGE, parameterValue));
+                return null;
+            }
+        }
+
+        @Override
+        public Class<Date> getParsedType() {
+            return Date.class;
+        }
+
+    }
+    
+    public static class NeedingInjectionParamParser implements ParamParser<Dep> {
+
+        // In a real application, you can also use @Named as each properties is binded by its name
+        @Inject
+        NinjaProperties properties;
+        
+        @Override
+        public Dep parseParameter(String field, String parameterValue, Validation validation) {
+            return new Dep(properties.get("needingInjectionParamParser.value") + "_" + parameterValue);
+        }
+
+        @Override
+        public Class<Dep> getParsedType() {
+            return Dep.class;
+        }
+        
+    }
 
     /**
      * Argument extractor that has a complex constructor for Guice. It depends on some
@@ -1026,7 +1099,7 @@ public class ControllerMethodInvokerTest {
         }
     }
 
-    public class Dep {
+    public static class Dep {
 
         private final String value;
 
@@ -1036,6 +1109,31 @@ public class ControllerMethodInvokerTest {
 
         public String value() {
             return value;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Dep other = (Dep) obj;
+            if (value == null) {
+                if (other.value != null)
+                    return false;
+            } else if (!value.equals(other.value))
+                return false;
+            return true;
         }
     }
 

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextImpl.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import ninja.Cookie;
 import ninja.Result;
 import ninja.bodyparser.BodyParserEngineManager;
+import ninja.params.ParamParsers;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.uploads.FileItem;
@@ -36,8 +37,8 @@ import org.apache.commons.fileupload.FileItemIterator;
  */
 public class AbstractContextImpl extends AbstractContext {
 
-    public AbstractContextImpl(BodyParserEngineManager bodyParserEngineManager, FlashScope flashScope, NinjaProperties ninjaProperties, Session session, Validation validation, Injector injector) {
-        super(bodyParserEngineManager, flashScope, ninjaProperties, session, validation, injector);
+    public AbstractContextImpl(BodyParserEngineManager bodyParserEngineManager, FlashScope flashScope, NinjaProperties ninjaProperties, Session session, Validation validation, Injector injector, ParamParsers paramParsers) {
+        super(bodyParserEngineManager, flashScope, ninjaProperties, session, validation, injector, paramParsers);
     }
 
     @Override

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -17,6 +17,8 @@
 package ninja.utils;
 
 import com.google.common.collect.Maps;
+
+import java.util.HashSet;
 import java.util.Map;
 import ninja.ContentTypes;
 import ninja.Context;
@@ -26,6 +28,8 @@ import ninja.Results;
 import ninja.Route;
 import ninja.bodyparser.BodyParserEngine;
 import ninja.bodyparser.BodyParserEngineManager;
+import ninja.params.ParamParser;
+import ninja.params.ParamParsers;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.validation.Validation;
@@ -80,7 +84,8 @@ public class AbstractContextTest {
                 ninjaProperties,
                 sessionCookie,
                 validation,
-                null);
+                null,
+                new ParamParsers(new HashSet<ParamParser>()));
         
         abstractContext.init("", "/");
     }
@@ -214,7 +219,7 @@ public class AbstractContextTest {
 
     @Test
     public void getPathParameterAsInteger() {
-    	AbstractContextImpl context = spy(abstractContext);
+    	  AbstractContextImpl context = spy(abstractContext);
 
         //mock a parametermap:
         Map<String, String> parameterMap = Maps.newHashMap();

--- a/ninja-core/src/test/java/ninja/utils/SwissKnifeTest.java
+++ b/ninja-core/src/test/java/ninja/utils/SwissKnifeTest.java
@@ -32,39 +32,6 @@ public class SwissKnifeTest {
 
     }
 
-    @Test
-    public void testConvert() {
-        
-        String aString = "aString";
-        String str = "1024";
-        String doubleStr = "1024.24";
-        String boolStr = "true";
-        String byteStr = "89";
-        char charStr = 'x';
-        String emptyString = "";
-
-        assertEquals(Integer.valueOf(str), SwissKnife.convert(str, int.class));
-        assertEquals(Integer.valueOf(str), SwissKnife.convert(str, Integer.class));
-        assertEquals(Long.valueOf(str), SwissKnife.convert(str, long.class));
-        assertEquals(Float.valueOf(doubleStr), SwissKnife.convert(doubleStr, float.class));
-        assertEquals(Float.valueOf(doubleStr), SwissKnife.convert(doubleStr, Float.class));
-        assertEquals(Double.valueOf(doubleStr), SwissKnife.convert(doubleStr, double.class));
-        assertEquals(Double.valueOf(doubleStr), SwissKnife.convert(doubleStr, Double.class));
-        assertEquals(Boolean.valueOf(boolStr), SwissKnife.convert(boolStr, boolean.class));
-        assertEquals(Boolean.valueOf(boolStr), SwissKnife.convert(boolStr, Boolean.class));
-        assertEquals(Byte.valueOf(byteStr), SwissKnife.convert(byteStr, byte.class));
-        assertEquals(Byte.valueOf(byteStr), SwissKnife.convert(byteStr, Byte.class));
-        assertEquals(Character.valueOf(charStr), SwissKnife.convert(String.valueOf(charStr), char.class));
-        assertEquals(Character.valueOf(charStr), SwissKnife.convert(String.valueOf(charStr), Character.class));
-        assertEquals(null, SwissKnife.convert(String.valueOf(emptyString), char.class));
-        assertEquals(null, SwissKnife.convert(String.valueOf(emptyString), Character.class));
-        
-        assertEquals(null, SwissKnife.convert(String.valueOf(aString), StringBuffer.class));
-        assertEquals(null, SwissKnife.convert(String.valueOf(aString), Integer.class));
-        
-        assertEquals(aString, SwissKnife.convert(String.valueOf(aString), String.class));
-    }
-
     // just for testing that camel case conversion stuff works
     public class MySuperTestObject {
     }

--- a/ninja-core/src/test/resources/conf/application.conf
+++ b/ninja-core/src/test/resources/conf/application.conf
@@ -45,3 +45,5 @@ getMultipleElementStringArrayWithoutSpaces=one,me
 # make sure that the constants are okay in NinjaConstant.*
 application.session.transferred_over_https_only=false
 application.secret = secret
+
+needingInjectionParamParser.value=hello

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import ninja.Cookie;
 import ninja.Result;
 import ninja.bodyparser.BodyParserEngineManager;
+import ninja.params.ParamParsers;
 import ninja.servlet.async.AsyncStrategy;
 import ninja.servlet.async.AsyncStrategyFactoryHolder;
 import ninja.session.FlashScope;
@@ -97,14 +98,16 @@ public class NinjaServletContext extends AbstractContext {
             ResultHandler resultHandler,
             Session session,
             Validation validation,
-            Injector injector) {
+            Injector injector,
+            ParamParsers paramParsers) {
         
         super(bodyParserEngineManager,
               flashScope,
               ninjaProperties,
               session,
               validation,
-              injector);
+              injector,
+              paramParsers);
         
         this.resultHandler = resultHandler;
     }

--- a/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import ninja.Route;
 import ninja.bodyparser.BodyParserEngineManager;
+import ninja.params.ParamParser;
+import ninja.params.ParamParsers;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.uploads.FileItem;
@@ -142,7 +145,8 @@ public class MultipartContextImplMemoryTest {
                 resultHandler,
                 sessionCookie,
                 validation,
-                injector
+                injector,
+                new ParamParsers(new HashSet<ParamParser>())
          )
         {
             public FileItemIterator getFileItemIterator() {

--- a/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
 import java.util.Map;
 
 import javax.servlet.ReadListener;
@@ -46,6 +47,8 @@ import ninja.Results;
 import ninja.Route;
 import ninja.bodyparser.BodyParserEngine;
 import ninja.bodyparser.BodyParserEngineManager;
+import ninja.params.ParamParser;
+import ninja.params.ParamParsers;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.utils.NinjaConstant;
@@ -119,7 +122,8 @@ public class NinjaServletContextTest {
                 resultHandler,
                 sessionCookie,
                 validation,
-                injector);
+                injector,
+                new ParamParsers(new HashSet<ParamParser>()));
     }
 
     @Test

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +31,8 @@ import ninja.Context;
 import ninja.Cookie;
 import ninja.Result;
 import ninja.Route;
+import ninja.params.ParamParser;
+import ninja.params.ParamParsers;
 import ninja.session.FlashScope;
 import ninja.session.Session;
 import ninja.uploads.FileItem;
@@ -70,6 +73,7 @@ public class FakeContext implements Context {
     private final Map<String, Object> attributes = new HashMap<>();
     private Object body;
     private final Validation validation = new ValidationImpl();
+    private final ParamParsers paramParsers = new ParamParsers(new HashSet<ParamParser>());
 
     private String acceptContentType;
 
@@ -217,11 +221,8 @@ public class FakeContext implements Context {
 
     @Override
     public <T> T getParameterAs(String key, Class<T> clazz, T defaultValue) {
-        try {
-            return SwissKnife.convert(key, clazz);
-        } catch (Exception e) {
-            return defaultValue;
-        }
+        T value = (T) paramParsers.getParamParser(clazz).parseParameter(key, key, validation);
+        return validation.hasFieldViolation(key) ? defaultValue : value;
     }
 
     public FakeContext addPathParameter(String key, String value) {


### PR DESCRIPTION
Hello.

I already tried to send this [request](https://github.com/ninjaframework/ninja/pull/448) before but your review, the modifications needed and the evolution of the main repository I have not been able to do a rebase. I tried several times but finally it took less pain to copy them on a fresh branch. 

If you remember it, the goal of this PR is to enhance the parsing of strings to simple types, from the parameters or from the request. In details, it allows :
- To avoid duplicated code or differences between ParamParsers and SwissKnife converters (their job are in fact the same)
- To allow the POST body engine to register validation errors on conversion failure
- To avoid registering enumeration at start
- To allow users to register their own ParamParser
- Even overriding default ones, which can be useful to specify a particular DateFormat
- To allow parsing of other objects inside the parsed POST object

Notes :
- Custom ParamParsers are instancied via an Injector, so that users can make usage of @Inject dependencies
- The convert method for Date from the SwissKnife class have been translated to a ParamParser, based on LocalDateTime (as the original method). I’m thinking about something more useful, with date format from the properties file based on current Locale ; but I didn’t want to make a bigger PR. The fact is that with this PR, each user will be able to write a parser with it’s own format.
- It works with the MultiBinder, and is documented as well
- I had to enhanced the Validation documentation page, to make the differences with the JSR303 validator clear (interpolated messages in bean violation // message keys in field validations)

Regards,

Jonathan
