### PR TITLE
Crypto should use getBytes("UTF-8")

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/Crypto.java
+++ b/ninja-core/src/main/java/ninja/utils/Crypto.java
@@ -16,6 +16,7 @@
 
 package ninja.utils;
 
+import java.nio.charset.StandardCharsets;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -57,7 +58,7 @@ public class Crypto {
         try {
 
             // Get an hmac_sha1 key from the raw key bytes
-            byte[] keyBytes = key.getBytes();
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
             SecretKeySpec signingKey = new SecretKeySpec(keyBytes, "HmacSHA1");
 
             // Get an hmac_sha1 Mac instance and initialize with the signing key
@@ -65,7 +66,7 @@ public class Crypto {
             mac.init(signingKey);
 
             // Compute the hmac on input data bytes
-            byte[] rawHmac = mac.doFinal(value.getBytes());
+            byte[] rawHmac = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
 
             // Convert raw bytes to Hex
             byte[] hexBytes = new Hex().encode(rawHmac);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.x.x
 =============
 
+ * 2016-09-20 Session signatures now explicitly use UTF-8 for String.getBytes (lishid)
  * 2016-09-01 Bump to minimum requirement of Java 8
  * 2016-09-01 jetty from 9.2.10.v20150310 to 9.3.11.v20160721
  * 2016-09-01 guava from 18.0 to 19.0


### PR DESCRIPTION
This is to guarantee consistent behavior across different platforms.

Disclaimer: The reason why this is desirable for me is to get consistent behavior with Play: 
https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/libs/crypto/Crypto.scala#L238

I think a migration from Play framework should work regardless, but having this here is probably for the best.
