### PR TITLE
Made dropping of DB schema with Flyway migrations configurable.

### DIFF
--- a/ninja-core/src/main/java/ninja/migrations/flyway/MigrationEngineFlyway.java
+++ b/ninja-core/src/main/java/ninja/migrations/flyway/MigrationEngineFlyway.java
@@ -49,7 +49,8 @@ public class MigrationEngineFlyway implements MigrationEngine {
 
         // In testmode we are cleaning the database so that subsequent testcases
         // get a fresh database.
-        if (ninjaProperties.isTest()) {
+        if (ninjaProperties.getBooleanWithDefault(NinjaConstant.NINJA_MIGRATION_DROP_SCHEMA,
+                ninjaProperties.isTest() ? true : false )) {
             flyway.clean();
         }
 

--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -214,6 +214,9 @@ public interface NinjaConstant {
     /** run migrations on startup of application */
     final String NINJA_MIGRATION_RUN = "ninja.migration.run";
     
+    /** boolean flag to determine if Flyway should drop the existing DB schema */
+    final String NINJA_MIGRATION_DROP_SCHEMA = "ninja.migration.drop";
+    
     /** The name of the persistence unit to use */
     String PERSISTENCE_UNIT_NAME = "ninja.jpa.persistence_unit_name";
     


### PR DESCRIPTION
- Added boolean configuration property "ninja.migration.drop", allowing
  users to enable or disable dropping of the database with flyway.
- Modified decision to let flyway drop the DB schema based on the
  following: boolean value of "ninja.migration.drop" property, and if not
  specified assuming "true" in test mode, and "false" in any other mode.
  This keeps backward compatibility with existing installations.
