### PR TITLE
Fix directory listing

### DIFF
--- a/ninja-core/src/main/java/ninja/AssetsController.java
+++ b/ninja-core/src/main/java/ninja/AssetsController.java
@@ -127,6 +127,9 @@ public class AssetsController {
         // check if stream exists. if not print a notfound exception
         if (url == null) {
             context.finalizeHeadersWithoutFlashAndSessionCookie(Results.notFound());
+        } else if (url.getProtocol().equals("file") && new File(url.getPath()).isDirectory()) {
+            // Disable listing of directory contents
+            context.finalizeHeadersWithoutFlashAndSessionCookie(Results.notFound());
         } else {
             try {
                 URLConnection urlConnection = url.openConnection();

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version X.X.X
+=============
+
+ * 2016-07-04 Fixed directory listing in AssetsController (mallowlabs)
+
 Version 5.6.0
 =============
 

--- a/ninja-core/src/test/java/ninja/AssetsControllerTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerTest.java
@@ -138,6 +138,21 @@ public class AssetsControllerTest {
     }
 
     @Test
+    public void testServeStaticDirectory() throws Exception {
+        when(contextRenderable.getRequestPath()).thenReturn("/");
+        Result result2 = assetsController.serveStatic();
+
+        Renderable renderable = (Renderable) result2.getRenderable();
+
+        Result result = Results.ok();
+
+        renderable.render(contextRenderable, result);
+
+        verify(contextRenderable).finalizeHeadersWithoutFlashAndSessionCookie(resultCaptor.capture());
+        assertEquals(Results.notFound().getStatusCode(), resultCaptor.getValue().getStatusCode());
+    }
+
+    @Test
     public void testServeStatic304NotModified() throws Exception {
 
         when(contextRenderable.getRequestPath()).thenReturn(


### PR DESCRIPTION
### Steps to reproduce

``` sh
$ mvn archetype:generate -DarchetypeGroupId=org.ninjaframework -DarchetypeArtifactId=ninja-servlet-archetype-simple
$ cd MY_INSTALLED_PROJECT
$ mvn clean package
$ mvn ninja:run -Dninja.mode=prod -Dninja.ssl.port=-1 &
$ curl http://localhost:8080/assets/css/
custom.css
```

I think that `curl`should get "404 not found". But Ninja returns file list in the directory.
This PR will fix this problem.
