### PR TITLE
Fix against DoS attack via long string(CVE-2016-3092)

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version X.X.X
+=============
+
+ * 2016-07-08 Security fix against DoS in Commons FileUpload (CVE-2016-3092) (suer)
+
 Version 5.6.0
 =============
 

--- a/pom.xml
+++ b/pom.xml
@@ -600,7 +600,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
             </dependency>
 
             <!-- Bean validation and reference implementation for JSR 303 -->


### PR DESCRIPTION
This PR updates commons-fileupload.

Apache Commons Fileupload before 1.3.2 allows DoS attack via long string.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092
