### PR TITLE
Fix directory listing (#513) is not enough

### DIFF
--- a/ninja-core/src/main/java/ninja/AssetsController.java
+++ b/ninja-core/src/main/java/ninja/AssetsController.java
@@ -16,9 +16,7 @@
 
 package ninja;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,14 +29,12 @@ import ninja.utils.MimeTypes;
 import ninja.utils.NinjaProperties;
 import ninja.utils.ResponseStreams;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * This controller serves public resources under /assets.
@@ -127,7 +123,7 @@ public class AssetsController {
         // check if stream exists. if not print a notfound exception
         if (url == null) {
             context.finalizeHeadersWithoutFlashAndSessionCookie(Results.notFound());
-        } else if (url.getProtocol().equals("file") && new File(url.getPath()).isDirectory()) {
+        } else if (assetsControllerHelper.isDirectoryURL(url)) {
             // Disable listing of directory contents
             context.finalizeHeadersWithoutFlashAndSessionCookie(Results.notFound());
         } else {

--- a/ninja-core/src/main/java/ninja/AssetsControllerHelper.java
+++ b/ninja-core/src/main/java/ninja/AssetsControllerHelper.java
@@ -15,6 +15,10 @@
  */
 package ninja;
 
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,4 +52,23 @@ public class AssetsControllerHelper {
                 : FilenameUtils.normalize(fileName);
         return StringUtils.removeStart(fileNameNormalized, "/");
     }
+
+    /**
+     * Check the URL is a directory.
+     * With war style deployment, AssetsController exposes the file list of assets directories.
+     * For example, a request to http://localhost:8080/assets/css/ displays the file list of css directory.
+     * So this method checks the URL is a directory.
+     *
+     * @param url A URL of assets
+     * @return true if the URL is a directory
+     */
+    public boolean isDirectoryURL(URL url) {
+        try {
+            return url.getProtocol().equals("file") && new File(url.toURI()).isDirectory();
+        } catch (URISyntaxException e) {
+            logger.error("Could not URL convert to URI", e);
+        }
+        return false;
+    }
+
 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,7 @@
+Version X.X.X
+=============
+
+ * 2016-07-24 Fix directory listing when the server running path contains whitespaces (mallowlabs)
  * 2016-07-19 Fix for request body parsing of inner objects (jlannoy)
 
 Version 5.7.0

--- a/ninja-core/src/test/java/ninja/AssetsControllerHelperTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerHelperTest.java
@@ -15,12 +15,18 @@
  */
 package ninja;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+import java.io.File;
+import java.net.URL;
+
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
-
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
@@ -32,6 +38,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class AssetsControllerHelperTest {
 
     AssetsControllerHelper assetsControllerHelper;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
     public void setup() {
@@ -61,4 +70,30 @@ public class AssetsControllerHelperTest {
         PowerMockito.verifyStatic();
         FilenameUtils.normalize("/dir1/test.test", true);
     }
+
+    @Test
+    public void testIsDirectoryURLWithJarProtocol() throws Exception {
+        boolean result = assetsControllerHelper.isDirectoryURL(new URL("jar:file:/home/ninja/ninja.jar!/"));
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void testIsDirectoryURLWithFile() throws Exception {
+        boolean result = assetsControllerHelper.isDirectoryURL(this.getClass().getResource("/assets/testasset.txt"));
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void testIsDirectoryURLWithDirectory() throws Exception {
+        boolean result = assetsControllerHelper.isDirectoryURL(this.getClass().getResource("/assets/assets/"));
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testIsDirectoryURLWithDirectoryContainsSpecialCharacters() throws Exception {
+        File dir = tempFolder.newFolder("a#b");
+        boolean result = assetsControllerHelper.isDirectoryURL(dir.toURI().toURL());
+        assertThat(result, is(true));
+    }
+
 }

--- a/ninja-core/src/test/java/ninja/AssetsControllerTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerTest.java
@@ -139,6 +139,14 @@ public class AssetsControllerTest {
 
     @Test
     public void testServeStaticDirectory() throws Exception {
+        AssetsControllerHelper assetsControllerHelper = Mockito.mock(AssetsControllerHelper.class, Mockito.CALLS_REAL_METHODS);
+
+        assetsController = new AssetsController(
+                assetsControllerHelper,
+                httpCacheToolkit,
+                mimeTypes,
+                ninjaProperties);
+
         when(contextRenderable.getRequestPath()).thenReturn("/");
         Result result2 = assetsController.serveStatic();
 
@@ -148,6 +156,7 @@ public class AssetsControllerTest {
 
         renderable.render(contextRenderable, result);
 
+        verify(assetsControllerHelper).isDirectoryURL(this.getClass().getResource("/assets/"));
         verify(contextRenderable).finalizeHeadersWithoutFlashAndSessionCookie(resultCaptor.capture());
         assertEquals(Results.notFound().getStatusCode(), resultCaptor.getValue().getStatusCode());
     }


### PR DESCRIPTION
The PR #513 is not enough because a problem is remaining.

If the server running path contains whitespaces (or other special characters like #), the directory check does not work.
### Steps to reproduce

```
$ mkdir /tmp/ninja\ files/ && cd /tmp/ninja\ files/
$ git clone --depth 1 git@github.com:ninjaframework/ninja.git
$ cd ninja
$ mvn test
...
Tests in error:
  testServeStaticDirectory(ninja.AssetsControllerTest)

Tests run: 518, Failures: 0, Errors: 1, Skipped: 0
...
```

This PR fixes these problems.
