### PR TITLE
Fixing inner objects instantiation

### DIFF
--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEnginePost.java
@@ -108,11 +108,13 @@ public class BodyParserEnginePost implements BodyParserEngine {
 
                 } else {
                     
-                    // Check if we have a parameter key corresponding to inner attributes of this field
+                    // Check if we have one parameter key corresponding to one valued inner attribute of this object field
                     for (String parameter : context.getParameters().keySet()) {
                         if(parameter.startsWith(paramPrefix + declaredField + ".")) {
-                            field.set(t, invoke(context, fieldType, paramPrefix + declaredField + "."));
-                            break;
+                            if(context.getParameter(parameter) != null && !context.getParameter(parameter).isEmpty()) {
+                                field.set(t, invoke(context, fieldType, paramPrefix + declaredField + "."));
+                                break;
+                            }
                         }
                     }
                     

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+ * 2016-07-19 Fix for request body parsing of inner objects (jlannoy)
+
 Version 5.7.0
 =============
 

--- a/ninja-core/src/test/java/ninja/bodyparser/BodyParserEnginePostTest.java
+++ b/ninja-core/src/test/java/ninja/bodyparser/BodyParserEnginePostTest.java
@@ -302,6 +302,11 @@ public class BodyParserEnginePostTest {
         map.put("object2.integerPrimitive", new String [] {"3000"});
         map.put("object2.integerObject", new String [] {"4000"});
         
+        Mockito.when(context.getParameter("object1.integerPrimitive")).thenReturn("1000");
+        Mockito.when(context.getParameter("object1.integerObject")).thenReturn("2000");
+        Mockito.when(context.getParameter("object2.integerPrimitive")).thenReturn("3000");
+        Mockito.when(context.getParameter("object2.integerObject")).thenReturn("4000");
+        
         Mockito.when(context.getParameters()).thenReturn(map);
         Mockito.when(context.getValidation()).thenReturn(validation);
 
@@ -316,6 +321,34 @@ public class BodyParserEnginePostTest {
         assertNotNull(testObject.object2);
         assertThat(testObject.object2.integerPrimitive, equalTo(3000));
         assertThat(testObject.object2.integerObject, equalTo(4000));
+        
+        assertFalse(validation.hasViolations());
+    }
+    
+    @Test
+    public void testBodyParserWithEmptyInnerObjects() {
+        // some setup for this method:
+        Map<String, String[]> map = new HashMap<>();
+        map.put("object1.integerPrimitive", new String [] {""});
+        map.put("object1.integerObject", new String [] {""});
+        map.put("object2.integerPrimitive", new String [] {null});
+        map.put("object2.integerObject", new String [] {null});
+        
+        Mockito.when(context.getParameter("object1.integerPrimitive")).thenReturn("");
+        Mockito.when(context.getParameter("object1.integerObject")).thenReturn("");
+        Mockito.when(context.getParameter("object2.integerPrimitive")).thenReturn(null);
+        Mockito.when(context.getParameter("object2.integerObject")).thenReturn(null);
+        
+        Mockito.when(context.getParameters()).thenReturn(map);
+        Mockito.when(context.getValidation()).thenReturn(validation);
+
+        // do
+        TestObjectWithInnerObjects testObject = bodyParserEnginePost.invoke(context, TestObjectWithInnerObjects.class);
+        
+        // and test:
+        assertNull(testObject.object1);
+        assertNull(testObject.object2);
+        // objects should not have been initialized for empty content
         
         assertFalse(validation.hasViolations());
     }


### PR DESCRIPTION
After the PR refactoring and enhancing the parsing of request body, I discovered one not-logical behavior. An inner objet of the main object being parsed will be instantiated as soon as a parameter with the right name is present. But as the request body comes from HTLM inputs (for example), the parameter is always presents in the request even if the field is empty. So inner objects are always instantiated even when not needed, which is not relevant.

This PR fixes it ; parameters are checked before inner objects are instantiated. Note that there is not such a problem if the parameter is invalid : the object will be instantiated, the value in it will stay empty, but an error message will be registered in the context validation object.
