### PR TITLE
Bump to latest dependency versions; prep for v5.8.0 release

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,17 @@
-Version X.X.X
+Version 5.8.0
 =============
 
+ * 2016-08-26 Final release supporting Java 7! Future development will target Java 8+.
+ * 2016-08-26 jetty from 9.2.10.v20150310 to 9.2.18.v20160721
+ * 2016-08-26 slf4j from 1.7.13 to 1.7.21
+ * 2016-08-26 joda from 2.7 to 2.9.4
+ * 2016-08-26 jackson from 2.5.1 to 2.8.1
+ * 2016-08-26 commons-io from 2.4 to 2.5
+ * 2016-08-26 commons-lang3 from 3.3.2 to 3.4
+ * 2016-08-26 commons-email from 1.3.3 to 1.4
+ * 2016-08-26 flyway-core from 4.0 to 4.0.3
+ * 2016-08-26 zt-exec from 1.7 to 1.9
+ * 2016-08-25 Migration module can be configured to drop schema with `ninja.migration.drop` property (jfendler)
  * 2016-07-24 Fix directory listing when the server running path contains whitespaces (mallowlabs)
  * 2016-07-19 Fix for request body parsing of inner objects (jlannoy)
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
             </developer>
             <developer>
                 <name>Joe Lauer</name>
-                <email>joe@lauer.bz</email>
+                <email>joe@fizzed.com</email>
                 <organization>Fizzed, Inc.</organization>
                 <organizationUrl>http://fizzed.com</organizationUrl>
                 <roles>
@@ -76,10 +76,10 @@
         <siteProjectVersion>${project.version}</siteProjectVersion>
         <jetty.version>9.2.10.v20150310</jetty.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
-        <jackson.version>2.5.1</jackson.version>
+        <jackson.version>2.8.1</jackson.version>
         <guice.version>4.0</guice.version>
         <metrics.version>3.1.1</metrics.version>
-        <slf4j.version>1.7.13</slf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
         <powermock.version>1.5.6</powermock.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
@@ -449,7 +449,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.7</version>
+                <version>2.9.4</version>
             </dependency>
 
             <!-- Our favorite dependency injection framework: -->
@@ -567,19 +567,19 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.3.2</version>
+                <version>3.4</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-email</artifactId>
-                <version>1.3.3</version>
+                <version>1.4</version>
             </dependency>
 
             <!-- Commons configuration makes handling of properties files really simple. -->
@@ -636,7 +636,7 @@
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-core</artifactId>
-                <version>4.0</version>
+                <version>4.0.3</version>
             </dependency>
 
             <!-- JPA dependencies -->
@@ -796,7 +796,7 @@
             <dependency>
                 <groupId>org.zeroturnaround</groupId>
                 <artifactId>zt-exec</artifactId>
-                <version>1.7</version>
+                <version>1.9</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
@raphaelbauer Carefully bumped versions of dependencies after reviewing their changelogs.  Most notable is Jetty to latest 9.2.x (last one targeting Java 7).  I think we should release as 5.8.0 since so many dependency versions were changed.  I'd suggest next dev to be 6.0.0-SNAPSHOT.
