### PR TITLE
Bump to minimum Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
   - oraclejdk8
-  - openjdk7

--- a/ninja-async-machine-beta/pom.xml
+++ b/ninja-async-machine-beta/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <url>http://www.ninjaframework.org</url>

--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <organization>
@@ -237,6 +237,11 @@
         </dependency>
         
         <!-- Testing -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+        </dependency>
+        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,11 @@
+Version 6.x.x
+=============
+
+ * 2016-09-01 Bump to minimum requirement of Java 8
+ * 2016-09-01 jetty from 9.2.10.v20150310 to 9.3.11.v20160721
+ * 2016-09-01 guava from 18.0 to 19.0
+ * 2016-09-01 prettytime from 3.2.7.Final to 4.0.1
+
 Version 5.8.0
 =============
 

--- a/ninja-core/src/test/java/ninja/AssetsControllerHelperTest.java
+++ b/ninja-core/src/test/java/ninja/AssetsControllerHelperTest.java
@@ -18,23 +18,13 @@ package ninja;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.net.URL;
-
-import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FilenameUtils.class)
 public class AssetsControllerHelperTest {
 
     AssetsControllerHelper assetsControllerHelper;
@@ -57,20 +47,7 @@ public class AssetsControllerHelperTest {
         assertEquals(null, assetsControllerHelper.normalizePathWithoutLeadingSlash(null, true));
         assertEquals("", assetsControllerHelper.normalizePathWithoutLeadingSlash("", true));
     }
-
-    @Test
-    public void testNormalizePathWithoutLeadingSlashCorrectFilnameUtilStaticMethodsCalled() {
-        PowerMockito.mockStatic(FilenameUtils.class, Mockito.CALLS_REAL_METHODS);
-
-        assetsControllerHelper.normalizePathWithoutLeadingSlash("/dir1/test.test", false);
-        PowerMockito.verifyStatic();
-        FilenameUtils.normalize("/dir1/test.test");
-
-        assetsControllerHelper.normalizePathWithoutLeadingSlash("/dir1/test.test", true);
-        PowerMockito.verifyStatic();
-        FilenameUtils.normalize("/dir1/test.test", true);
-    }
-
+    
     @Test
     public void testIsDirectoryURLWithJarProtocol() throws Exception {
         boolean result = assetsControllerHelper.isDirectoryURL(new URL("jar:file:/home/ninja/ninja.jar!/"));

--- a/ninja-jaxy-routes/pom.xml
+++ b/ninja-jaxy-routes/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.ninjaframework</groupId>
 		<artifactId>ninja</artifactId>
-		<version>5.8.1-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/ninja-maven-plugin/pom.xml
+++ b/ninja-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>ninja-maven-plugin</artifactId>

--- a/ninja-metrics-ganglia/pom.xml
+++ b/ninja-metrics-ganglia/pom.xml
@@ -16,7 +16,7 @@ and limitations under the License. -->
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <url>http://www.ninjaframework.org</url>

--- a/ninja-metrics-graphite/pom.xml
+++ b/ninja-metrics-graphite/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.ninjaframework</groupId>
 		<artifactId>ninja</artifactId>
-		<version>5.8.1-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>

--- a/ninja-metrics-influxdb/pom.xml
+++ b/ninja-metrics-influxdb/pom.xml
@@ -16,7 +16,7 @@ and limitations under the License. -->
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <url>http://www.ninjaframework.org</url>

--- a/ninja-metrics-librato/pom.xml
+++ b/ninja-metrics-librato/pom.xml
@@ -16,7 +16,7 @@ and limitations under the License. -->
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <url>http://www.ninjaframework.org</url>

--- a/ninja-metrics/pom.xml
+++ b/ninja-metrics/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.ninjaframework</groupId>
 		<artifactId>ninja</artifactId>
-		<version>5.8.1-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 	</parent>
 
 	<url>http://www.ninjaframework.org</url>

--- a/ninja-servlet-archetype-simple/pom.xml
+++ b/ninja-servlet-archetype-simple/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
   
 

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -26,8 +26,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <url>http://www.ninjaframework.org</url>

--- a/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/AssetsControllerTest.java
@@ -26,9 +26,9 @@ import org.apache.http.HttpResponse;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
-import static org.hamcrest.CoreMatchers.is;
 import org.junit.Assert;
 import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 
 public class AssetsControllerTest extends NinjaTest {
 
@@ -44,10 +44,10 @@ public class AssetsControllerTest extends NinjaTest {
                 headers);
 
         // this is a mimetype nobody knows of...
-        // but it is listetd in the ninja mimetypes... therefore it will be found:
-        // case insensitivity makes test realistic
+        // but it is listetd in the ninja mimetypes... therefore it will be found
+        // servers change case & whitespace (e.g. jetty 9.2 vs. 9.3)
         String contentType = httpResponse.getHeaders("Content-Type")[0].getValue();
-        assertThat("application/dxf; charset=UTF-8".equalsIgnoreCase(contentType), is(true));
+        assertThat(contentType.replace(" ", ""), equalToIgnoringCase("application/dxf;charset=UTF-8"));
     }
     
     @Test

--- a/ninja-servlet-jpa-blog-archetype/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
   
 

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <url>http://www.ninjaframework.org</url>

--- a/ninja-servlet/pom.xml
+++ b/ninja-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <url>http://www.ninjaframework.org</url>

--- a/ninja-standalone/pom.xml
+++ b/ninja-standalone/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <url>http://www.ninjaframework.org</url>

--- a/ninja-test-utilities/pom.xml
+++ b/ninja-test-utilities/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja</artifactId>
-        <version>5.8.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     
     <url>http://www.ninjaframework.org</url>
@@ -48,6 +48,13 @@
         </dependency>
 
         <!-- Testing is mainly done by mockito: -->
+        <!-- Order of hamcrest first then junit is important -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
     <groupId>org.ninjaframework</groupId>
     <artifactId>ninja</artifactId>
     <packaging>pom</packaging>
-    <version>5.8.1-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <url>http://www.ninjaframework.org</url>
-    <name>${project.groupId}:${project.artifactId}</name>
+    <name>${project.artifactId}</name>
     <description>Ninja is a full stack web framework for Java.
         Rock solid, fast, and super productive.</description>
         
@@ -73,8 +73,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
         <siteProjectVersion>${project.version}</siteProjectVersion>
-        <jetty.version>9.2.10.v20150310</jetty.version>
+        <jetty.version>9.3.11.v20160721</jetty.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
         <jackson.version>2.8.1</jackson.version>
         <guice.version>4.0</guice.version>
@@ -92,7 +93,7 @@
         <!-- end formatting options for Netbeans -->
     </properties>
 
-    <!-- Fix version 1.7 of java compiler in all submodules: -->
+    <!-- Fix version 1.8 of java compiler in all submodules: -->
     <build>
 
         <pluginManagement>
@@ -117,10 +118,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.5.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <!--
@@ -495,7 +496,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>5.0.1</version>
+                <version>5.0.3</version>
             </dependency>  
             
             <!-- Afterburner lib optimizes Jackson and improves
@@ -518,7 +519,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>19.0</version>
             </dependency>
 
             <!-- reflections is used for classpath scanning -->
@@ -693,6 +694,29 @@
             </dependency>
             
             <dependency>
+                <groupId>org.ocpsoft.prettytime</groupId>
+                <artifactId>prettytime</artifactId>
+                <version>4.0.1.Final</version>
+            </dependency>
+            
+            <!-- for ninja-maven-plugin -->
+            
+            <dependency>
+                <groupId>org.zeroturnaround</groupId>
+                <artifactId>zt-exec</artifactId>
+                <version>1.9</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>3.4</version>
+                <scope>provided</scope>
+            </dependency>
+            
+            <!-- UI and databases for demos -->
+            
+            <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>bootstrap</artifactId>
                 <version>3.3.4</version>
@@ -704,13 +728,11 @@
                 <version>3.4.9</version>
             </dependency>
 
-
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>1.4.186</version>
             </dependency>
-            
             
             <!--HttpCient is used to mainly test low level Json Apis -->
             <dependency>
@@ -758,18 +780,25 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-        
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>java-hamcrest</artifactId>
+                <version>2.0.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+                        
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>1.9.5</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
             
@@ -783,27 +812,8 @@
             <dependency>
                 <groupId>com.icegreen</groupId>
                 <artifactId>greenmail</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.1</version>
                 <scope>test</scope>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.ocpsoft.prettytime</groupId>
-                <artifactId>prettytime</artifactId>
-                <version>3.2.7.Final</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.zeroturnaround</groupId>
-                <artifactId>zt-exec</artifactId>
-                <version>1.9</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>3.4</version>
-                <scope>provided</scope>
             </dependency>
             
             <dependency>
@@ -820,8 +830,7 @@
                 <scope>test</scope>
             </dependency>  
             
-            <!-- small http library for unit tests that don't need power of
-            httpclient -->
+            <!-- small http library for unit tests that don't need power of httpclient -->
             <dependency>
                 <groupId>com.github.kevinsawicki</groupId>
                 <artifactId>http-request</artifactId>


### PR DESCRIPTION
- Bump to minimum Java 8
- Update to latest third party dependencies (jetty, guava, prettytime)

Unfortunately, guice 4.1.0 is out and updating it breaks numerous tests.  I suspect that's due to being incompatible with our mockito & powermock dependencies.  Unable to update mockito to 2.x series as well.
