### PR TITLE
Route with lambdas (functional methods)

### DIFF
--- a/ninja-core/src/main/java/ninja/ControllerMethods.java
+++ b/ninja-core/src/main/java/ninja/ControllerMethods.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import java.io.Serializable;
+
+/**
+ * Functional interfaces for Ninja controller methods accepting up to X
+ * number of arguments with type inference.
+ */
+public class ControllerMethods {
+    
+    /**
+     * Marker interface that all functional interfaces will extend.  Useful for
+     * simple validation an object is a ControllerMethod.
+     */
+    static public interface ControllerMethod extends Serializable { }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod0 extends ControllerMethod {
+        Result apply() throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod1<A> extends ControllerMethod {
+        Result apply(A a) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod2<A,B> extends ControllerMethod {
+        Result apply(A a, B b) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod3<A,B,C> extends ControllerMethod {
+        Result apply(A a, B b, C c) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod4<A,B,C,D> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod5<A,B,C,D,E> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod6<A,B,C,D,E,F> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod7<A,B,C,D,E,F,G> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod8<A,B,C,D,E,F,G,H> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod9<A,B,C,D,E,F,G,H,I> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod10<A,B,C,D,E,F,G,H,I,J> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod11<A,B,C,D,E,F,G,H,I,J,K> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod12<A,B,C,D,E,F,G,H,I,J,K,L> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod13<A,B,C,D,E,F,G,H,I,J,K,L,M> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod14<A,B,C,D,E,F,G,H,I,J,K,L,M,N> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n) throws Exception;
+    }
+    
+    @FunctionalInterface
+    static public interface ControllerMethod15<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O> extends ControllerMethod {
+        Result apply(A a, B b, C c, D d, E e, F f, G g, H h, I i, J j, K k, L l, M m, N n, O o) throws Exception;
+    }
+    
+    // if you need more than 15 arguments then we recommend using the
+    // legacy Class, methodName strategy
+    
+    // helper methods to allow classes to accept `ControllerMethod` but still
+    // have the compiler create the correct functional method under-the-hood
+    
+    static public ControllerMethod0 of(ControllerMethod0 functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A> ControllerMethod1<A> of(ControllerMethod1<A> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B> ControllerMethod2<A,B> of(ControllerMethod2<A,B> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C> ControllerMethod3<A,B,C> of(ControllerMethod3<A,B,C> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D> ControllerMethod4<A,B,C,D> of(ControllerMethod4<A,B,C,D> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E> ControllerMethod5<A,B,C,D,E> of(ControllerMethod5<A,B,C,D,E> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F> ControllerMethod6<A,B,C,D,E,F> of(ControllerMethod6<A,B,C,D,E,F> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G> ControllerMethod7<A,B,C,D,E,F,G> of(ControllerMethod7<A,B,C,D,E,F,G> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H> ControllerMethod8<A,B,C,D,E,F,G,H> of(ControllerMethod8<A,B,C,D,E,F,G,H> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I> ControllerMethod9<A,B,C,D,E,F,G,H,I> of(ControllerMethod9<A,B,C,D,E,F,G,H,I> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J> ControllerMethod10<A,B,C,D,E,F,G,H,I,J> of(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J,K> ControllerMethod11<A,B,C,D,E,F,G,H,I,J,K> of(ControllerMethod11<A,B,C,D,E,F,G,H,I,J,K> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J,K,L> ControllerMethod12<A,B,C,D,E,F,G,H,I,J,K,L> of(ControllerMethod12<A,B,C,D,E,F,G,H,I,J,K,L> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J,K,L,M> ControllerMethod13<A,B,C,D,E,F,G,H,I,J,K,L,M> of(ControllerMethod13<A,B,C,D,E,F,G,H,I,J,K,L,M> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J,K,L,M,N> ControllerMethod14<A,B,C,D,E,F,G,H,I,J,K,L,M,N> of(ControllerMethod14<A,B,C,D,E,F,G,H,I,J,K,L,M,N> functionalMethod) {
+        return functionalMethod;
+    }
+    
+    static public <A,B,C,D,E,F,G,H,I,J,K,L,M,N,O> ControllerMethod15<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O> of(ControllerMethod15<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O> functionalMethod) {
+        return functionalMethod;
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/FilterChain.java
+++ b/ninja-core/src/main/java/ninja/FilterChain.java
@@ -20,11 +20,13 @@ package ninja;
  * A filter chain
  */
 public interface FilterChain {
+    
     /**
      * Pass the request to the next filter
      * 
-     * @param context
-     *            The context for the request
+     * @param context The context for the request
+     * @return The result
      */
     Result next(Context context);
+    
 }

--- a/ninja-core/src/main/java/ninja/FilterChainEnd.java
+++ b/ninja-core/src/main/java/ninja/FilterChainEnd.java
@@ -26,28 +26,20 @@ import com.google.inject.Provider;
  * @author James Roper
  */
 class FilterChainEnd implements FilterChain {
-    private Provider<?> controllerProvider;
-    private ControllerMethodInvoker controllerMethodInvoker;
-    private Result result;
+    
+    private final Provider<?> targetObjectProvider;
+    private final ControllerMethodInvoker controllerMethodInvoker;
 
-    FilterChainEnd(Result result) {
-        this.result = result;
-    }
-
-    FilterChainEnd(Provider<?> controllerProvider,
+    FilterChainEnd(Provider<?> targetObjectProvider,
                    ControllerMethodInvoker controllerMethodInvoker) {
-        this.controllerProvider = controllerProvider;
+        this.targetObjectProvider = targetObjectProvider;
         this.controllerMethodInvoker = controllerMethodInvoker;
     }
 
     @Override
     public Result next(Context context) {
-        if(result != null) {
-            return result;
-        }
-
-        Result controllerResult = (Result) controllerMethodInvoker.invoke(
-                controllerProvider.get(), context);
+        Result controllerResult = (Result)controllerMethodInvoker.invoke(
+            targetObjectProvider.get(), context);
 
         if (controllerResult instanceof AsyncResult) {
             // Make sure handle async has been called

--- a/ninja-core/src/main/java/ninja/FilterChainImpl.java
+++ b/ninja-core/src/main/java/ninja/FilterChainImpl.java
@@ -22,6 +22,7 @@ import com.google.inject.Provider;
  * Implementation of the filter chain
  */
 class FilterChainImpl implements FilterChain {
+    
     private final Provider<? extends Filter> filterProvider;
     private final FilterChain next;
 

--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -45,7 +45,6 @@ public class Route {
     //private static final String PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE = "\\{.*?:\\s(.*?)\\}";
     private final String httpMethod;
     private final String uri;
-    private final Class controllerClass;
     private final Method controllerMethod;
     private final FilterChain filterChain;
 
@@ -54,15 +53,12 @@ public class Route {
 
     public Route(String httpMethod,
             String uri,
-            Class controllerClass,
             Method controllerMethod,
             FilterChain filterChain) {
         this.httpMethod = httpMethod;
         this.uri = uri;
-        this.controllerClass = controllerClass;
         this.controllerMethod = controllerMethod;
         this.filterChain = filterChain;
-
         parameterNames = ImmutableList.copyOf(doParseParameters(uri));
         regex = Pattern.compile(convertRawUriToRegex(uri));
     }
@@ -80,7 +76,7 @@ public class Route {
     }
 
     public Class<?> getControllerClass() {
-        return controllerClass;
+        return controllerMethod != null ? controllerMethod.getDeclaringClass() : null;
     }
 
     public FilterChain getFilterChain() {

--- a/ninja-core/src/main/java/ninja/RouteBuilder.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilder.java
@@ -16,16 +16,49 @@
 
 package ninja;
 
+import ninja.ControllerMethods.*;
 import ninja.utils.MethodReference;
 
 public interface RouteBuilder {
 
     RouteBuilder route(String uri);
 
-    void with(Class controller, String controllerMethod);
+    void with(Class<?> controllerClass, String controllerMethod);
 
+    @Deprecated
     void with(MethodReference controllerMethodRef);
     
+    /**
+     * A static result to return for this route.
+     * @param result The result to return on every request.
+     * @deprecated Use the functional interface methods to supply a new result
+     *      for each route request.  Its recommended to use <code>() -> Results.redirect("/")</code>.
+     */
+    @Deprecated
     void with(Result result);
     
+    void with(ControllerMethod functionalMethod);
+    
+    void with(ControllerMethod0 functionalMethod);
+    
+    <A> void with(ControllerMethod1<A> functionalMethod);
+    
+    <A,B> void with(ControllerMethod2<A,B> functionalMethod);
+    
+    <A,B,C> void with(ControllerMethod3<A,B,C> functionalMethod);
+    
+    <A,B,C,D> void with(ControllerMethod4<A,B,C,D> functionalMethod);
+    
+    <A,B,C,D,E> void with(ControllerMethod5<A,B,C,D,E> functionalMethod);
+    
+    <A,B,C,D,E,F> void with(ControllerMethod6<A,B,C,D,E,F> functionalMethod);
+    
+    <A,B,C,D,E,F,G> void with(ControllerMethod7<A,B,C,D,E,F,G> functionalMethod);
+    
+    <A,B,C,D,E,F,G,H> void with(ControllerMethod8<A,B,C,D,E,F,G,H> functionalMethod);
+    
+    <A,B,C,D,E,F,G,H,I> void with(ControllerMethod9<A,B,C,D,E,F,G,H,I> functionalMethod);
+    
+    <A,B,C,D,E,F,G,H,I,J> void with(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> functionalMethod);
+
 }

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -316,23 +316,29 @@ public class RouteBuilderImpl implements RouteBuilder {
     private Set<Class<? extends Filter>> calculateFiltersForClass(Class controller) {
         LinkedHashSet<Class<? extends Filter>> filters = new LinkedHashSet<>();
         
+        //
         // Step up the superclass tree, so that superclass filters come first
+        //
+        
         // Superclass
         if (controller.getSuperclass() != null) {
             filters.addAll(calculateFiltersForClass(controller.getSuperclass()));
         }
+        
         // Interfaces
         if (controller.getInterfaces() != null) {
             for (Class clazz : controller.getInterfaces()) {
                 filters.addAll(calculateFiltersForClass(clazz));
             }
         }
+        
         // Now add from here
         FilterWith filterWith = (FilterWith) controller
                 .getAnnotation(FilterWith.class);
         if (filterWith != null) {
             filters.addAll(Arrays.asList(filterWith.value()));
         }
+        
         // And return
         return filters;
     }

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -21,26 +21,32 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
-
 import ninja.params.ControllerMethodInvoker;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.util.Providers;
+import java.util.Optional;
+import ninja.ControllerMethods.*;
+import ninja.utils.Lambdas;
+import ninja.utils.Lambdas.LambdaInfo;
 import ninja.utils.MethodReference;
 
 public class RouteBuilderImpl implements RouteBuilder {
-
-    private static final Logger log = LoggerFactory
-            .getLogger(RouteBuilder.class);
+    private static final Logger log = LoggerFactory.getLogger(RouteBuilder.class);
 
     private String httpMethod;
     private String uri;
-    private Class controller;
-    private Method controllerMethod;
-    private Result result;
+    private Method functionalMethod;
+    private Optional<Method> implementationMethod;  // method to use for parameter/annotation extraction
+    private Optional<Object> targetObject;          // instance to invoke
 
+    public RouteBuilderImpl() {
+        this.implementationMethod = Optional.empty();
+        this.targetObject = Optional.empty();
+    }
+    
     public RouteBuilderImpl GET() {
         httpMethod = "GET";
         return this;
@@ -77,20 +83,116 @@ public class RouteBuilderImpl implements RouteBuilder {
     }
 
     @Override
-    public void with(Class controller, String controllerMethod) {
-        this.controller = controller;
-        this.controllerMethod = verifyThatControllerAndMethodExists(controller,
-                controllerMethod);
+    public void with(Class controllerClass, String controllerMethod) {
+        this.functionalMethod
+            = verifyControllerMethod(controllerClass, controllerMethod);
+    }
+    
+    @Override @Deprecated
+    public void with(MethodReference methodRef) {
+        with(methodRef.getDeclaringClass(), methodRef.getMethodName());
+    }
+    
+    @Override @Deprecated
+    public void with(final Result result) {
+        withFunctionalMethod(ControllerMethods.of(() -> result));
+    }
+    
+    @Override
+    public void with(ControllerMethod functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public void with(ControllerMethod0 functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A> void with(ControllerMethod1<A> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B> void with(ControllerMethod2<A,B> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C> void with(ControllerMethod3<A,B,C> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D> void with(ControllerMethod4<A,B,C,D> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E> void with(ControllerMethod5<A,B,C,D,E> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E,F> void with(ControllerMethod6<A,B,C,D,E,F> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E,F,G> void with(ControllerMethod7<A,B,C,D,E,F,G> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E,F,G,H> void with(ControllerMethod8<A,B,C,D,E,F,G,H> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E,F,G,H,I> void with(ControllerMethod9<A,B,C,D,E,F,G,H,I> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
+    }
+    
+    @Override
+    public <A,B,C,D,E,F,G,H,I,J> void with(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> functionalMethod) {
+        withFunctionalMethod(functionalMethod);
     }
 
-    @Override
-    public void with(MethodReference controllerMethodRef) {
-        with(controllerMethodRef.getDeclaringClass(), controllerMethodRef.getMethodName());
-    }
+    private void withFunctionalMethod(ControllerMethod functionalMethod) {
+        try {
+            LambdaInfo lambdaInfo = Lambdas.reflect(functionalMethod);
 
-    @Override
-    public void with(Result result) {
-        this.result = result;
+            log.trace("uri {} with lambda {}", uri, lambdaInfo);
+            
+            switch (lambdaInfo.getKind()) {
+                case ANY_INSTANCE_METHOD_REFERENCE:
+                case STATIC_METHOD_REFERENCE:
+                    // call impl method just like before Java 8
+                    this.functionalMethod = lambdaInfo.getImplementationMethod();
+                    return;
+                case SPECIFIC_INSTANCE_METHOD_REFERENCE:
+                case ANONYMOUS_METHOD_REFERENCE:
+                    // only safe to use the impl method for argument types if
+                    // the number of arguments matches between the methods
+                    if (lambdaInfo.areMethodParameterCountsEqual()) {    
+                        this.functionalMethod = lambdaInfo.getFunctionalMethod();
+                        this.implementationMethod = Optional.of(lambdaInfo.getImplementationMethod());
+                        this.targetObject = Optional.of(functionalMethod);
+                        return;
+                    }
+            }
+        } catch (IllegalArgumentException e) {
+            // unable to detect lambda (e.g. such as anonymous/concrete class)
+        }
+        
+        // fallback to simple call the "apply" method on the supplied method instance
+        try {
+            this.functionalMethod = Lambdas.getMethod(functionalMethod.getClass(), "apply");
+            this.functionalMethod.setAccessible(true);
+            this.targetObject = Optional.of(functionalMethod);
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -115,28 +217,22 @@ public class RouteBuilderImpl implements RouteBuilder {
      *            The method
      * @return The actual method
      */
-    private Method verifyThatControllerAndMethodExists(Class controller,
-                                                       String controllerMethod) {
-
+    private Method verifyControllerMethod(Class<?> controllerClass,
+                                          String controllerMethod) {
         try {
-
             Method methodFromQueryingClass = null;
 
             // 1. Make sure method is in class
             // 2. Make sure only one method is there. Otherwise we cannot really
-            // know what
-            // to do with the parameters.
-            for (Method method : controller.getMethods()) {
-
+            // know what to do with the parameters.
+            for (Method method : controllerClass.getMethods()) {
                 if (method.getName().equals(controllerMethod)) {
                     if (methodFromQueryingClass == null) {
                         methodFromQueryingClass = method;
                     } else {
                         throw new NoSuchMethodException();
                     }
-
                 }
-
             }
 
             if (methodFromQueryingClass == null) {
@@ -156,9 +252,8 @@ public class RouteBuilderImpl implements RouteBuilder {
                     "Error while checking for valid Controller / controllerMethod combination",
                     e);
         } catch (NoSuchMethodException e) {
-
             log.error("Error in route configuration!!!");
-            log.error("Can not find Controller " + controller.getName()
+            log.error("Can not find Controller " + controllerClass.getName()
                     + " and method " + controllerMethod);
             log.error("Hint: make sure the controller returns a ninja.Result!");
             log.error("Hint: Ninja does not allow more than one method with the same name!");
@@ -167,64 +262,61 @@ public class RouteBuilderImpl implements RouteBuilder {
     }
 
     /**
-     * Build the route
-     *
-     * @param injector
-     *            The injector to build the route with
+     * Build the route.
+     * @param injector The injector to build the route with
+     * @return The built route
      */
     public Route buildRoute(Injector injector) {
-        if(controller == null && result == null) {
+        if (functionalMethod == null) {
             log.error("Error in route configuration for {}", uri);
-            throw new IllegalStateException("Route not with a controller or result");
+            throw new IllegalStateException("Route missing a controller method");
         }
 
         // Calculate filters
-        LinkedList<Class<? extends Filter>> filters = new LinkedList<Class<? extends Filter>>();
-        if(controller != null) {
-            if (controllerMethod == null) {
-                throw new IllegalStateException(
-                        String.format("Route '%s' does not have a controller method", uri));
-            }
-            filters.addAll(calculateFiltersForClass(controller));
-            FilterWith filterWith = controllerMethod
-                    .getAnnotation(FilterWith.class);
-            if (filterWith != null) {
-                filters.addAll(Arrays.asList(filterWith.value()));
-            }
+        LinkedList<Class<? extends Filter>> filters = new LinkedList<>();
+        filters.addAll(calculateFiltersForClass(functionalMethod.getDeclaringClass()));
+        FilterWith filterWith = functionalMethod
+                .getAnnotation(FilterWith.class);
+        if (filterWith != null) {
+            filters.addAll(Arrays.asList(filterWith.value()));
         }
+        
+        FilterChain filterChain = buildFilterChain(injector, filters);
 
-        return new Route(httpMethod, uri, controller, controllerMethod,
-                buildFilterChain(injector, filters, controller,
-                        controllerMethod, result));
+        return new Route(httpMethod, uri, functionalMethod, filterChain);
     }
 
     private FilterChain buildFilterChain(Injector injector,
-                                         LinkedList<Class<? extends Filter>> filters,
-                                         Class<?> controller,
-                                         Method controllerMethod,
-                                         Result result) {
+                                         LinkedList<Class<? extends Filter>> filters) {
 
         if (filters.isEmpty()) {
+            
+            // either target object (functional method) or guice will create new instance
+            Provider<?> targetProvider = (targetObject.isPresent() ?
+                Providers.of(targetObject.get())
+                    : injector.getProvider(functionalMethod.getDeclaringClass()));
 
-            return result != null ? new FilterChainEnd(result) :
-                    new FilterChainEnd(injector.getProvider(controller),
-                            ControllerMethodInvoker.build(controllerMethod, injector));
+            // invoke functional method with optionally using impl for argument extraction
+            ControllerMethodInvoker methodInvoker
+                = ControllerMethodInvoker.build(
+                    functionalMethod, implementationMethod.orElse(functionalMethod), injector);
 
+            return new FilterChainEnd(targetProvider, methodInvoker);
+            
         } else {
 
             Class<? extends Filter> filter = filters.pop();
 
             return new FilterChainImpl(injector.getProvider(filter),
-                    buildFilterChain(injector, filters, controller,
-                            controllerMethod, result));
-
+                buildFilterChain(injector, filters));
+            
         }
     }
 
     private Set<Class<? extends Filter>> calculateFiltersForClass(Class controller) {
-        LinkedHashSet<Class<? extends Filter>> filters = new LinkedHashSet<Class<? extends Filter>>();
-        // First step up the superclass tree, so that superclass filters come
-        // first
+        LinkedHashSet<Class<? extends Filter>> filters = new LinkedHashSet<>();
+        
+        // Step up the superclass tree, so that superclass filters come first
         // Superclass
         if (controller.getSuperclass() != null) {
             filters.addAll(calculateFiltersForClass(controller.getSuperclass()));

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -25,32 +25,24 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import ninja.utils.NinjaProperties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import java.lang.reflect.Method;
 
 public class RouterImpl implements Router {
-
+    static private final Logger logger = LoggerFactory.getLogger(RouterImpl.class);
+    
     private final NinjaProperties ninjaProperties;
-
-    private final Logger logger = LoggerFactory.getLogger(RouterImpl.class);
-
     private final List<RouteBuilderImpl> allRouteBuilders = new ArrayList<>();
     private final Injector injector;
-
     private List<Route> routes;
     // for fast reverse route lookups
     private Map<MethodReference,Route> reverseRoutes;
-
     // This regex works for both {myParam} AND {myParam: .*} (with regex)
     private final String VARIABLE_PART_PATTERN_WITH_PLACEHOLDER = "\\{(%s)(:\\s([^}]*))?\\}"; 
 

--- a/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
+++ b/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
@@ -39,6 +39,7 @@ import com.google.inject.Injector;
  * @author James Roper
  */
 public class ControllerMethodInvoker {
+    
     private final Method method;
     private final ArgumentExtractor<?>[] argumentExtractors;
 
@@ -55,9 +56,7 @@ public class ControllerMethodInvoker {
         }
         try {
             return method.invoke(controller, arguments);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalAccessException | IllegalArgumentException e) {
             throw new RuntimeException(e);
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof RuntimeException) {
@@ -67,12 +66,23 @@ public class ControllerMethodInvoker {
             }
         }
     }
-
-    public static ControllerMethodInvoker build(Method method, Injector injector) {
+    
+    /**
+     * Builds an invoker for a functional method.  Understands what parameters
+     * to inject and extract based on type and annotations.
+     * @param functionalMethod The method to be invoked
+     * @param implementationMethod The method to use for determining what
+     *      actual parameters and annotations to use for each argument.  Useful
+     *      when type/lambda erasure makes the functional interface not reliable
+     *      for reflecting.
+     * @param injector The guice injector
+     * @return An invoker
+     */
+    public static ControllerMethodInvoker build(Method functionalMethod, Method implementationMethod, Injector injector) {
         // get both the parameters...
-        final Class[] paramTypes = method.getParameterTypes();
+        final Class[] paramTypes = implementationMethod.getParameterTypes();
         // ... and all annotations for the parameters
-        final Annotation[][] paramAnnotations = method
+        final Annotation[][] paramAnnotations = implementationMethod
                 .getParameterAnnotations();
 
         ArgumentExtractor<?>[] argumentExtractors = new ArgumentExtractor<?>[paramTypes.length];
@@ -84,7 +94,7 @@ public class ControllerMethodInvoker {
                         injector);
             } catch (RoutingException e) {
                 throw new RoutingException("Error building argument extractor for parameter " + i +
-                        " in method " + method.getDeclaringClass().getName() + "." + method.getName() + "()", e);
+                        " in method " + implementationMethod.getDeclaringClass().getName() + "." + implementationMethod.getName() + "()", e);
             }
         }
 
@@ -94,7 +104,7 @@ public class ControllerMethodInvoker {
             if (argumentExtractors[i] == null) {
                 if (bodyAsFound > -1) {
                     throw new RoutingException("Only one parameter may be deserialised as the body "
-                            + method.getDeclaringClass().getName() + "." + method.getName() + "()\n"
+                            + implementationMethod.getDeclaringClass().getName() + "." + implementationMethod.getName() + "()\n"
                             + "Extracted parameter is type: " + paramTypes[bodyAsFound].getName() + "\n"
                             + "Extra parmeter is type: " + paramTypes[i].getName());
                 } else {
@@ -112,7 +122,7 @@ public class ControllerMethodInvoker {
                     argumentExtractors[i]);
         }
 
-        return new ControllerMethodInvoker(method, argumentExtractors);
+        return new ControllerMethodInvoker(functionalMethod, argumentExtractors);
     }
 
     private static ArgumentExtractor<?> getArgumentExtractor(Class<?> paramType,
@@ -158,8 +168,8 @@ public class ControllerMethodInvoker {
             Annotation[] annotations, Injector injector, ArgumentExtractor<?> extractor) {
         // We have validators that get applied before parsing, and validators
         // that get applied after parsing.
-        List<Validator<?>> preParseValidators = new ArrayList<Validator<?>>();
-        List<Validator<?>> postParseValidators = new ArrayList<Validator<?>>();
+        List<Validator<?>> preParseValidators = new ArrayList<>();
+        List<Validator<?>> postParseValidators = new ArrayList<>();
 
         Class<?> boxedParamType = paramType;
         if (paramType.isPrimitive()) {

--- a/ninja-core/src/main/java/ninja/utils/Lambdas.java
+++ b/ninja-core/src/main/java/ninja/utils/Lambdas.java
@@ -30,7 +30,7 @@ public class Lambdas {
      * or anonymously defined.
      * https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html
      */
-    static public enum Kind {
+    public static enum Kind {
         // Reference to a static method (e.g. ContainingClass::staticMethodName)
         STATIC_METHOD_REFERENCE,
         // Reference to an instance method of a specific object (e.g. specificObject::instanceMethodName)
@@ -41,7 +41,7 @@ public class Lambdas {
         ANONYMOUS_METHOD_REFERENCE
     }
     
-    static public class LambdaInfo {
+    public static class LambdaInfo {
         private final Object lambda;
         private final Kind kind;
         private final SerializedLambda serializedLambda;
@@ -93,22 +93,20 @@ public class Lambdas {
         }
     }
     
-    static public LambdaInfo reflect(Object lambda) {
+    public static LambdaInfo reflect(Object lambda) {
         Objects.requireNonNull(lambda);
         
-        // this will fail 
+        // note: this throws a runtime exception if the lambda isn't serializable
+        // or if the object isn't actually a lambda (e.g. an anon class)
         SerializedLambda serializedLambda = getSerializedLambda(lambda);
         
         Method functionalMethod;
         try {
             functionalMethod = getMethod(lambda.getClass(),
                 serializedLambda.getFunctionalInterfaceMethodName());
-            //log.debug("functionalMethod: {}", functionalMethod);
             
             // important: only way classes other than the creator can invoke it
             functionalMethod.setAccessible(true);
-            
-            //functionalMethod = getFunctionalMethod(serializedLambda);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             throw new RuntimeException("Unable to getFunctionalMethod", e);
         }
@@ -116,7 +114,6 @@ public class Lambdas {
         Method implementationMethod;
         try {
             implementationMethod = getImplementationMethod(serializedLambda);
-            //log.debug("implementationMethod: {}", implementationMethod);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             throw new RuntimeException("Unable to getImplementationMethod", e);
         }
@@ -150,7 +147,7 @@ public class Lambdas {
      * @param lambda An object that is an instance of a functional interface. 
      * @return The SerializedLambda
      */
-    static public SerializedLambda getSerializedLambda(Object lambda) {
+    public static SerializedLambda getSerializedLambda(Object lambda) {
         Objects.requireNonNull(lambda);
         
         if (!(lambda instanceof java.io.Serializable)) {
@@ -178,22 +175,22 @@ public class Lambdas {
         throw new RuntimeException("writeReplace method not found");
     }
     
-    static public Method getFunctionalMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
+    public static Method getFunctionalMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
         return getMethod(serializedLambda.getFunctionalInterfaceClass(),
             serializedLambda.getFunctionalInterfaceMethodName());
     }
     
-    static public Method getImplementationMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
+    public static Method getImplementationMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
         return getMethod(serializedLambda.getImplClass(),
             serializedLambda.getImplMethodName());
     }
     
-    static public Method getMethod(String className, String methodName) throws NoSuchMethodException, ClassNotFoundException {
+    public static Method getMethod(String className, String methodName) throws NoSuchMethodException, ClassNotFoundException {
         Class<?> clazz = Class.forName(className.replace('/', '.'));
         return getMethod(clazz, methodName);
     }
     
-    static public Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException, ClassNotFoundException {
+    public static Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException, ClassNotFoundException {
         while (clazz != null) {
             for (Method method : clazz.getDeclaredMethods()) {
                 if (method.getName().equals(methodName)) {

--- a/ninja-core/src/main/java/ninja/utils/Lambdas.java
+++ b/ninja-core/src/main/java/ninja/utils/Lambdas.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.utils;
+
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Lambdas {
+    private static final Logger log = LoggerFactory.getLogger(Lambdas.class);
+    
+    /**
+     * The kind of lambda.  Lambdas in Java can either be references to methods
+     * or anonymously defined.
+     * https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html
+     */
+    static public enum Kind {
+        // Reference to a static method (e.g. ContainingClass::staticMethodName)
+        STATIC_METHOD_REFERENCE,
+        // Reference to an instance method of a specific object (e.g. specificObject::instanceMethodName)
+        SPECIFIC_INSTANCE_METHOD_REFERENCE,
+        // Reference to an instance method of an arbitrary object of a particular type (e.g. ContainingClass::instanceMethodName)
+        ANY_INSTANCE_METHOD_REFERENCE,
+        // Anonymously defined (e.g. () -> return "a"; )
+        ANONYMOUS_METHOD_REFERENCE
+    }
+    
+    static public class LambdaInfo {
+        private final Object lambda;
+        private final Kind kind;
+        private final SerializedLambda serializedLambda;
+        private final Method functionalMethod;
+        private final Method implementationMethod;
+
+        public LambdaInfo(Object lambda, Kind kind, SerializedLambda serializedLambda, Method functionalMethod, Method implementationMethod) {
+            this.lambda = lambda;
+            this.kind = kind;
+            this.serializedLambda = serializedLambda;
+            this.functionalMethod = functionalMethod;
+            this.implementationMethod = implementationMethod;
+        }
+
+        public Object getLambda() {
+            return lambda;
+        }
+        
+        public Kind getKind() {
+            return kind;
+        }
+
+        public SerializedLambda getSerializedLambda() {
+            return serializedLambda;
+        }
+
+        public Method getFunctionalMethod() {
+            return functionalMethod;
+        }
+        
+        public Method getImplementationMethod() {
+            return implementationMethod;
+        }
+        
+        public boolean areMethodParameterCountsEqual() {
+            // in case of captured arguments sometimes these do not match
+            return this.functionalMethod.getParameterCount() ==
+                    this.implementationMethod.getParameterCount();
+        }
+        
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                .append("kind=").append(kind)
+                .append(" func=").append(functionalMethod)
+                .append(" impl=").append(implementationMethod)
+                .append(" serialized=").append(serializedLambda)
+                .toString();
+        }
+    }
+    
+    static public LambdaInfo reflect(Object lambda) {
+        Objects.requireNonNull(lambda);
+        
+        // this will fail 
+        SerializedLambda serializedLambda = getSerializedLambda(lambda);
+        
+        Method functionalMethod;
+        try {
+            functionalMethod = getMethod(lambda.getClass(),
+                serializedLambda.getFunctionalInterfaceMethodName());
+            //log.debug("functionalMethod: {}", functionalMethod);
+            
+            // important: only way classes other than the creator can invoke it
+            functionalMethod.setAccessible(true);
+            
+            //functionalMethod = getFunctionalMethod(serializedLambda);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new RuntimeException("Unable to getFunctionalMethod", e);
+        }
+        
+        Method implementationMethod;
+        try {
+            implementationMethod = getImplementationMethod(serializedLambda);
+            //log.debug("implementationMethod: {}", implementationMethod);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new RuntimeException("Unable to getImplementationMethod", e);
+        }
+        
+        Kind kind;
+        
+        // https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/MethodHandleInfo.html
+        int implMethodKind = serializedLambda.getImplMethodKind();
+        
+        if (implMethodKind == 6) {  // REF_invokeStatic
+            if (serializedLambda.getImplMethodName().startsWith("lambda$")) {
+                kind = Kind.ANONYMOUS_METHOD_REFERENCE;
+            } else {
+                kind = Kind.STATIC_METHOD_REFERENCE;
+            }
+        } else {
+            if (serializedLambda.getCapturedArgCount() > 0) {
+                kind = Kind.SPECIFIC_INSTANCE_METHOD_REFERENCE;
+            } else {
+                kind = Kind.ANY_INSTANCE_METHOD_REFERENCE;
+            }
+        }
+        
+        return new LambdaInfo(lambda, kind, serializedLambda, functionalMethod, implementationMethod);
+    }
+    
+    /**
+     * Tries to get a SerializedLambda from an Object by searching the class
+     * hierarchy for a <code>writeReplace</code> method.  The lambda must
+     * be serializable in order for this method to return a value.
+     * @param lambda An object that is an instance of a functional interface. 
+     * @return The SerializedLambda
+     */
+    static public SerializedLambda getSerializedLambda(Object lambda) {
+        Objects.requireNonNull(lambda);
+        
+        if (!(lambda instanceof java.io.Serializable)) {
+            throw new IllegalArgumentException("Functional object does not implement java.io.Serializable");
+        }
+
+        for (Class<?> clazz = lambda.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            try {
+                Method replaceMethod = clazz.getDeclaredMethod("writeReplace");
+                replaceMethod.setAccessible(true);
+                Object serializedForm = replaceMethod.invoke(lambda);
+
+                if (serializedForm instanceof SerializedLambda) {
+                    return (SerializedLambda) serializedForm;
+                }
+            } catch (NoSuchMethodError e) {
+                // fall through the loop and try the next class
+            } catch (NoSuchMethodException e) {
+                throw new IllegalArgumentException("Functional object is not a lambda");
+            } catch (SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                throw new RuntimeException("Unable to cleanly serialize lambda", e);
+            }
+        }
+
+        throw new RuntimeException("writeReplace method not found");
+    }
+    
+    static public Method getFunctionalMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
+        return getMethod(serializedLambda.getFunctionalInterfaceClass(),
+            serializedLambda.getFunctionalInterfaceMethodName());
+    }
+    
+    static public Method getImplementationMethod(SerializedLambda serializedLambda) throws NoSuchMethodException, ClassNotFoundException {
+        return getMethod(serializedLambda.getImplClass(),
+            serializedLambda.getImplMethodName());
+    }
+    
+    static public Method getMethod(String className, String methodName) throws NoSuchMethodException, ClassNotFoundException {
+        Class<?> clazz = Class.forName(className.replace('/', '.'));
+        return getMethod(clazz, methodName);
+    }
+    
+    static public Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException, ClassNotFoundException {
+        while (clazz != null) {
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (method.getName().equals(methodName)) {
+                    return method;
+                }
+            }
+            // no match then try interfaces in order
+            for (Class<?> interfaceClass : clazz.getInterfaces()) {
+                for (Method method : interfaceClass.getDeclaredMethods()) {
+                    return method;
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        
+        throw new NoSuchMethodException("Method " + methodName + " not found in " + clazz);
+    }
+    
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,8 @@
 Version 6.x.x
 =============
-
- * 2016-09-01 Bump to minimum requirement of Java 8
+ 
+ * 2016-09-29 Route using Java 8 lambda expressions (jjlauer)
+ * 2016-09-01 Bump to minimum requirement of Java 8 (jjlauer)
  * 2016-09-01 jetty from 9.2.10.v20150310 to 9.3.11.v20160721
  * 2016-09-01 guava from 18.0 to 19.0
  * 2016-09-01 prettytime from 3.2.7.Final to 4.0.1

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/basic_concepts.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/basic_concepts.md
@@ -21,7 +21,7 @@ public class Routes implements ApplicationRoutes {
     @Override
     public void init(Router router) {
 
-        router.GET().route("/").with(ApplicationController.class, "index");
+        router.GET().route("/").with(ApplicationController::index);
 
     }
 }

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
@@ -62,7 +62,7 @@ Let's say and the user visits the following URL...
 ... and we got a route definition like that:
 
 <pre class="prettyprint">
-router.GET().route("/user/{id}/{email}/userDashboard").with(AppController.class, "userDashboard");
+router.GET().route("/user/{id}/{email}/userDashboard").with(AppController::userDashboard);
 </pre>
 
 We can then get all variable parts of this URL via the following method controller

--- a/ninja-core/src/site/markdown/documentation/getting_started/the_mvc_pattern.md
+++ b/ninja-core/src/site/markdown/documentation/getting_started/the_mvc_pattern.md
@@ -40,7 +40,7 @@ public class Routes implements ApplicationRoutes {
     @Override
     public void init(Router router) {
 
-        router.GET().route("/").with(ApplicationController.class, "index");
+        router.GET().route("/").with(ApplicationController::index);
 
     }
 }

--- a/ninja-core/src/site/markdown/documentation/upgrade_guide.md
+++ b/ninja-core/src/site/markdown/documentation/upgrade_guide.md
@@ -7,8 +7,10 @@ your application to the latest Ninja version. Simply start with your current
 version and then work your way up to the top of the document.
 
 
-to latest
----------
+to 6.0.0
+--------
+
+Java 8 is required.
 
 to 5.4.0
 --------

--- a/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouteBuilderImplTest.java
@@ -29,8 +29,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.inject.Injector;
 import ninja.utils.MethodReference;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RouteBuilderImplTest {
@@ -39,83 +41,69 @@ public class RouteBuilderImplTest {
     Injector injector;
 
     @Test
-    public void testBasicGETRoute() {
-
+    public void basicGETRoute() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("GET", "/index"));
-
     }
 
     @Test
-    public void testBasicPOSTRoute() {
-
+    public void basicPOSTRoute() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.POST().route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("POST", "/index"));
-
     }
 
     @Test
-    public void testBasicPUTRoute() {
-
+    public void basicPUTRoute() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.PUT().route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("PUT", "/index"));
-
     }
 
     @Test
-    public void testBasicRoutes() {
-
+    public void basicRoutes() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.OPTIONS().route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("OPTIONS", "/index"));
-
     }
     
     @Test
-    public void testBasisHEAD() {
-
+    public void basisHEAD() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.HEAD().route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("HEAD", "/index"));
-
     }
     
     @Test
-    public void testBasicAnyHttpMethod() {
-
+    public void basicAnyHttpMethod() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.METHOD("PROPFIND").route("/index");
 
         assertTrue(buildRoute(routeBuilder).matches("PROPFIND", "/index"));
-
     }
 
     @Test
-    public void testBasicRoutesWithRegex() {
-
+    public void basicRoutesWithRegex() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/.*");
 
         Route route = buildRoute(routeBuilder);
-        // make sure the route catches everything:
+        
+        // make sure the route catches everything
         assertTrue(route.matches("GET", "/index"));
         assertTrue(route.matches("GET", "/stylesheet.css"));
         assertTrue(route.matches("GET", "/public/stylesheet.css"));
         assertTrue(route.matches("GET", "/public/bootstrap.js"));
-
     }
 
     @Test
-    public void testBasicPlaceholersAndParameters() {
-
+    public void basicPlaceholersAndParameters() {
         // /////////////////////////////////////////////////////////////////////
         // One parameter:
         // /////////////////////////////////////////////////////////////////////
@@ -149,12 +137,10 @@ public class RouteBuilderImplTest {
         assertEquals(2, map.entrySet().size());
         assertEquals("John", map.get("name"));
         assertEquals("20", map.get("id"));
-
     }
 
     @Test
-    public void testBasicPlaceholersParametersAndRegex() {
-
+    public void basicPlaceholersParametersAndRegex() {
         // test that parameter parsing works in conjunction with
         // regex expressions...
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
@@ -178,9 +164,8 @@ public class RouteBuilderImplTest {
 
     }
 
-        @Test
-    public void testBasicPlaceholersParametersAndRegexInsideVariableParts() {
-
+    @Test
+    public void basicPlaceholersParametersAndRegexInsideVariableParts() {
         // test that parameter parsing works in conjunction with
         // regex expressions...
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
@@ -220,7 +205,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testParametersDontCrossSlashes() {
+    public void parametersDontCrossSlashes() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}/{id2}/{id3}/morestuff/at/the/end");
         Route route = buildRoute(routeBuilder);
@@ -232,7 +217,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testPointsInRegexDontCrashRegexInTheMiddleOfTheRoute() {
+    public void pointsInRegexDontCrashRegexInTheMiddleOfTheRoute() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}/myname");
         Route route = buildRoute(routeBuilder);
@@ -254,7 +239,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testPointsInRegexDontCrashRegexAtEnd() {
+    public void pointsInRegexDontCrashRegexAtEnd() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}");
         Route route = buildRoute(routeBuilder);
@@ -269,7 +254,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testRegexInRouteWorksWithEscapes() {
+    public void regexInRouteWorksWithEscapes() {
         // Test escaped constructs in regex
         // regex with escaped construct in a route
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
@@ -290,7 +275,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testRegexInRouteWorksWithoutSlashAtTheEnd() {
+    public void regexInRouteWorksWithoutSlashAtTheEnd() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}/.*");
         Route route = buildRoute(routeBuilder);
@@ -317,7 +302,7 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testRouteWithUrlEncodedSlashGetsChoppedCorrectly() {
+    public void routeWithUrlEncodedSlashGetsChoppedCorrectly() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/blah/{id}/.*");
         Route route = buildRoute(routeBuilder);
@@ -336,7 +321,9 @@ public class RouteBuilderImplTest {
     }
 
     @Test
-    public void testRouteWithResult() {
+    public void routeWithResult() {
+        Context context = mock(Context.class);
+        
         String template = "/directly_result/stuff";
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/directly_result/route").with(Results.html().template(template));
@@ -344,12 +331,12 @@ public class RouteBuilderImplTest {
         Route route = routeBuilder.buildRoute(injector);
         assertTrue(route.matches("GET", "/directly_result/route"));
 
-        Result result = route.getFilterChain().next(null);
+        Result result = route.getFilterChain().next(context);
         assertEquals(result.getTemplate(), template);
     }
 
     @Test
-    public void testFailedControllerRegistration() {
+    public void failedControllerRegistration() {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/failure").with(MockController.class, "DoesNotExist");
 
@@ -362,14 +349,14 @@ public class RouteBuilderImplTest {
     }
     
     @Test
-    public void testRouteWithMethodReference() throws Exception {
+    public void routeWithMethodReference() throws Exception {
         RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
         routeBuilder.GET().route("/method_reference").with(new MethodReference(MockController.class, "execute"));
 
         Route route = routeBuilder.buildRoute(injector);
         assertTrue(route.matches("GET", "/method_reference"));
 
-        assertThat(route.getControllerClass().newInstance(), instanceOf(MockController.class));
+        assertThat(route.getControllerClass(), is(MockController.class));
     }
 
     private Route buildRoute(RouteBuilderImpl builder) {
@@ -381,6 +368,78 @@ public class RouteBuilderImplTest {
         public Result execute() {
             return null;
         }
+        public Result execute2(Context context) {
+            return null;
+        }
+        static public Result execute3(Context context) {
+            return null;
+        }
+    }
+    
+    @Test
+    public void routeToAnyInstanceMethodReference() throws Exception {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/execute").with(MockController::execute);
+        Route route = routeBuilder.buildRoute(injector);
+        
+        assertTrue(route.matches("GET", "/execute"));
+        assertThat(route.getControllerClass(), is(MockController.class));
+        assertThat(route.getControllerMethod().getName(), is("execute"));
+    }
+    
+    @Test
+    public void routeToSpecificInstanceMethodReference() throws Exception {
+        MockController controller = new MockController();
+        
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/execute").with(controller::execute);
+        Route route = routeBuilder.buildRoute(injector);
+        
+        assertTrue(route.matches("GET", "/execute"));
+        assertThat(route.getControllerClass().getCanonicalName(), startsWith(this.getClass().getCanonicalName()));
+        assertThat(route.getControllerMethod().getName(), is("apply"));
+    }
+    
+    @Test
+    public void routeToStaticMethodReference() throws Exception {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/execute").with(MockController::execute3);
+        Route route = routeBuilder.buildRoute(injector);
+        
+        assertTrue(route.matches("GET", "/execute"));
+        assertThat(route.getControllerClass(), is(MockController.class));
+        assertThat(route.getControllerMethod().getName(), is("execute3"));
+    }
+    
+    @Test
+    @SuppressWarnings("Convert2Lambda")
+    public void routeToAnonymousClassReference() throws Exception {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        
+        routeBuilder.GET().route("/execute").with(new ControllerMethods.ControllerMethod0() {
+            @Override
+            public Result apply() {
+                return Results.redirect("/");
+            }
+        });
+        
+        Route route = routeBuilder.buildRoute(injector);
+        
+        assertTrue(route.matches("GET", "/execute"));
+        assertThat(route.getControllerClass().isAnonymousClass(), is(true));
+        assertThat(route.getControllerMethod().getName(), is("apply"));
+    }
+    
+    @Test
+    public void routeToAnonymousMethodReference() throws Exception {
+        RouteBuilderImpl routeBuilder = new RouteBuilderImpl();
+        routeBuilder.GET().route("/execute").with(() -> Results.redirect("/"));
+        Route route = routeBuilder.buildRoute(injector);
+        
+        assertTrue(route.matches("GET", "/execute"));
+        // should be a class within this test class as a real lambda
+        assertThat(route.getControllerClass().getCanonicalName(), startsWith(this.getClass().getCanonicalName()));
+        assertThat(route.getControllerMethod().getName(), is("apply"));
     }
 
 }

--- a/ninja-core/src/test/java/ninja/RouterImplTest.java
+++ b/ninja-core/src/test/java/ninja/RouterImplTest.java
@@ -20,18 +20,23 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import ninja.utils.NinjaProperties;
-
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import java.util.Collections;
+import ninja.ControllerMethods.ControllerMethod0;
+import ninja.ControllerMethods.ControllerMethod1;
+import ninja.params.Param;
+import ninja.params.ParamParsers;
 import ninja.utils.MethodReference;
+import ninja.validation.ValidationImpl;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * => Most tests are done via class RoutesTest in project
@@ -52,50 +57,73 @@ public class RouterImplTest {
     Provider<TestController> testControllerProvider;
 
     @Before
+    @SuppressWarnings("Convert2Lambda")
     public void before() {
-
         when(testControllerProvider.get()).thenReturn(new TestController());
         when(injector.getProvider(TestController.class)).thenReturn(testControllerProvider);
+        when(injector.getInstance(ParamParsers.class)).thenReturn(new ParamParsers(Collections.emptySet()));
         router = new RouterImpl(injector, ninjaProperties);
 
         // add route:
         router.GET().route("/testroute").with(TestController.class, "index");
         router.GET().route("/user/{email}/{id: .*}").with(TestController.class, "user");
         router.GET().route("/u{userId: .*}/entries/{entryId: .*}").with(TestController.class, "entry");
+        
         // second route to index should not break reverse routing matching the first
         router.GET().route("/testroute/another_url_by_index").with(TestController.class, "index");
         router.GET().route("/ref").with(new MethodReference(TestController.class, "ref"));
+        
+        // functional interface / lambda routing
+        TestController testController1 = new TestController("Hi!");
+        router.GET().route("/any_instance_method_ref").with(TestController::home);
+        router.GET().route("/any_instance_method_ref_exception").with(TestController::exception);
+        router.GET().route("/any_instance_method_ref2").with(ControllerMethods.of(TestController::home));
+        router.GET().route("/specific_instance_method_ref").with(testController1::message);
+        router.GET().route("/specific_instance_method_ref_annotations").with(testController1::status);
+        router.GET().route("/anonymous_method_ref").with(() -> Results.status(202));
+        Result staticResult = Results.status(208);
+        router.GET().route("/anonymous_method_ref_captured").with(() -> staticResult);
+        router.GET().route("/anonymous_method_ref_context").with((Context context) -> Results.status(context.getParameterAsInteger("status")));
+        router.GET().route("/anonymous_class").with(new ControllerMethod0() {
+            @Override
+            public Result apply() {
+                return Results.status(203);
+            }
+        });
+        router.GET().route("/anonymous_class_annotations").with(new ControllerMethod1<Integer>() {
+            @Override
+            public Result apply(@Param("status") Integer status) {
+                return Results.status(status);
+            }
+        });
         
         router.compileRoutes();
     }
 
     @Test
-    public void testGetReverseRouteWithNoContextPathWorks() {
-
+    public void getReverseRouteWithNoContextPathWorks() {
         String contextPath = "";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
 
         String route = router.getReverseRoute(TestController.class, "index");
 
-        assertThat(route, CoreMatchers.equalTo("/testroute"));
-
+        assertThat(route, is("/testroute"));
+        
     }
-
+    
     @Test
-    public void testGetReverseRouteContextPathWorks() {
-
+    public void getReverseRouteContextPathWorks() {
         String contextPath = "/myappcontext";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
 
         String route = router.getReverseRoute(TestController.class, "index");
 
-        assertThat(route, equalTo("/myappcontext/testroute"));
+        assertThat(route, is("/myappcontext/testroute"));
 
     }
 
     @Test
-    public void testGetReverseRouteWithRegexWorks() {
-
+    public void getReverseRouteWithRegexWorks() {
         String contextPath = "";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
 
@@ -107,12 +135,12 @@ public class RouterImplTest {
                 "id",
                 10000);
 
-        assertThat(route, equalTo("/user/me@me.com/10000"));
+        assertThat(route, is("/user/me@me.com/10000"));
 
     }
 
     @Test
-    public void testGetReverseRouteWithRegexAndQueryParametersWorks() {
+    public void getReverseRouteWithRegexAndQueryParametersWorks() {
 
         String contextPath = "";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
@@ -132,7 +160,7 @@ public class RouterImplTest {
     }
 
     @Test
-    public void testGetReverseRouteWithMultipleRegexWorks() {
+    public void getReverseRouteWithMultipleRegexWorks() {
 
         String contextPath = "";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
@@ -144,8 +172,7 @@ public class RouterImplTest {
     }
     
     @Test
-    public void testGetReverseRouteWithMethodReference() {
-
+    public void getReverseRouteWithMethodReference() {
         String contextPath = "";
         when(ninjaProperties.getContextPath()).thenReturn(contextPath);
 
@@ -157,33 +184,161 @@ public class RouterImplTest {
         assertThat(route2, is("/ref"));
     }
 
-    // Just a dummy TestController for mocking...
+    @Test
+    public void routeForAnyInstanceMethodReference() {
+        Route route = router.getRouteFor("GET", "/any_instance_method_ref");
+
+        Result result = route.getFilterChain().next(null);
+        
+        assertThat(result.getStatusCode(), is(201));
+    }
+    
+    @Test
+    public void routeForAnyInstanceMethodReferenceThrowsException() {
+        Route route = router.getRouteFor("GET", "/any_instance_method_ref_exception");
+
+        try {
+            Result result = route.getFilterChain().next(null);
+            fail();
+        } catch (Exception e) {
+            assertThat(e.getCause().getMessage(), is("test"));
+        }
+    }
+    
+    @Test
+    public void routeForAnyInstanceMethodReference2() {
+        Route route = router.getRouteFor("GET", "/any_instance_method_ref2");
+
+        Result result = route.getFilterChain().next(null);
+        
+        assertThat(result.getStatusCode(), is(201));
+    }
+    
+    @Test
+    public void routeForSpecificInstanceMethodReference() {
+        Route route = router.getRouteFor("GET", "/specific_instance_method_ref");
+
+        Result result = route.getFilterChain().next(null);
+        
+        // message set on specific instance
+        assertThat(result.getRenderable(), is("Hi!"));
+    }
+    
+    @Test
+    public void routeForSpecificInstanceMethodReferenceWithAnnotations() {
+        Context context = mock(Context.class);
+        when(context.getParameter("status")).thenReturn("207");
+        when(context.getValidation()).thenReturn(new ValidationImpl());
+        
+        Route route = router.getRouteFor("GET", "/specific_instance_method_ref_annotations");
+
+        Result result = route.getFilterChain().next(context);
+        
+        // message set on specific instance
+        assertThat(result.getStatusCode(), is(207));
+        assertThat(result.getRenderable(), is("Hi!"));
+    }
+    
+    @Test
+    public void routeForAnonymoumsMethodReference() {
+        Route route = router.getRouteFor("GET", "/anonymous_method_ref");
+
+        Result result = route.getFilterChain().next(null);
+        
+        assertThat(result.getStatusCode(), is(202));
+    }
+    
+    @Test
+    public void routeForAnonymoumsMethodReferenceWithCaptured() {
+        Context context = mock(Context.class);
+        
+        Route route = router.getRouteFor("GET", "/anonymous_method_ref_captured");
+
+        Result result = route.getFilterChain().next(context);
+        
+        assertThat(result.getStatusCode(), is(208));
+    }
+    
+    @Test
+    public void routeForAnonymoumsMethodReferenceWithContext() {
+        Context context = mock(Context.class);
+        when(context.getParameterAsInteger("status")).thenReturn(206);
+        
+        Route route = router.getRouteFor("GET", "/anonymous_method_ref_context");
+
+        Result result = route.getFilterChain().next(context);
+        
+        assertThat(result.getStatusCode(), is(206));
+    }
+    
+    @Test
+    public void routeForAnonymoumsClassInstance() {
+        Route route = router.getRouteFor("GET", "/anonymous_class");
+
+        Result result = route.getFilterChain().next(null);
+        
+        assertThat(result.getStatusCode(), is(203));
+    }
+    
+    @Test
+    public void routeForAnonymoumsClassInstanceWithAnnotations() {
+        Context context = mock(Context.class);
+        when(context.getParameter("status")).thenReturn("205");
+        when(context.getValidation()).thenReturn(new ValidationImpl());
+        
+        Route route = router.getRouteFor("GET", "/anonymous_class_annotations");
+
+        Result result = route.getFilterChain().next(context);
+        
+        assertThat(result.getStatusCode(), is(205));
+    }
+
+    /**
+     * A dummy TestController for mocking.
+     */
     public static class TestController {
-
+        
+        private final String message;
+        
+        public TestController() {
+            this("not set");
+        }
+        
+        public TestController(String message) {
+            this.message = message;
+        }
+        
         public Result index() {
-
             return Results.ok();
-
         }
 
         public Result user() {
-
             return Results.ok();
-
         }
 
         public Result entry() {
-
             return Results.ok();
+        }
 
+        public Result ref() {
+            return Results.ok();
+        }
+
+        public Result home() {
+            return Results.status(201);
         }
         
-        public Result ref() {
-
-            return Results.ok();
-
+        public Result message() {
+            return Results.ok().render(message);
         }
-
+        
+        public Result status(@Param("status") Integer status) {
+            return Results.status(status).render(message);
+        }
+        
+        public Result exception() throws Exception {
+            throw new Exception("test");
+        }
     }
-
+    
 }

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -851,7 +851,7 @@ public class ControllerMethodInvokerTest {
                 break;
             }
         }
-        return ControllerMethodInvoker.build(method, Guice.createInjector(new AbstractModule() {
+        return ControllerMethodInvoker.build(method, method, Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {
                 Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);

--- a/ninja-core/src/test/java/ninja/utils/LambdasTest.java
+++ b/ninja-core/src/test/java/ninja/utils/LambdasTest.java
@@ -19,6 +19,7 @@ package ninja.utils;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -172,26 +173,6 @@ public class LambdasTest {
         assertThat(serializedLambda.getImplMethodSignature(), is("(Lninja/Context;)Lninja/Result;"));
         assertThat(serializedLambda.getImplMethodKind(), is(6));    // 6 = REF_invokeStatic
         assertThat(serializedLambda.getCapturedArgCount(), is(0));
-    }
-    
-    @Test @Ignore
-    public void anonymousMethodReferenceErasesParameterAnnotations() throws Exception {
-        ControllerMethod2<Context,String> lambda = (Context context, @Param("a") String a) -> Results.html().renderRaw(a.getBytes(StandardCharsets.UTF_8));
-        
-        Method method = Arrays.asList(lambda.getClass().getDeclaredMethods()).stream()
-            .filter(m -> m.getName().equals("apply"))
-            .findFirst()
-            .get();
-        
-        System.out.println("method: " + method);
-        
-        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        for (Annotation[] as : parameterAnnotations) {
-            for (Annotation a : as) {
-                System.out.println("annotation: " + a.annotationType());
-            }
-        }
-        
     }
 
 }

--- a/ninja-core/src/test/java/ninja/utils/LambdasTest.java
+++ b/ninja-core/src/test/java/ninja/utils/LambdasTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.utils;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import ninja.Context;
+import ninja.Result;
+import ninja.Results;
+import ninja.params.Param;
+import ninja.ControllerMethods.ControllerMethod1;
+import ninja.ControllerMethods.ControllerMethod2;
+import ninja.utils.Lambdas.Kind;
+import ninja.utils.Lambdas.LambdaInfo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import org.junit.Ignore;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class LambdasTest {
+
+    @FunctionalInterface
+    static public interface Function1<T,R> extends Serializable {
+        R apply(T t);
+    }
+    
+    @FunctionalInterface
+    static public interface Function2<C,T,R> extends Serializable { 
+        R apply(C c, T t);
+    }
+    
+    static private String longToString(Long value) {
+        return value.toString();
+    }
+    
+    @Test
+    public void staticMethodReference() throws Exception {
+        Function1<Long,String> lambda = LambdasTest::longToString;
+        
+        LambdaInfo lambdaInfo = Lambdas.reflect(lambda);
+        
+        assertThat(lambdaInfo.getKind(), is(Kind.STATIC_METHOD_REFERENCE));
+        
+        SerializedLambda serializedLambda = lambdaInfo.getSerializedLambda();
+        
+        assertThat(serializedLambda.getFunctionalInterfaceMethodName(), is("apply"));
+        assertThat(serializedLambda.getImplClass().replace('/', '.'), is(LambdasTest.class.getCanonicalName()));
+        assertThat(serializedLambda.getImplMethodName(), is("longToString"));
+        assertThat(serializedLambda.getImplMethodKind(), is(6));    // 6 = static method
+        assertThat(serializedLambda.getCapturedArgCount(), is(0));
+        
+        // verify it can be dynamically invoked
+        String value = (String)lambdaInfo.getImplementationMethod().invoke(null, 1L);
+        
+        assertThat(value, is("1"));
+    }
+    
+    static public class Calculator {
+        private final Long initial;
+
+        public Calculator(Long initial) {
+            this.initial = initial;
+        }
+        
+        public String l2s(Long value) {
+            long calculated = initial + value;
+            return Long.toString(calculated);
+        }
+    }
+    
+    @Test
+    public void specificInstanceMethodReference() throws Exception {
+        Calculator calc = new Calculator(1L);
+        
+        Function1<Long,String> lambda = calc::l2s;
+        
+        LambdaInfo lambdaInfo = Lambdas.reflect(lambda);
+        
+        assertThat(lambdaInfo.getKind(), is(Kind.SPECIFIC_INSTANCE_METHOD_REFERENCE));
+        
+        SerializedLambda serializedLambda = lambdaInfo.getSerializedLambda();
+        
+        assertThat(serializedLambda.getFunctionalInterfaceMethodName(), is("apply"));
+        assertThat(serializedLambda.getImplClass().replace('/', '.').replace('$', '.'), is(Calculator.class.getCanonicalName()));
+        assertThat(serializedLambda.getImplMethodName(), is("l2s"));
+        assertThat(serializedLambda.getImplMethodSignature(), is("(Ljava/lang/Long;)Ljava/lang/String;"));
+        assertThat(serializedLambda.getCapturedArgCount(), is(1));  // captured "this"
+        assertThat(serializedLambda.getCapturedArg(0), is(calc));   // captured "this"
+        
+        // verify it can be dynamically invoked
+        String value = (String)lambdaInfo.getFunctionalMethod().invoke(lambda, 1L);
+        //String value = (String)lambda.getClass().getMethod("apply", Long.class).invoke(calc, 1L);
+        
+        assertThat(value, is("2"));
+    }
+    
+    private Result home() {
+        return Results.html().renderRaw("Hi".getBytes(StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    public void anyInstanceMethodReference() throws Exception {
+        ControllerMethod1<LambdasTest> lambda = LambdasTest::home;
+        
+        LambdaInfo lambdaInfo = Lambdas.reflect(lambda);
+        
+        assertThat(lambdaInfo.getKind(), is(Kind.ANY_INSTANCE_METHOD_REFERENCE));
+        
+        SerializedLambda serializedLambda = lambdaInfo.getSerializedLambda();
+        
+        assertThat(serializedLambda.getFunctionalInterfaceMethodName(), is("apply"));
+        assertThat(serializedLambda.getImplClass().replace('/', '.'), is(LambdasTest.class.getCanonicalName()));
+        assertThat(serializedLambda.getImplMethodName(), is("home"));
+        assertThat(serializedLambda.getImplMethodSignature(), is("()Lninja/Result;"));
+        assertThat(serializedLambda.getCapturedArgCount(), is(0));
+    }
+    
+    @Test
+    public void anonymousClassReference() throws Exception {
+        @SuppressWarnings("Convert2Lambda")
+        ControllerMethod1<Context> lambda = new ControllerMethod1<Context>() {
+            @Override
+            public Result apply(Context a) {
+                return Results.html().renderRaw("".getBytes(StandardCharsets.UTF_8));
+            }
+        };
+        
+        try {
+            LambdaInfo lambdaInfo = Lambdas.reflect(lambda);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void anonymousMethodReference() throws Exception {
+        ControllerMethod1<Context> lambda = (Context context) -> Results.html().renderRaw("".getBytes(StandardCharsets.UTF_8));
+        
+        LambdaInfo lambdaInfo = Lambdas.reflect(lambda);
+        
+        assertThat(lambdaInfo.getKind(), is(Kind.ANONYMOUS_METHOD_REFERENCE));
+        
+        SerializedLambda serializedLambda = lambdaInfo.getSerializedLambda();
+        
+        assertThat(serializedLambda.getFunctionalInterfaceMethodName(), is("apply"));
+        assertThat(serializedLambda.getImplClass().replace('/', '.'), is(LambdasTest.class.getCanonicalName()));
+        assertThat(serializedLambda.getImplMethodName(), startsWith("lambda$"));
+        assertThat(serializedLambda.getInstantiatedMethodType(), is("(Lninja/Context;)Lninja/Result;"));
+        // includes captured args btw...
+        assertThat(serializedLambda.getImplMethodSignature(), is("(Lninja/Context;)Lninja/Result;"));
+        assertThat(serializedLambda.getImplMethodKind(), is(6));    // 6 = REF_invokeStatic
+        assertThat(serializedLambda.getCapturedArgCount(), is(0));
+    }
+    
+    @Test @Ignore
+    public void anonymousMethodReferenceErasesParameterAnnotations() throws Exception {
+        ControllerMethod2<Context,String> lambda = (Context context, @Param("a") String a) -> Results.html().renderRaw(a.getBytes(StandardCharsets.UTF_8));
+        
+        Method method = Arrays.asList(lambda.getClass().getDeclaredMethods()).stream()
+            .filter(m -> m.getName().equals("apply"))
+            .findFirst()
+            .get();
+        
+        System.out.println("method: " + method);
+        
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        for (Annotation[] as : parameterAnnotations) {
+            for (Annotation a : as) {
+                System.out.println("annotation: " + a.annotationType());
+            }
+        }
+        
+    }
+
+}

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/conf/Routes.java
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/src/main/java/conf/Routes.java
@@ -30,20 +30,20 @@ public class Routes implements ApplicationRoutes {
     @Override
     public void init(Router router) {  
         
-        router.GET().route("/").with(ApplicationController.class, "index");
-        router.GET().route("/hello_world.json").with(ApplicationController.class, "helloWorldJson");
+        router.GET().route("/").with(ApplicationController::index);
+        router.GET().route("/hello_world.json").with(ApplicationController::helloWorldJson);
         
  
         ///////////////////////////////////////////////////////////////////////
         // Assets (pictures / javascript)
         ///////////////////////////////////////////////////////////////////////    
-        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");
-        router.GET().route("/assets/{fileName: .*}").with(AssetsController.class, "serveStatic");
+        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController::serveWebJars);
+        router.GET().route("/assets/{fileName: .*}").with(AssetsController::serveStatic);
         
         ///////////////////////////////////////////////////////////////////////
         // Index / Catchall shows index page
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/.*").with(ApplicationController.class, "index");
+        router.GET().route("/.*").with(ApplicationController::index);
     }
 
 }

--- a/ninja-servlet-integration-test/src/main/java/conf/Routes.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Routes.java
@@ -35,10 +35,14 @@ import controllers.PrettyTimeController;
 import controllers.UdpPingController;
 import controllers.UploadController;
 import controllers.UploadControllerAuto;
+import java.nio.charset.StandardCharsets;
+import ninja.Context;
+import ninja.ControllerMethods;
+import ninja.session.Session;
 
 public class Routes implements ApplicationRoutes {
 
-    private NinjaProperties ninjaProperties;
+    private final NinjaProperties ninjaProperties;
 
     @Inject
     public Routes(NinjaProperties ninjaProperties) {
@@ -61,120 +65,138 @@ public class Routes implements ApplicationRoutes {
         // /////////////////////////////////////////////////////////////////////
         // some default functions
         // /////////////////////////////////////////////////////////////////////
-        // simply render a page:
-        router.GET().route("/").with(ApplicationController.class, "index");
+        // render a page
+        router.GET().route("/").with(ApplicationController::index);
 
-        // with result
-        router.GET().route("/route_with_result").with(Results.html().template("/views/routeWithResult.ftl.html"));
+        // with static result (not recommended w/ new lambda feature)
+        router.GET().route("/route_with_result")
+            .with(Results.html().template("/views/routeWithResult.ftl.html"));
 
+        // lambda routing
+        router.GET().route("/lambda_anonymous")
+            .with(() -> {
+                return Results.status(201).renderRaw("Hi!".getBytes(StandardCharsets.UTF_8));
+            });
+
+        // controller method using lambda and arguments
+        router.GET().route("/lambda_anonymous_args")
+            .with((Context context, Session session) -> {
+                session.clear();
+                String body = "Query: " + context.getParameter("a");
+                return Results.html().renderRaw(body.getBytes(StandardCharsets.UTF_8));
+            });
+        
         // render a page with variable route parts:
-        router.GET().route("/user/{id}/{email}/userDashboard").with(ApplicationController.class, "userDashboard");
+        // use of() method to verify it works
+        router.GET().route("/user/{id}/{email}/userDashboard").with(ControllerMethods.of(ApplicationController::userDashboard));
 
-        router.GET().route("/validation").with(ApplicationController.class, "validation");
+        router.GET().route("/validation").with(ApplicationController::validation);
 
+        // retain legacy class+methodName to verify backwards compat
         router.GET().route("/jsonp").with(ApplicationController.class, "testJsonP");
 
         // redirect back to /
-        router.GET().route("/redirect").with(ApplicationController.class, "redirect");
+        router.GET().route("/redirect").with(ApplicationController::redirect);
 
-        router.GET().route("/session").with(ApplicationController.class, "session");
+        router.GET().route("/session").with(ApplicationController::session);
 
-        router.GET().route("/flash_success").with(ApplicationController.class, "flashSuccess");
-        router.GET().route("/flash_error").with(ApplicationController.class, "flashError");
-        router.GET().route("/flash_any").with(ApplicationController.class, "flashAny");
+        router.GET().route("/flash_success").with(ApplicationController::flashSuccess);
+        router.GET().route("/flash_error").with(ApplicationController::flashError);
+        router.GET().route("/flash_any").with(ApplicationController::flashAny);
 
-        router.GET().route("/htmlEscaping").with(ApplicationController.class, "htmlEscaping");
-        router.GET().route("/test_reverse_routing").with(ApplicationController.class, "testReverseRouting");
-        router.GET().route("/test_get_context_path_works").with(ApplicationController.class, "testGetContextPathWorks");
-        router.GET().route("/test_that_freemarker_emits_400_when_template_not_found").with(Results.html().template("/views/A_TEMPLATE_THAT_DOES_NOT_EXIST.ftl.html"));
+        router.GET().route("/htmlEscaping").with(ApplicationController::htmlEscaping);
+        router.GET().route("/test_reverse_routing").with(ApplicationController::testReverseRouting);
+        router.GET().route("/test_get_context_path_works").with(ApplicationController::testGetContextPathWorks);
+        router.GET().route("/test_that_freemarker_emits_400_when_template_not_found")
+            .with(Results.html().template("/views/A_TEMPLATE_THAT_DOES_NOT_EXIST.ftl.html"));
         // /////////////////////////////////////////////////////////////////////
         // Json support
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/api/person.json").with(PersonController.class, "getPersonJson");
-        router.POST().route("/api/person.json").with(PersonController.class, "postPersonJson");
+        router.GET().route("/api/person.json").with(PersonController::getPersonJson);
+        router.POST().route("/api/person.json").with(PersonController::postPersonJson);
 
-        router.GET().route("/api/person.xml").with(PersonController.class, "getPersonXml");
-        router.POST().route("/api/person.xml").with(PersonController.class, "postPersonXml");
+        router.GET().route("/api/person.xml").with(PersonController::getPersonXml);
+        router.POST().route("/api/person.xml").with(PersonController::postPersonXml);
 
-        router.GET().route("/api/person").with(PersonController.class, "getPersonViaContentNegotiation");
-        router.GET().route("/api/person_with_content_negotiation_fallback").with(PersonController.class, "getPersonViaContentNegotiationAndFallback");
+        router.GET().route("/api/person").with(PersonController::getPersonViaContentNegotiation);
+        router.GET().route("/api/person_with_content_negotiation_fallback").with(PersonController::getPersonViaContentNegotiationAndFallback);
 
         // /////////////////////////////////////////////////////////////////////
         // Form parsing support
         // /////////////////////////////////////////////////////////////////////
-        router.POST().route("/form").with(ApplicationController.class, "postForm");
+        router.POST().route("/form").with(ApplicationController::postForm);
 
         // /////////////////////////////////////////////////////////////////////
         // Direct object rendering with template test
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/direct_rendering").with(ApplicationController.class, "directObjectTemplateRendering");
+        router.GET().route("/direct_rendering").with(ApplicationController::directObjectTemplateRendering);
 
         // /////////////////////////////////////////////////////////////////////
         // Cache support test
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/test_caching").with(ApplicationController.class, "testCaching");
+        router.GET().route("/test_caching").with(ApplicationController::testCaching);
 
         // /////////////////////////////////////////////////////////////////////
         // Lifecycle support
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/udpcount").with(UdpPingController.class, "getCount");
+        router.GET().route("/udpcount").with(UdpPingController::getCount);
 
         // /////////////////////////////////////////////////////////////////////
         // Route filtering example:
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/filter").with(FilterController.class, "filter");
-        router.GET().route("/teapot").with(FilterController.class, "teapot");
+        router.GET().route("/filter").with(FilterController::filter);
+        router.GET().route("/teapot").with(FilterController::teapot);
 
         // /////////////////////////////////////////////////////////////////////
         // Route filtering example:
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/injection").with(InjectionExampleController.class, "injection");
-        router.GET().route("/serviceInitTime").with(InjectionExampleController.class, "serviceInitTime");
+        router.GET().route("/injection").with(InjectionExampleController::injection);
+        router.GET().route("/serviceInitTime").with(InjectionExampleController::serviceInitTime);
 
         // /////////////////////////////////////////////////////////////////////
         // Async example:
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/async").with(AsyncController.class, "asyncEcho");
+        router.GET().route("/async").with(AsyncController::asyncEcho);
 
         // /////////////////////////////////////////////////////////////////////
         // I18n:
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/i18n").with(I18nController.class, "index");
-        router.GET().route("/i18n/{language}").with(I18nController.class, "indexWithLanguage");
+        router.GET().route("/i18n").with(I18nController::index);
+        router.GET().route("/i18n/{language}").with(I18nController::indexWithLanguage);
 
         // /////////////////////////////////////////////////////////////////////
         // PrettyTime:
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/prettyTime").with(PrettyTimeController.class, "index");
-        router.GET().route("/prettyTime/{language}").with(PrettyTimeController.class, "indexWithLanguage");
+        router.GET().route("/prettyTime").with(PrettyTimeController::index);
+        router.GET().route("/prettyTime/{language}").with(PrettyTimeController::indexWithLanguage);
 
         // /////////////////////////////////////////////////////////////////////
         // Upload showcase
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/upload").with(UploadController.class, "upload");
-        router.POST().route("/uploadFinish").with(UploadController.class, "uploadFinish");
-        router.POST().route("/uploadFinishAuto").with(UploadControllerAuto.class, "uploadFinishAuto");
+        router.GET().route("/upload").with(UploadController::upload);
+        router.POST().route("/uploadFinish").with(UploadController::uploadFinish);
+        router.POST().route("/uploadFinishAuto").with(UploadControllerAuto::uploadFinishAuto);
         
         // /////////////////////////////////////////////////////////////////////
         // Authenticity
         // /////////////////////////////////////////////////////////////////////
-        router.GET().route("/token").with(AuthenticityController.class, "token");
-        router.GET().route("/form").with(AuthenticityController.class, "form");
-        router.GET().route("/authenticate").with(AuthenticityController.class, "authenticate");
-        router.GET().route("/notauthenticate").with(AuthenticityController.class, "notauthenticate");
-        router.GET().route("/unauthorized").with(AuthenticityController.class, "unauthorized");
-        router.POST().route("/authorized").with(AuthenticityController.class, "authorized");
+        router.GET().route("/token").with(AuthenticityController::token);
+        router.GET().route("/form").with(AuthenticityController::form);
+        router.GET().route("/authenticate").with(AuthenticityController::authenticate);
+        router.GET().route("/notauthenticate").with(AuthenticityController::notauthenticate);
+        router.GET().route("/unauthorized").with(AuthenticityController::unauthorized);
+        router.POST().route("/authorized").with(AuthenticityController::authorized);
         
         //this is a route that should only be accessible when NOT in production
         // this is tested in RoutesTest
         if (!ninjaProperties.isProd()) {
-            router.GET().route("/_test/testPage").with(ApplicationController.class, "testPage");
+            router.GET().route("/_test/testPage").with(ApplicationController::testPage);
         }
 
-        router.GET().route("/bad_request").with(ApplicationController.class, "badRequest");
+        router.GET().route("/bad_request").with(ApplicationController::badRequest);
 
-        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");
-        router.GET().route("/assets/{fileName: .*}").with(AssetsController.class, "serveStatic");
+        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController::serveWebJars);
+        router.GET().route("/assets/{fileName: .*}").with(AssetsController::serveStatic);
 
     }
 

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -92,7 +92,7 @@ public class ApplicationController {
                                 @PathParam("id") Integer id,
                                 Context context) {
 
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         // generate tuples, convert integer to string here because Freemarker
         // does it in locale
         // dependent way with commas etc
@@ -108,8 +108,8 @@ public class ApplicationController {
     }
 
     @Timed
-    public Result validation(Validation validation,
-                             @Param("email") @Required String email) {
+    public Result validation(@Param("email") @Required String email,
+                             Validation validation) {
 
         if (validation.hasViolations()) {
             return Results.json()

--- a/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import ninja.RecycledNinjaServerTester;
 import ninja.utils.NinjaTestBrowser;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
 import org.junit.Before;
 
 public class ApplicationControllerTest extends RecycledNinjaServerTester {
@@ -55,6 +57,22 @@ public class ApplicationControllerTest extends RecycledNinjaServerTester {
         // from the index screen:
         assertTrue(result.contains("Integration Test"));
 
+    }
+    
+    @Test
+    public void lambdaAnonymous() {
+        // if lambda worked then we'd be redirected to index
+        String result = ninjaTestBrowser.makeRequest(withBaseUrl("/lambda_anonymous"));
+        
+        assertThat(result, containsString("Hi!"));
+    }
+    
+    @Test
+    public void lambdaAnonymousArgs() {
+        // if lambda worked then we'd be redirected to index
+        String result = ninjaTestBrowser.makeRequest(withBaseUrl("/lambda_anonymous_args?a=joe"));
+        
+        assertThat(result, containsString("Query: joe"));
     }
 
     @Test

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/conf/Routes.java
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/main/java/conf/Routes.java
@@ -50,46 +50,46 @@ public class Routes implements ApplicationRoutes {
         
         // puts test data into db:
         if (!ninjaProperties.isProd()) {
-            router.GET().route("/setup").with(ApplicationController.class, "setup");
+            router.GET().route("/setup").with(ApplicationController::setup);
         }
         
         ///////////////////////////////////////////////////////////////////////
         // Login / Logout
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/login").with(LoginLogoutController.class, "login");
-        router.POST().route("/login").with(LoginLogoutController.class, "loginPost");
-        router.GET().route("/logout").with(LoginLogoutController.class, "logout");
+        router.GET().route("/login").with(LoginLogoutController::login);
+        router.POST().route("/login").with(LoginLogoutController::loginPost);
+        router.GET().route("/logout").with(LoginLogoutController::logout);
         
         ///////////////////////////////////////////////////////////////////////
         // Create new article
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/article/new").with(ArticleController.class, "articleNew");
-        router.POST().route("/article/new").with(ArticleController.class, "articleNewPost");
+        router.GET().route("/article/new").with(ArticleController::articleNew);
+        router.POST().route("/article/new").with(ArticleController::articleNewPost);
         
         ///////////////////////////////////////////////////////////////////////
         // Create new article
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/article/{id}").with(ArticleController.class, "articleShow");
+        router.GET().route("/article/{id}").with(ArticleController::articleShow);
 
         ///////////////////////////////////////////////////////////////////////
         // Api for management of software
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/api/{username}/articles.json").with(ApiController.class, "getArticlesJson");
-        router.GET().route("/api/{username}/article/{id}.json").with(ApiController.class, "getArticleJson");
-        router.GET().route("/api/{username}/articles.xml").with(ApiController.class, "getArticlesXml");
-        router.POST().route("/api/{username}/article.json").with(ApiController.class, "postArticleJson");
-        router.POST().route("/api/{username}/article.xml").with(ApiController.class, "postArticleXml");
+        router.GET().route("/api/{username}/articles.json").with(ApiController::getArticlesJson);
+        router.GET().route("/api/{username}/article/{id}.json").with(ApiController::getArticleJson);
+        router.GET().route("/api/{username}/articles.xml").with(ApiController::getArticlesXml);
+        router.POST().route("/api/{username}/article.json").with(ApiController::postArticleJson);
+        router.POST().route("/api/{username}/article.xml").with(ApiController::postArticleXml);
  
         ///////////////////////////////////////////////////////////////////////
         // Assets (pictures / javascript)
         ///////////////////////////////////////////////////////////////////////    
-        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");
-        router.GET().route("/assets/{fileName: .*}").with(AssetsController.class, "serveStatic");
+        router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController::serveWebJars);
+        router.GET().route("/assets/{fileName: .*}").with(AssetsController::serveStatic);
         
         ///////////////////////////////////////////////////////////////////////
         // Index / Catchall shows index page
         ///////////////////////////////////////////////////////////////////////
-        router.GET().route("/.*").with(ApplicationController.class, "index");
+        router.GET().route("/.*").with(ApplicationController::index);
     }
 
 }

--- a/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/MultipartContextImplMemoryTest.java
@@ -285,7 +285,7 @@ public class MultipartContextImplMemoryTest {
 
         Class<ControllerImpl> controllerClass = ControllerImpl.class;
         Method controllerMethod = ControllerImpl.class.getMethod("method1");
-        Route route = new Route("GET", "/", controllerClass, controllerMethod, null);
+        Route route = new Route("GET", "/", controllerMethod, null);
         context.setRoute(route);
 
         Assert.assertEquals("test#1", context.getParameterAsFileItem(file1).getContentType());
@@ -297,7 +297,7 @@ public class MultipartContextImplMemoryTest {
 
         Class<ControllerImpl> controllerClass = ControllerImpl.class;
         Method controllerMethod = ControllerImpl.class.getMethod("method2");
-        Route route = new Route("GET", "/", controllerClass, controllerMethod, null);
+        Route route = new Route("GET", "/", controllerMethod, null);
         context.setRoute(route);
         
         context.init(servletContext, httpServletRequest, httpServletResponse);


### PR DESCRIPTION
Major new feature for Java 8+.  Router now accepts Java 8 lambdas and does some smart things with them.  Routes can now be checked to exist by the compiler (as well as nice IDE things like jumping to the method, changing name on refactor, etc.)

In the case of a method reference, then the underlying real impl method is used (so reverse routing can still work).  In the case we can't then the functional method is used instead.  Injecting parameters via guice still works.  One issue is Java does not retain parameter annotations on anonymous lambdas (e.g. `(@Param("a") String a) -> Results.ok()`).  That's why its still encouraged to put your controller method in a real class since those annotations are absolutely retained.

I wanted to get this merged now to let folks test it out on more platforms.  Once we're happy with it we can move onto allowing reverse routing via the same technique as well as proper doc changes.

One last thing.  I'm not aware of any other web framework who can inject parameters into lambdas or retain the original implementation method in the case of a method reference (e.g. `router.GET().route("/article/new").with(ArticleController::articleNew);`
