### PR TITLE
New ninja.ReverseRouter (supports Java 8)

### DIFF
--- a/ninja-core/src/main/java/ninja/ReverseRouter.java
+++ b/ninja-core/src/main/java/ninja/ReverseRouter.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import com.google.common.base.Optional;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import ninja.ControllerMethods.ControllerMethod;
+import ninja.ReverseRouter.Builder;
+import ninja.utils.LambdaRoute;
+import ninja.utils.MethodReference;
+import ninja.utils.NinjaProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reverse routing. Lookup the uri associated with a controller method.
+ * 
+ * @author Joe Lauer (jjlauer)
+ */
+public class ReverseRouter implements WithControllerMethod<Builder> {
+    static private final Logger log = LoggerFactory.getLogger(ReverseRouter.class);
+    
+    static public class Builder {
+        
+        private final String contextPath;
+        private final Route route;
+        private Map<String,String> paths;
+        private Map<String,String> queries;
+        
+        public Builder(String contextPath, Route route) {
+            this.contextPath = contextPath;
+            this.route = route;
+        }
+
+        public Route getRoute() {
+            return route;
+        }
+        
+        /**
+         * Add a parameter as a path replacement. Will validate the path parameter
+         * exists. This method will URL encode the values when building the final
+         * result.
+         * @param name The path parameter name
+         * @param value The path parameter value
+         * @return A reference to this builder
+         * @see #rawPath(java.lang.String, java.lang.Object) 
+         */
+        public Builder path(String name, Object value) {
+            return setPath(name, value, false);
+        }
+        
+        /**
+         * Identical to <code>path</code> except the path parameter value will
+         * NOT be url encoded when building the final url.
+         * @param name The path parameter name
+         * @param value The path parameter value
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object) 
+         */
+        public Builder rawPath(String name, Object value) {
+            return setPath(name, value, true);
+        }
+        
+        private Builder setPath(String name, Object value, boolean raw) {
+            Objects.requireNonNull(name, "name required");
+            Objects.requireNonNull(value, "value required");
+
+            if (route.getParameters() == null || !route.getParameters().containsKey(name)) {
+                throw new IllegalArgumentException("Reverse route " + route.getUri()
+                    + " does not have a path parameter '" + name + "'");
+            }
+            
+            if (this.paths == null) {
+                this.paths = new HashMap<>();
+            }
+            
+            this.paths.put(name, safeValue(value, raw));
+            
+            return this;
+        }
+        
+        /**
+         * Add a parameter as a query string value. This method will URL encode
+         * the values when building the final result.
+         * @param name The query string parameter name
+         * @param value The query string parameter value
+         * @return A reference to this builder
+         * @see #rawQuery(java.lang.String, java.lang.Object) 
+         */
+        public Builder query(String name, Object value) {
+            return setQuery(name, value, false);
+        }
+        
+        /**
+         * Identical to <code>query</code> except the query string value will
+         * NOT be url encoded when building the final url.
+         * @param name The query string parameter name
+         * @param value The query string parameter value
+         * @return A reference to this builder
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder rawQuery(String name, Object value) {
+            return setQuery(name, value, true);
+        }
+        
+        private Builder setQuery(String name, Object value, boolean raw) {
+            Objects.requireNonNull(name, "name required");
+
+            if (this.queries == null) {
+                // retain ordering
+                this.queries = new LinkedHashMap<>();
+            }
+            
+            this.queries.put(name, safeValue(value, raw));
+            
+            return this;
+        }
+        
+        /**
+         * Add a map containing pairs with replacements for either path or query
+         * string parameters. This method will URL encode the values when building
+         * the final result.  When replacing path parameters it's recommended
+         * to use the <code>path</code> method since it will validate the parameter
+         * exists, while this method would fallback to adding the value as a query
+         * string parameter if the path parameter did not exist.
+         * @param parameterMap The map containing pairs of name and values.
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder params(Map<String,Object> parameterMap) {
+            return setParams(parameterMap, false);
+        }
+        
+        /**
+         * Identical to <code>params</code> except this method will NOT url
+         * encode the values when building the final result.  When replacing path
+         * parameters it's recommended to use the <code>path</code> method since
+         * it will validate the parameter exists, while this method would fallback
+         * to adding the value as a query string parameter if the path parameter
+         * did not exist.
+         * @param parameterMap The map containing pairs of name and values.
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder rawParams(Map<String,Object> parameterMap) {
+            return setParams(parameterMap, true);
+        }
+        
+        private Builder setParams(Map<String,Object> parameterMap, boolean raw) {
+            if (parameterMap != null) {
+                parameterMap.forEach((name, value) -> setParam(name, value, raw));
+            }
+            return this;
+        }
+        
+        /**
+         * Add a list containing pairs with replacements for either path or query
+         * string parameters. This method will URL encode the values when building
+         * the final result.  When replacing path parameters it's recommended
+         * to use the <code>path</code> method since it will validate the parameter
+         * exists, while this method would fallback to adding the value as a query
+         * string parameter if the path parameter did not exist.
+         * @param parameterMap The list of pairs of name and values.
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder params(Object... parameterMap) {
+            return setParams(false, parameterMap);
+        }
+        
+        /**
+         * Identical to <code>params</code> except this method will NOT url
+         * encode the values when building the final result.  When replacing path
+         * parameters it's recommended to use the <code>path</code> method since
+         * it will validate the parameter exists, while this method would fallback
+         * to adding the value as a query string parameter if the path parameter
+         * did not exist.
+         * @param parameterMap The list of pairs of name and values.
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder rawParams(Object... parameterMap) {
+            return setParams(true, parameterMap);
+        }
+        
+        private Builder setParams(boolean raw, Object... parameterMap) {
+            if (parameterMap != null) {
+                if (parameterMap.length % 2 != 0) {
+                    throw new IllegalArgumentException("Always provide key (as String) value (as Object) pairs in parameterMap. That means providing e.g. 2, 4, 6... objects.");
+                }
+
+                for (int i = 0; i < parameterMap.length; i += 2) {
+                    setParam((String)parameterMap[i], parameterMap[i+1], raw);
+                }
+            }
+            return this;
+        }
+        
+        /**
+         * Add a parameter as a path replacement if it exists or will fallback
+         * to adding it a a query string value.  This method will URL encode the
+         * values when building the final result.
+         * @param name The parameter name
+         * @param value The parameter value
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object) 
+         */
+        public Builder param(String name, Object value) {
+            return setParam(name, value, false);
+        }
+        
+        /**
+         * Identical to <code>param</code> except this method will NOT url
+         * encode the values when building the final result.
+         * @param name The parameter name
+         * @param value The parameter value
+         * @return A reference to this builder
+         * @see #path(java.lang.String, java.lang.Object)
+         * @see #query(java.lang.String, java.lang.Object)
+         */
+        public Builder rawParam(String name, Object value) {
+            return setParam(name, value, true);
+        }
+        
+        private Builder setParam(String name, Object value, boolean raw) {
+            Objects.requireNonNull(name, "name required");
+            
+            if (this.route.getParameters().containsKey(name)) {
+                return setPath(name, value, raw);
+            } else {
+                return setQuery(name, value, raw);
+            }
+        }
+        
+        private String safeValue(Object value, boolean raw) {
+            String s = (value == null ? null : value.toString());
+            if (!raw && s != null) {
+                try {
+                    s = URLEncoder.encode(s, "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+            return s;
+        }
+        
+        private int safeMapSize(Map map) {
+            return (map != null ? map.size() : 0);
+        }
+        
+        /**
+         * Builds the final url. Will validate expected parameters match actual.
+         * @return The final resulting url
+         */
+        public String build() {
+            // number of params valid?
+            int expectedParamSize = safeMapSize(this.route.getParameters());
+            int actualParamSize = safeMapSize(this.paths);
+            if (expectedParamSize != actualParamSize) {
+                throw new IllegalArgumentException("Reverse route " + route.getUri()
+                    + " requires " + expectedParamSize + " parameters but got "
+                    + actualParamSize + " instead");
+            }
+            
+            String rawUri = this.route.getUri();
+            
+            StringBuilder buffer = new StringBuilder(rawUri.length());
+
+            // append contextPath
+            if (this.contextPath != null && this.contextPath.length() > 0) {
+                buffer.append(this.contextPath);
+            }
+            
+            // replace path parameters
+            int lastIndex = 0;
+            
+            if (this.paths != null) {
+                for (RouteParameter rp : this.route.getParameters().values()) {
+                    String value = this.paths.get(rp.getName());
+                    
+                    if (value == null) {
+                        throw new IllegalArgumentException("Reverse route " + route.getUri()
+                            + " missing value for path parameter '" + rp.getName() + "'");
+                    }
+                    
+                    // append any text before this token
+                    buffer.append(rawUri.substring(lastIndex, rp.getIndex()));
+                    // append value
+                    buffer.append(value);
+                    // the next index to start from
+                    lastIndex = rp.getIndex() + rp.getToken().length();
+                }
+            }
+            
+            // append whatever remains
+            if (lastIndex < rawUri.length()) {
+                buffer.append(rawUri.substring(lastIndex));
+            }
+            
+            // append query params
+            if (this.queries != null) {
+                int i = 0;
+                for (Map.Entry<String,String> entry : this.queries.entrySet()) {
+                    buffer.append((i == 0 ? '?' : '&'));
+                    buffer.append(entry.getKey());
+                    if (entry.getValue() != null) {
+                        buffer.append('=');
+                        buffer.append(entry.getValue());
+                    }
+                    i++;
+                }
+            }
+            
+            return buffer.toString();
+        }
+        
+        /**
+         * Builds the result as a <code>ninja.Result</code> redirect.
+         * @return A Ninja redirect result
+         */
+        public Result redirect() {
+            return Results.redirect(build());
+        }
+
+        @Override
+        public String toString() {
+            return this.build();
+        }
+    }
+    
+    private final NinjaProperties ninjaProperties;
+    private final Router router;
+    
+    @Inject
+    public ReverseRouter(NinjaProperties ninjaProperties,
+                         Router router) {
+        this.ninjaProperties = ninjaProperties;
+        this.router = router;
+    }
+    
+    /**
+     * Retrieves a the reverse route for this controllerClass and method.
+     * 
+     * @param controllerClass The controllerClass e.g. ApplicationController.class
+     * @param methodName the methodName of the class e.g. "index"
+     * @return A <code>Builder</code> allowing setting path placeholders and
+     *      query string parameters.
+     */
+    public Builder with(Class<?> controllerClass, String methodName) {
+        return builder(controllerClass, methodName);
+    }
+    
+    /**
+     * Retrieves a the reverse route for the method reference (e.g. controller
+     * class and method name).
+     * 
+     * @param methodRef The reference to a method
+     * @return A <code>Builder</code> allowing setting path placeholders and
+     *      query string parameters.
+     */
+    public Builder with(MethodReference methodRef) {
+        return builder(methodRef.getDeclaringClass(), methodRef.getMethodName());
+    }
+    
+    /**
+     * Retrieves a the reverse route for a method referenced with Java-8
+     * lambdas (functional method references).
+     * 
+     * @param controllerMethod The Java-8 style method reference such as
+     *      <code>ApplicationController::index</code>.
+     * @return A <code>Builder</code> allowing setting path placeholders and
+     *      query string parameters.
+     */
+    @Override
+    public Builder with(ControllerMethod controllerMethod) {
+        LambdaRoute lambdaRoute = LambdaRoute.resolve(controllerMethod);
+        
+        // only need the functional method for the reverse lookup
+        Method method = lambdaRoute.getFunctionalMethod();
+        
+        return builder(method.getDeclaringClass(), method.getName());
+    }
+    
+    private Builder builder(Class<?> controllerClass, String methodName) {
+        Optional<Route> route = this.router.getRouteForControllerClassAndMethod(
+            controllerClass, methodName);
+        
+        if (route.isPresent()) {
+            return new Builder(this.ninjaProperties.getContextPath(), route.get());
+        }
+        
+        throw new IllegalArgumentException("Reverse route not found for " +
+            controllerClass.getCanonicalName() + "." + methodName);
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/Route.java
+++ b/ninja-core/src/main/java/ninja/Route.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 
 /**
  * A route
@@ -47,8 +47,7 @@ public class Route {
     private final String uri;
     private final Method controllerMethod;
     private final FilterChain filterChain;
-
-    private final List<String> parameterNames;
+    private final LinkedHashMap<String,RouteParameter> parameters;
     private final Pattern regex;
 
     public Route(String httpMethod,
@@ -59,10 +58,13 @@ public class Route {
         this.uri = uri;
         this.controllerMethod = controllerMethod;
         this.filterChain = filterChain;
-        parameterNames = ImmutableList.copyOf(doParseParameters(uri));
-        regex = Pattern.compile(convertRawUriToRegex(uri));
+        this.parameters = RouteParameter.parse(uri);
+        this.regex = Pattern.compile(convertRawUriToRegex(uri));
     }
 
+    /**
+     * @deprecated Use getUri()
+     */
     public String getUrl() {
         return uri;
     }
@@ -87,6 +89,10 @@ public class Route {
         return controllerMethod;
     }
 
+    public LinkedHashMap<String,RouteParameter> getParameters() {
+        return parameters;
+    }
+    
     /**
      * Matches /index to /index or /me/1 to /person/{id}
      *
@@ -114,45 +120,19 @@ public class Route {
      * @return A map with all parameters of that uri. Encoded in => encoded out.
      */
     public Map<String, String> getPathParametersEncoded(String uri) {
-
         Map<String, String> map = Maps.newHashMap();
 
         Matcher m = regex.matcher(uri);
 
         if (m.matches()) {
+            Iterator<String> it = this.parameters.keySet().iterator();
             for (int i = 1; i < m.groupCount() + 1; i++) {
-                map.put(parameterNames.get(i - 1), m.group(i));
+                String parameterName = it.next();
+                map.put(parameterName, m.group(i));
             }
         }
-
+        
         return map;
-
-    }
-
-    /**
-     *
-     * Extracts the name of the parameters from a route
-     *
-     * /{my_id}/{my_name}
-     *
-     * would return a List with "my_id" and "my_name"
-     *
-     * @param rawRoute
-     * @return a list with the names of all parameters in that route.
-     */
-    private static List<String> doParseParameters(String rawRoute) {
-        List<String> list = new ArrayList<String>();
-
-        Matcher m = PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(rawRoute);
-
-        while (m.find()) {
-            // group(1) is the name of the group. Must be always there...
-            // "/assets/{file}" and "/assets/{file: [a-zA-Z][a-zA-Z_0-9]}" 
-            // will return file.
-            list.add(m.group(1));
-        }
-
-        return list;
     }
 
     /**

--- a/ninja-core/src/main/java/ninja/RouteBuilder.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilder.java
@@ -16,10 +16,9 @@
 
 package ninja;
 
-import ninja.ControllerMethods.*;
 import ninja.utils.MethodReference;
 
-public interface RouteBuilder {
+public interface RouteBuilder extends WithControllerMethod<Void> {
 
     RouteBuilder route(String uri);
 
@@ -36,29 +35,5 @@ public interface RouteBuilder {
      */
     @Deprecated
     void with(Result result);
-    
-    void with(ControllerMethod functionalMethod);
-    
-    void with(ControllerMethod0 functionalMethod);
-    
-    <A> void with(ControllerMethod1<A> functionalMethod);
-    
-    <A,B> void with(ControllerMethod2<A,B> functionalMethod);
-    
-    <A,B,C> void with(ControllerMethod3<A,B,C> functionalMethod);
-    
-    <A,B,C,D> void with(ControllerMethod4<A,B,C,D> functionalMethod);
-    
-    <A,B,C,D,E> void with(ControllerMethod5<A,B,C,D,E> functionalMethod);
-    
-    <A,B,C,D,E,F> void with(ControllerMethod6<A,B,C,D,E,F> functionalMethod);
-    
-    <A,B,C,D,E,F,G> void with(ControllerMethod7<A,B,C,D,E,F,G> functionalMethod);
-    
-    <A,B,C,D,E,F,G,H> void with(ControllerMethod8<A,B,C,D,E,F,G,H> functionalMethod);
-    
-    <A,B,C,D,E,F,G,H,I> void with(ControllerMethod9<A,B,C,D,E,F,G,H,I> functionalMethod);
-    
-    <A,B,C,D,E,F,G,H,I,J> void with(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> functionalMethod);
 
 }

--- a/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
+++ b/ninja-core/src/main/java/ninja/RouteBuilderImpl.java
@@ -28,9 +28,8 @@ import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.util.Providers;
 import java.util.Optional;
-import ninja.ControllerMethods.*;
-import ninja.utils.Lambdas;
-import ninja.utils.Lambdas.LambdaInfo;
+import ninja.ControllerMethods.ControllerMethod;
+import ninja.utils.LambdaRoute;
 import ninja.utils.MethodReference;
 
 public class RouteBuilderImpl implements RouteBuilder {
@@ -95,104 +94,16 @@ public class RouteBuilderImpl implements RouteBuilder {
     
     @Override @Deprecated
     public void with(final Result result) {
-        withFunctionalMethod(ControllerMethods.of(() -> result));
+        with(ControllerMethods.of(() -> result));
     }
     
     @Override
-    public void with(ControllerMethod functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public void with(ControllerMethod0 functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A> void with(ControllerMethod1<A> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B> void with(ControllerMethod2<A,B> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C> void with(ControllerMethod3<A,B,C> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D> void with(ControllerMethod4<A,B,C,D> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E> void with(ControllerMethod5<A,B,C,D,E> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E,F> void with(ControllerMethod6<A,B,C,D,E,F> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E,F,G> void with(ControllerMethod7<A,B,C,D,E,F,G> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E,F,G,H> void with(ControllerMethod8<A,B,C,D,E,F,G,H> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E,F,G,H,I> void with(ControllerMethod9<A,B,C,D,E,F,G,H,I> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-    
-    @Override
-    public <A,B,C,D,E,F,G,H,I,J> void with(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> functionalMethod) {
-        withFunctionalMethod(functionalMethod);
-    }
-
-    private void withFunctionalMethod(ControllerMethod functionalMethod) {
-        try {
-            LambdaInfo lambdaInfo = Lambdas.reflect(functionalMethod);
-
-            log.trace("uri {} with lambda {}", uri, lambdaInfo);
-            
-            switch (lambdaInfo.getKind()) {
-                case ANY_INSTANCE_METHOD_REFERENCE:
-                case STATIC_METHOD_REFERENCE:
-                    // call impl method just like before Java 8
-                    this.functionalMethod = lambdaInfo.getImplementationMethod();
-                    return;
-                case SPECIFIC_INSTANCE_METHOD_REFERENCE:
-                case ANONYMOUS_METHOD_REFERENCE:
-                    // only safe to use the impl method for argument types if
-                    // the number of arguments matches between the methods
-                    if (lambdaInfo.areMethodParameterCountsEqual()) {    
-                        this.functionalMethod = lambdaInfo.getFunctionalMethod();
-                        this.implementationMethod = Optional.of(lambdaInfo.getImplementationMethod());
-                        this.targetObject = Optional.of(functionalMethod);
-                        return;
-                    }
-            }
-        } catch (IllegalArgumentException e) {
-            // unable to detect lambda (e.g. such as anonymous/concrete class)
-        }
-        
-        // fallback to simple call the "apply" method on the supplied method instance
-        try {
-            this.functionalMethod = Lambdas.getMethod(functionalMethod.getClass(), "apply");
-            this.functionalMethod.setAccessible(true);
-            this.targetObject = Optional.of(functionalMethod);
-        } catch (NoSuchMethodException | ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
+    public Void with(ControllerMethod controllerMethod) {
+        LambdaRoute lambdaRoute = LambdaRoute.resolve(controllerMethod);
+        this.functionalMethod = lambdaRoute.getFunctionalMethod();
+        this.implementationMethod = lambdaRoute.getImplementationMethod();
+        this.targetObject = lambdaRoute.getTargetObject();
+        return null;
     }
 
     @Override

--- a/ninja-core/src/main/java/ninja/RouteParameter.java
+++ b/ninja-core/src/main/java/ninja/RouteParameter.java
@@ -78,8 +78,8 @@ public class RouteParameter {
      * @return A map containing the named parameters in the order they were
      *      parsed or null if no parameters were parsed.
      */
-    static public LinkedHashMap<String,RouteParameter> parse(String path) {
-        LinkedHashMap<String,RouteParameter> params = null;
+    static public LinkedHashMap<String, RouteParameter> parse(String path) {
+        LinkedHashMap<String, RouteParameter> params = null;
         
         // extract any named parameters
         Matcher matcher = Route.PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(path);
@@ -87,7 +87,7 @@ public class RouteParameter {
             RouteParameter param = new RouteParameter(
                 matcher.start(0), matcher.group(0), matcher.group(1), matcher.group(3));
             
-            // lazily create map (so its null if no path params exist)
+            // lazily create map (so it's null if no path params exist)
             if (params == null) {
                 params = new LinkedHashMap<>();
             }

--- a/ninja-core/src/main/java/ninja/RouteParameter.java
+++ b/ninja-core/src/main/java/ninja/RouteParameter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import java.util.LinkedHashMap;
+import java.util.regex.Matcher;
+
+/**
+ * Parameter in a Route.
+ * 
+ * @author Joe Lauer
+ */
+public class RouteParameter {
+    
+    // eg. {id: [0-9]+}
+    private final int index;    // index of where token starts
+    private final String token; // "{id: [0-9]+}"
+    private final String name;  // "id"
+    private final String regex; // "[0-9]+"
+
+    public RouteParameter(int index, String token, String name, String regex) {
+        this.index = index;
+        this.token = token;
+        this.name = name;
+        this.regex = regex;
+    }
+
+    /**
+     * Gets the index of where the token starts in the original uri.
+     * @return An index of where the token is
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * The exact string of the parameter such as "{id: [0-9]+}" in "{id: [0-9]+}"
+     * @return The parameter token
+     */
+    public String getToken() {
+        return token;
+    }
+    
+    /**
+     * The name of the parameter such as "id" in "{id: [0-9]+}"
+     * @return The name of the parameter
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The regex of the parameter such as "[0-9]+" in "{id: [0-9]+}"
+     * @return The regex of the parameter or null if no regex was included
+     *      for the parameter.
+     */
+    public String getRegex() {
+        return regex;
+    }
+    
+    /**
+     * Parse a path such as "/user/{id: [0-9]+}/email/{addr}" for the named
+     * parameters.
+     * @param path The path to parse
+     * @return A map containing the named parameters in the order they were
+     *      parsed or null if no parameters were parsed.
+     */
+    static public LinkedHashMap<String,RouteParameter> parse(String path) {
+        LinkedHashMap<String,RouteParameter> params = null;
+        
+        // extract any named parameters
+        Matcher matcher = Route.PATTERN_FOR_VARIABLE_PARTS_OF_ROUTE.matcher(path);
+        while (matcher.find()) {
+            RouteParameter param = new RouteParameter(
+                matcher.start(0), matcher.group(0), matcher.group(1), matcher.group(3));
+            
+            // lazily create map (so its null if no path params exist)
+            if (params == null) {
+                params = new LinkedHashMap<>();
+            }
+            
+            params.put(param.getName(), param);
+        }
+        
+        return params;
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -43,6 +43,9 @@ public interface Router {
      * @param clazz The controllerClass e.g. ApplicationController.class
      * @param methodName the methodName of the class e.g. "index"
      * @return The final url (without server, and without any prefixes)
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
      */
     public String getReverseRoute(Class<?> clazz, String methodName);
     
@@ -61,6 +64,9 @@ public interface Router {
      *          or simply use a String. If the raw uri does not contain the placeholders
      *          they will be added as query parameters ?key=value&key2=value2 and so on
      * @return The final url (without server, and without any prefixes)
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
      */
     public String getReverseRoute(Class<?> clazz, String methodName, Map<String, Object> parameterMap);
 
@@ -79,6 +85,9 @@ public interface Router {
      *          or simply use a String. If the raw uri does not contain the placeholders
      *          they will be added as query parameters ?key=value&key2=value2 and so on
      * @return The final url (without server, and without any prefixes)
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
      */
     public String getReverseRoute(Class<?> clazz, String methodName, Object ... parameterMap);
     
@@ -98,18 +107,40 @@ public interface Router {
      *          or simply use a String. If the raw uri does not contain the placeholders
      *          they will be added as query parameters ?key=value&key2=value2 and so on
      * @return The final url (without server, and without any prefixes)
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
      */
     public String getReverseRoute(Class<?> controllerClass,
                                  String controllerMethodName,
                                  Optional<Map<String, Object>> parameterMap);
         
-    
+    /**
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
+     */
     public String getReverseRoute(MethodReference controllerMethodRef);
     
+    /**
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
+     */
     public String getReverseRoute(MethodReference controllerMethodRef, Map<String, Object> parameterMap);
     
+    /**
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
+     */
     public String getReverseRoute(MethodReference controllerMethodRef, Object ... parameterMap);
     
+    /**
+     * @deprecated Reverse routing in the Router is not validated and does not
+     *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
+     *      to build your reverse routes.
+     */
     public String getReverseRoute(MethodReference controllerMethodRef, Optional<Map<String, Object>> parameterMap);
     
     /**
@@ -123,6 +154,9 @@ public interface Router {
      * Returns the list of compiled routes.
      */
     public List<Route> getRoutes();
+    
+    public Optional<Route> getRouteForControllerClassAndMethod(
+        Class<?> controllerClass, String controllerMethodName);
 
     // /////////////////////////////////////////////////////////////////////////
     // convenience methods to use the route in a DSL like way

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -47,6 +47,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(Class<?> clazz, String methodName);
     
     /**
@@ -68,6 +69,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(Class<?> clazz, String methodName, Map<String, Object> parameterMap);
 
     /**
@@ -89,6 +91,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(Class<?> clazz, String methodName, Object ... parameterMap);
     
     
@@ -111,6 +114,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(Class<?> controllerClass,
                                  String controllerMethodName,
                                  Optional<Map<String, Object>> parameterMap);
@@ -120,6 +124,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(MethodReference controllerMethodRef);
     
     /**
@@ -127,6 +132,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(MethodReference controllerMethodRef, Map<String, Object> parameterMap);
     
     /**
@@ -134,6 +140,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(MethodReference controllerMethodRef, Object ... parameterMap);
     
     /**
@@ -141,6 +148,7 @@ public interface Router {
      *      URL-escape path or query parameters. Use <code>ninja.ReverseRouter</code>
      *      to build your reverse routes.
      */
+    @Deprecated
     public String getReverseRoute(MethodReference controllerMethodRef, Optional<Map<String, Object>> parameterMap);
     
     /**

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -19,12 +19,8 @@ package ninja;
 import ninja.utils.MethodReference;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import ninja.utils.NinjaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,9 +43,8 @@ public class RouterImpl implements Router {
     private final String VARIABLE_PART_PATTERN_WITH_PLACEHOLDER = "\\{(%s)(:\\s([^}]*))?\\}"; 
 
     @Inject
-    public RouterImpl(
-            Injector injector,
-            NinjaProperties ninjaProperties) {
+    public RouterImpl(Injector injector,
+                      NinjaProperties ninjaProperties) {
         this.injector = injector;
         this.ninjaProperties = ninjaProperties;
     }
@@ -106,15 +101,12 @@ public class RouterImpl implements Router {
     public String getReverseRoute(Class<?> controllerClass,
             String controllerMethodName,
             Map<String, Object> parameterMap) {
-
         Optional<Map<String, Object>> parameterMapOptional
                 = Optional.fromNullable(parameterMap);
 
         return getReverseRoute(
-                controllerClass,
-                controllerMethodName,
+                controllerClass, controllerMethodName,
                 parameterMapOptional);
-
     }
     
     @Override
@@ -123,33 +115,22 @@ public class RouterImpl implements Router {
             String controllerMethodName,
             Optional<Map<String, Object>> parameterMap) {
 
-        Optional<Route> route
-                = getRouteForControllerClassAndMethod(
-                        controllerClass,
-                        controllerMethodName);
-        
-        if (route.isPresent()) {
-
-            // The original url. Something like route/user/{id}/{email}/userDashboard/{name: .*}
-            String urlWithReplacedPlaceholders
-                    = replaceVariablePartsOfUrlWithValuesProvidedByUser(
-                            route.get().getUrl(),
-                            parameterMap);
-
-            String finalUrl = addContextPathToUrlIfAvailable(
-                    urlWithReplacedPlaceholders,
-                    ninjaProperties);
-
-            return finalUrl;
-
-        }
-        else {
-            logger.info(
-                    "Could not find any reverse route for the method {} of the Controller class {}",
-                    controllerMethodName, controllerClass.getSimpleName());
+        try {
+            ReverseRouter.Builder reverseRouteBuilder
+                = new ReverseRouter(ninjaProperties, this)
+                    .with(controllerClass, controllerMethodName);
+            
+            if (parameterMap.isPresent()) {
+                // params are not escaped with the deprecated method of creating
+                // reverse routes.  use ReverseRouter!
+                reverseRouteBuilder.rawParams(parameterMap.get());
+            }
+            
+            return reverseRouteBuilder.build();
+        } catch (IllegalArgumentException e) {
+            logger.error("Unable to cleanly build reverse route", e);
             return null;
         }
-        
     }
     
     @Override
@@ -288,7 +269,8 @@ public class RouterImpl implements Router {
         }
     }
 
-    private Optional<Route> getRouteForControllerClassAndMethod(
+    @Override
+    public Optional<Route> getRouteForControllerClassAndMethod(
             Class<?> controllerClass,
             String controllerMethodName) {
 
@@ -301,94 +283,7 @@ public class RouterImpl implements Router {
         
         return Optional.fromNullable(route);
     }
-
-    private String replaceVariablePartsOfUrlWithValuesProvidedByUser(
-            String routeUrlWithVariableParts,
-            Optional<Map<String, Object>> parameterMap) {
-
-        String urlWithReplacedPlaceholders = routeUrlWithVariableParts;
-
-        if (parameterMap.isPresent()) {
-
-            Map<String, Object> queryParameterMap = new HashMap<>(parameterMap.get().size());
-
-            for (Entry<String, Object> parameterPair : parameterMap.get().entrySet()) {
-
-                boolean foundAsPathParameter = false;
-
-                StringBuffer stringBuffer = new StringBuffer();
-
-                String buffer = String.format(
-                        VARIABLE_PART_PATTERN_WITH_PLACEHOLDER,
-                        parameterPair.getKey());
-
-                Pattern PATTERN = Pattern.compile(buffer);
-                Matcher matcher = PATTERN.matcher(urlWithReplacedPlaceholders);
-
-                while (matcher.find()) {
-
-                    String resultingRegexReplacement = parameterPair.getValue().toString();
-
-                    matcher.appendReplacement(stringBuffer, resultingRegexReplacement);
-
-                    foundAsPathParameter = true;
-                }
-
-                matcher.appendTail(stringBuffer);
-                urlWithReplacedPlaceholders = stringBuffer.toString();
-
-                if (!foundAsPathParameter) {
-
-                    queryParameterMap.put(parameterPair.getKey(), parameterPair.getValue());
-
-                }
-
-            }
-
-            // now prepare the query string for this url if we got some query params
-            if (queryParameterMap.size() > 0) {
-
-                StringBuilder queryParameterStringBuffer = new StringBuilder();
-
-                // The uri is now replaced => we now have to add potential query parameters
-                for (Iterator<Entry<String, Object>> iterator = queryParameterMap.entrySet().iterator();
-                        iterator.hasNext();) {
-
-                    Entry<String, Object> queryParameterEntry = iterator.next();
-                    queryParameterStringBuffer.append(queryParameterEntry.getKey());
-                    queryParameterStringBuffer.append("=");
-                    queryParameterStringBuffer.append(queryParameterEntry.getValue());
-
-                    if (iterator.hasNext()) {
-                        queryParameterStringBuffer.append("&");
-                    }
-
-                }
-
-                urlWithReplacedPlaceholders = urlWithReplacedPlaceholders
-                        + "?"
-                        + queryParameterStringBuffer.toString();
-
-            }
-
-        }
-
-        return urlWithReplacedPlaceholders;
-    }
-
-    private String addContextPathToUrlIfAvailable(
-            String routeWithoutContextPath,
-            NinjaProperties ninjaProperties) {
-
-
-
-        // contextPath can only be empty. never null.
-        return ninjaProperties.getContextPath()
-                    + routeWithoutContextPath;
-
-
-    }
-
+    
     private void logRoutes() {
         // determine the width of the columns
         int maxMethodLen = 0;

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -121,9 +121,16 @@ public class RouterImpl implements Router {
                     .with(controllerClass, controllerMethodName);
             
             if (parameterMap.isPresent()) {
-                // params are not escaped with the deprecated method of creating
+                // pathOrQueryParams are not escaped with the deprecated method of creating
                 // reverse routes.  use ReverseRouter!
-                reverseRouteBuilder.rawParams(parameterMap.get());
+                parameterMap.get().forEach((name, value) -> {
+                    // path or query param?
+                    if (reverseRouteBuilder.getRoute().getParameters().containsKey(name)) {
+                        reverseRouteBuilder.rawPathParam(name, value);
+                    } else {
+                        reverseRouteBuilder.rawQueryParam(name, value);
+                    }
+                });
             }
             
             return reverseRouteBuilder.build();

--- a/ninja-core/src/main/java/ninja/WithControllerMethod.java
+++ b/ninja-core/src/main/java/ninja/WithControllerMethod.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja;
+
+import ninja.ControllerMethods.ControllerMethod;
+import ninja.ControllerMethods.ControllerMethod0;
+import ninja.ControllerMethods.ControllerMethod1;
+import ninja.ControllerMethods.ControllerMethod10;
+import ninja.ControllerMethods.ControllerMethod2;
+import ninja.ControllerMethods.ControllerMethod3;
+import ninja.ControllerMethods.ControllerMethod4;
+import ninja.ControllerMethods.ControllerMethod5;
+import ninja.ControllerMethods.ControllerMethod6;
+import ninja.ControllerMethods.ControllerMethod7;
+import ninja.ControllerMethods.ControllerMethod8;
+import ninja.ControllerMethods.ControllerMethod9;
+
+/**
+ * Interface that exposes multiple with methods that accept a large number of
+ * various argument combinations.
+ * @param <T> The result to return
+ */
+public interface WithControllerMethod<T> {
+    
+    T with(ControllerMethod controllerMethod);
+    
+    default T with(ControllerMethod0 controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A> T with(ControllerMethod1<A> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B> T with(ControllerMethod2<A,B> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C> T with(ControllerMethod3<A,B,C> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D> T with(ControllerMethod4<A,B,C,D> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E> T with(ControllerMethod5<A,B,C,D,E> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E,F> T with(ControllerMethod6<A,B,C,D,E,F> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E,F,G> T with(ControllerMethod7<A,B,C,D,E,F,G> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E,F,G,H> T with(ControllerMethod8<A,B,C,D,E,F,G,H> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E,F,G,H,I> T with(ControllerMethod9<A,B,C,D,E,F,G,H,I> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+    default <A,B,C,D,E,F,G,H,I,J> T with(ControllerMethod10<A,B,C,D,E,F,G,H,I,J> controllerMethod) {
+        return with((ControllerMethod)controllerMethod);
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/utils/LambdaRoute.java
+++ b/ninja-core/src/main/java/ninja/utils/LambdaRoute.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.utils;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import ninja.ControllerMethods.ControllerMethod;
+
+public class LambdaRoute {
+    
+    private final Method functionalMethod;
+    private final Optional<Method> implementationMethod;
+    private final Optional<Object> targetObject;
+
+    public LambdaRoute(Method functionalMethod, Method implementationMethod, Object targetObject) {
+        this.functionalMethod = functionalMethod;
+        this.implementationMethod = Optional.ofNullable(implementationMethod);
+        this.targetObject = Optional.ofNullable(targetObject);
+    }
+
+    public Method getFunctionalMethod() {
+        return functionalMethod;
+    }
+
+    public Optional<Method> getImplementationMethod() {
+        return implementationMethod;
+    }
+
+    public Optional<Object> getTargetObject() {
+        return targetObject;
+    }
+    
+    static public LambdaRoute resolve(ControllerMethod controllerMethod) {
+        try {
+            Lambdas.LambdaInfo lambdaInfo = Lambdas.reflect(controllerMethod);
+
+            switch (lambdaInfo.getKind()) {
+                case ANY_INSTANCE_METHOD_REFERENCE:
+                case STATIC_METHOD_REFERENCE:
+                    // call impl method just like before Java 8
+                    return new LambdaRoute(lambdaInfo.getImplementationMethod(), null, null);
+                case SPECIFIC_INSTANCE_METHOD_REFERENCE:
+                case ANONYMOUS_METHOD_REFERENCE:
+                    // only safe to use the impl method for argument types if
+                    // the number of arguments matches between the methods
+                    if (lambdaInfo.areMethodParameterCountsEqual()) {
+                        return new LambdaRoute(
+                            lambdaInfo.getFunctionalMethod(),
+                            lambdaInfo.getImplementationMethod(),
+                            controllerMethod);
+                    }
+            }
+        } catch (IllegalArgumentException e) {
+            // unable to detect lambda (e.g. such as anonymous/concrete class)
+        }
+        
+        // fallback to simple call the "apply" method on the supplied method instance
+        try {
+            Method functionalMethod = Lambdas.getMethod(controllerMethod.getClass(), "apply");
+            functionalMethod.setAccessible(true);
+            return new LambdaRoute(functionalMethod, null, controllerMethod);
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,7 +1,8 @@
 Version 6.x.x
 =============
  
- * 2016-10-03 Remove `async-machine-beta` module
+ * 2016-12-19 New `ninja.ReverseRouter` for validated, URL-safe reverse routing using Java 8 lambda expressions in addition to legacy Class + method name references. (jjlauer)
+ * 2016-10-03 Remove `async-machine-beta` module (jjlauer)
  * 2016-09-29 Route using Java 8 lambda expressions (jjlauer)
  * 2016-09-20 Session signatures now explicitly use UTF-8 for String.getBytes (lishid)
  * 2016-09-01 Bump to minimum requirement of Java 8 (jjlauer)

--- a/ninja-core/src/test/java/ninja/ReverseRouterTest.java
+++ b/ninja-core/src/test/java/ninja/ReverseRouterTest.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (C) 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+import com.google.common.collect.ImmutableMap;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import ninja.utils.NinjaProperties;
+import org.junit.Before;
+import org.junit.Test;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import java.util.Collections;
+import ninja.params.Param;
+import ninja.params.ParamParsers;
+import ninja.utils.MethodReference;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.mock;
+
+public class ReverseRouterTest {
+
+    Router router;
+    ReverseRouter reverseRouter;
+    NinjaProperties ninjaProperties;
+    Injector injector;
+    Provider<TestController> testControllerProvider;
+
+    @Before
+    @SuppressWarnings("Convert2Lambda")
+    public void before() {
+        this.ninjaProperties = mock(NinjaProperties.class);
+        this.injector = mock(Injector.class);
+        this.testControllerProvider = mock(Provider.class);
+        when(testControllerProvider.get()).thenReturn(new TestController());
+        when(injector.getProvider(TestController.class)).thenReturn(testControllerProvider);
+        when(injector.getInstance(ParamParsers.class)).thenReturn(new ParamParsers(Collections.emptySet()));
+        router = new RouterImpl(injector, ninjaProperties);
+        reverseRouter = new ReverseRouter(ninjaProperties, router);
+        
+        router.GET().route("/home").with(TestController::home);
+        router.GET().route("/user/{email}/{id: .*}").with(TestController::user);
+        router.GET().route("/u{userId: .*}/entries/{entryId: .*}").with(TestController::entry);
+        // second route to index should not break reverse routing matching the first
+        router.GET().route("/home/index").with(TestController::index);
+        
+        router.compileRoutes();
+    }
+
+    @Test
+    public void simple() {
+        String route = reverseRouter.with(TestController::home).build();
+        
+        assertThat(route, is("/home"));
+    }
+    
+    @Test
+    public void simpleWithMethodReference() {
+        MethodReference methodRef = new MethodReference(TestController.class, "home");
+        
+        String route = reverseRouter.with(methodRef).build();
+        
+        assertThat(route, is("/home"));
+    }
+    
+    @Test
+    public void simpleWithClassReference() {
+        String route = reverseRouter.with(TestController.class, "home").build();
+        
+        assertThat(route, is("/home"));
+    }
+    
+    @Test
+    public void simpleWithContext() {
+        String contextPath = "/context";
+        when(ninjaProperties.getContextPath()).thenReturn(contextPath);
+
+        String route = reverseRouter.with(TestController::home).build();
+        
+        assertThat(route, is("/context/home"));
+    }
+    
+    @Test
+    public void simpleWithQuery() {
+        String route = reverseRouter.with(TestController::home)
+            .query("filter", true)
+            .query("a", 1L)
+            .query("foo", "bar")
+            .query("email", "test@example.com")
+            .build();
+        
+        // insertion order retained
+        assertThat(route, is("/home?filter=true&a=1&foo=bar&email=test%40example.com"));
+    }
+    
+    @Test
+    public void simpleWithRawQuery() {
+        String route = reverseRouter.with(TestController::home)
+            .rawQuery("email", "test@example.com")
+            .build();
+        
+        // insertion order retained
+        assertThat(route, is("/home?email=test@example.com"));
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void routeNotFound() {
+        reverseRouter.with(TestController::notfound)
+            .build();
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void simpleNoPathParamsThrowsException() {
+        reverseRouter.with(TestController::home)
+            .path("id", 1000000L)
+            .build();
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void simpleInvalidPathParamThrowsException() {
+        reverseRouter.with(TestController::user)
+            .path("id2", 1000000L)
+            .build();
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void simpleMissingAllPathParamThrowsException() {
+        // param for email missing
+        reverseRouter.with(TestController::user)
+            .build();
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void simpleNotEnoughPathParamThrowsException() {
+        // param for email missing
+        reverseRouter.with(TestController::user)
+            .path("id", 1000000L)
+            .build();
+    }
+    
+    @Test
+    public void path() {
+        String route = reverseRouter.with(TestController::user)
+            .path("email", "test@example.com")
+            .path("id", 1000000L)
+            .build();
+        
+        assertThat(route, is("/user/test%40example.com/1000000"));
+    }
+    
+    @Test
+    public void rawPath() {
+        String route = reverseRouter.with(TestController::user)
+            .rawPath("email", "test@example.com")
+            .path("id", 1000000L)
+            .build();
+        
+        assertThat(route, is("/user/test@example.com/1000000"));
+    }
+    
+    @Test
+    public void verifySecondRouteMatched() {
+        String route = reverseRouter.with(TestController::index)
+            .build();
+        
+        assertThat(route, is("/home/index"));
+    }
+    
+    @Test
+    public void param() {
+        String route = reverseRouter.with(TestController::user)
+            .param("email", "test@example.com")
+            .param("id", 1000000L)
+            .param("filter", true)
+            .build();
+        
+        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
+    }
+    
+    @Test
+    public void rawParam() {
+        String route = reverseRouter.with(TestController::user)
+            .rawParam("email", "test@example.com")
+            .rawParam("id", 1000000L)
+            .rawParam("filter", true)
+            .build();
+        
+        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
+    }
+    
+    @Test
+    public void paramsWithMap() {
+        ImmutableMap<String,Object> parameterMap = ImmutableMap.of(
+                "filter", true, "email", "test@example.com", "id", 1000000L);
+        
+        String route = reverseRouter.with(TestController::user)
+            .params(parameterMap)
+            .build();
+        
+        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
+    }
+    
+    @Test
+    public void rawParamsWithMap() {
+        ImmutableMap<String,Object> parameterMap = ImmutableMap.of(
+                "filter", true, "email", "test@example.com", "id", 1000000L);
+        
+        String route = reverseRouter.with(TestController::user)
+            .rawParams(parameterMap)
+            .build();
+        
+        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
+    }
+    
+    @Test
+    public void paramsWithVarArgs() {
+        String route = reverseRouter.with(TestController::user)
+            .params("filter", true, "email", "test@example.com", "id", 1000000L)
+            .build();
+        
+        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
+    }
+    
+    @Test
+    public void rawParamsWithVarArgs() {
+        String route = reverseRouter.with(TestController::user)
+            .rawParams("filter", true, "email", "test@example.com", "id", 1000000L)
+            .build();
+        
+        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
+    }
+    
+    /**
+     * A dummy TestController for mocking.
+     */
+    public static class TestController {
+        
+        private final String message;
+        
+        public TestController() {
+            this("not set");
+        }
+        
+        public TestController(String message) {
+            this.message = message;
+        }
+        
+        public Result notfound() {
+            return Results.ok();
+        }
+        
+        public Result index() {
+            return Results.ok();
+        }
+
+        public Result user() {
+            return Results.ok();
+        }
+
+        public Result entry() {
+            return Results.ok();
+        }
+
+        public Result ref() {
+            return Results.ok();
+        }
+
+        public Result home() {
+            return Results.status(201);
+        }
+        
+        public Result message() {
+            return Results.ok().render(message);
+        }
+        
+        public Result status(@Param("status") Integer status) {
+            return Results.status(status).render(message);
+        }
+        
+        public Result exception() throws Exception {
+            throw new Exception("test");
+        }
+    }
+    
+}

--- a/ninja-core/src/test/java/ninja/ReverseRouterTest.java
+++ b/ninja-core/src/test/java/ninja/ReverseRouterTest.java
@@ -96,10 +96,10 @@ public class ReverseRouterTest {
     @Test
     public void simpleWithQuery() {
         String route = reverseRouter.with(TestController::home)
-            .query("filter", true)
-            .query("a", 1L)
-            .query("foo", "bar")
-            .query("email", "test@example.com")
+            .queryParam("filter", true)
+            .queryParam("a", 1L)
+            .queryParam("foo", "bar")
+            .queryParam("email", "test@example.com")
             .build();
         
         // insertion order retained
@@ -109,7 +109,7 @@ public class ReverseRouterTest {
     @Test
     public void simpleWithRawQuery() {
         String route = reverseRouter.with(TestController::home)
-            .rawQuery("email", "test@example.com")
+            .rawQueryParam("email", "test@example.com")
             .build();
         
         // insertion order retained
@@ -125,14 +125,14 @@ public class ReverseRouterTest {
     @Test(expected=IllegalArgumentException.class)
     public void simpleNoPathParamsThrowsException() {
         reverseRouter.with(TestController::home)
-            .path("id", 1000000L)
+            .pathParam("id", 1000000L)
             .build();
     }
     
     @Test(expected=IllegalArgumentException.class)
     public void simpleInvalidPathParamThrowsException() {
         reverseRouter.with(TestController::user)
-            .path("id2", 1000000L)
+            .pathParam("id2", 1000000L)
             .build();
     }
     
@@ -147,15 +147,15 @@ public class ReverseRouterTest {
     public void simpleNotEnoughPathParamThrowsException() {
         // param for email missing
         reverseRouter.with(TestController::user)
-            .path("id", 1000000L)
+            .pathParam("id", 1000000L)
             .build();
     }
     
     @Test
     public void path() {
         String route = reverseRouter.with(TestController::user)
-            .path("email", "test@example.com")
-            .path("id", 1000000L)
+            .pathParam("email", "test@example.com")
+            .pathParam("id", 1000000L)
             .build();
         
         assertThat(route, is("/user/test%40example.com/1000000"));
@@ -164,8 +164,8 @@ public class ReverseRouterTest {
     @Test
     public void rawPath() {
         String route = reverseRouter.with(TestController::user)
-            .rawPath("email", "test@example.com")
-            .path("id", 1000000L)
+            .rawPathParam("email", "test@example.com")
+            .pathParam("id", 1000000L)
             .build();
         
         assertThat(route, is("/user/test@example.com/1000000"));
@@ -177,70 +177,6 @@ public class ReverseRouterTest {
             .build();
         
         assertThat(route, is("/home/index"));
-    }
-    
-    @Test
-    public void param() {
-        String route = reverseRouter.with(TestController::user)
-            .param("email", "test@example.com")
-            .param("id", 1000000L)
-            .param("filter", true)
-            .build();
-        
-        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
-    }
-    
-    @Test
-    public void rawParam() {
-        String route = reverseRouter.with(TestController::user)
-            .rawParam("email", "test@example.com")
-            .rawParam("id", 1000000L)
-            .rawParam("filter", true)
-            .build();
-        
-        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
-    }
-    
-    @Test
-    public void paramsWithMap() {
-        ImmutableMap<String,Object> parameterMap = ImmutableMap.of(
-                "filter", true, "email", "test@example.com", "id", 1000000L);
-        
-        String route = reverseRouter.with(TestController::user)
-            .params(parameterMap)
-            .build();
-        
-        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
-    }
-    
-    @Test
-    public void rawParamsWithMap() {
-        ImmutableMap<String,Object> parameterMap = ImmutableMap.of(
-                "filter", true, "email", "test@example.com", "id", 1000000L);
-        
-        String route = reverseRouter.with(TestController::user)
-            .rawParams(parameterMap)
-            .build();
-        
-        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
-    }
-    
-    @Test
-    public void paramsWithVarArgs() {
-        String route = reverseRouter.with(TestController::user)
-            .params("filter", true, "email", "test@example.com", "id", 1000000L)
-            .build();
-        
-        assertThat(route, is("/user/test%40example.com/1000000?filter=true"));
-    }
-    
-    @Test
-    public void rawParamsWithVarArgs() {
-        String route = reverseRouter.with(TestController::user)
-            .rawParams("filter", true, "email", "test@example.com", "id", 1000000L)
-            .build();
-        
-        assertThat(route, is("/user/test@example.com/1000000?filter=true"));
     }
     
     /**

--- a/ninja-core/src/test/java/ninja/RouteParameterTest.java
+++ b/ninja-core/src/test/java/ninja/RouteParameterTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja;
+
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import java.util.Map;
+import ninja.params.Param;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class RouteParameterTest {
+
+    @Test
+    public void parse() {
+        Map<String,RouteParameter> params;
+        RouteParameter param;
+        
+        // no named parameters is null
+        params = RouteParameter.parse("/user");
+        assertThat(params, is(nullValue()));
+        
+        params = RouteParameter.parse("/user/{id}/{email: [0-9]+}");
+        
+        param = params.get("id");
+        assertThat(param.getName(), is("id"));
+        assertThat(param.getToken(), is("{id}"));
+        assertThat(param.getRegex(), is(nullValue()));
+        
+        param = params.get("email");
+        assertThat(param.getName(), is("email"));
+        assertThat(param.getToken(), is("{email: [0-9]+}"));
+        assertThat(param.getRegex(), is("[0-9]+"));
+    }
+    
+}

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -23,7 +23,6 @@ import models.FormObject;
 import ninja.Context;
 import ninja.Result;
 import ninja.Results;
-import ninja.Router;
 import ninja.cache.NinjaCache;
 import ninja.exceptions.BadRequestException;
 import ninja.i18n.Lang;
@@ -40,6 +39,7 @@ import ninja.validation.Validation;
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import ninja.ReverseRouter;
@@ -92,20 +92,19 @@ public class ApplicationController {
     public Result userDashboard(@PathParam("email") String email,
                                 @PathParam("id") Integer id,
                                 Context context) {
-
-        Map<String, Object> map = new HashMap<>();
-        // generate tuples, convert integer to string here because Freemarker
-        // does it in locale
-        // dependent way with commas etc
-        map.put("id", Integer.toString(id));
-        map.put("email", email);
-        
+        // build reverse route
         String reverseRoute = reverseRouter
             .with(ApplicationController::userDashboard)
-                .params(map)
+                .pathParam("id", id)
+                .pathParam("email", email)
                 .build();
 
-        map.put("reverseRoute", reverseRoute);
+        // build map
+        Map<String,Object> map = new HashMap<String,Object>() {{
+            put("id", id);
+            put("email", email);
+            put("reverseRoute", reverseRoute);
+        }};
         
         // and render page with both parameters:
         return Results.html().render(map);

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import ninja.ReverseRouter;
 
 @Singleton
 public class ApplicationController {
@@ -62,7 +63,7 @@ public class ApplicationController {
     Messages messages;
 
     @Inject
-    Router router;
+    ReverseRouter reverseRouter;
     
     @Inject
     NinjaCache ninjaCache;
@@ -99,7 +100,10 @@ public class ApplicationController {
         map.put("id", Integer.toString(id));
         map.put("email", email);
         
-        String reverseRoute = router.getReverseRoute(ApplicationController.class, "userDashboard", map);
+        String reverseRoute = reverseRouter
+            .with(ApplicationController::userDashboard)
+                .params(map)
+                .build();
 
         map.put("reverseRoute", reverseRoute);
         

--- a/ninja-servlet-integration-test/src/test/java/conf/RoutesTest.java
+++ b/ninja-servlet-integration-test/src/test/java/conf/RoutesTest.java
@@ -79,7 +79,7 @@ public class RoutesTest extends NinjaRouterTest {
         generatedReverseRoute = router.getReverseRoute(ApplicationController.class, "userDashboard");
         
         // this looks strange, but is expected:
-        assertEquals("/user/{id}/{email}/userDashboard", generatedReverseRoute);
+        assertEquals(null, generatedReverseRoute);
         
 
 

--- a/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
@@ -129,10 +129,10 @@ public class ApplicationControllerTest extends RecycledNinjaServerTester {
                 ninjaTestBrowser.makeRequest(withBaseUrl("/user/12345/john@example.com/userDashboard"), headers);
 
         // And assert that stuff is visible on page:
-        assertTrue(response.contains("john@example.com"));
-        assertTrue(response.contains("12345"));
+        assertThat(response, containsString("john@example.com"));
+        assertThat(response, containsString("12345"));
         // Assert that reverse routing works:
-        assertTrue(response.contains("By the way... Reverse url of this rawUrl is: /user/12345/john@example.com/userDashboard"));
+        assertThat(response, containsString("By the way... Reverse url of this rawUrl is: /user/12345/john@example.com/userDashboard"));
 
     }
 


### PR DESCRIPTION
This closes the loop on the new Java 8-style routing w/ lambdas and method references.  The new `ninja.ReverseRouter` class is a much improved & safer way to do reverse routing.  I've been bitten many times over the years on non-existent or changed routes that result in NPEs.  No more.  The reverse router will throw exceptions if routes are missing, path parameters are missing, etc.  Along with Java-8 method references, refactoring your code either should make these just work or the compiler will break. Values are now URL-escaped by default unless you explicitly use the `raw` versions of each method. `ninja.RouterImpl` now uses this reverse router under-the-hood as well. A new builder-style syntax for returned reverse routes let you safely build your result with various helper methods.

```java
public Result myMethod() {
        String url = reverseRouter.with(ApplicationController::users_show)
            .path("id", 1000)
            .path("email", "test@example.com")
            .query("filtered", true)
            .build();
        
        // /users/1000/test%40example.com?filtered=true
        // ...
    }
```
Routes should also be a tad faster since the parameters are parsed and stored during compile-time so that replacing them during runtime requires no regex matching.