### PR TITLE
fix to issue #532

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/CookieEncryption.java
+++ b/ninja-core/src/main/java/ninja/utils/CookieEncryption.java
@@ -102,7 +102,7 @@ public class CookieEncryption {
             throw new RuntimeException(ex);
         } catch (GeneralSecurityException ex) {
             logger.error("Failed to encrypt data.", ex);
-            throw new RuntimeException(ex);
+            return "";
         }
     }
 
@@ -136,7 +136,7 @@ public class CookieEncryption {
             throw new RuntimeException(ex);
         } catch (GeneralSecurityException ex) {
             logger.error("Failed to decrypt data.", ex);
-            throw new RuntimeException(ex);
+            return "";
         }
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.x.x
 =============
  
+ * 2016-12-25 Fix issue #532: return clean session instead of runtime error when session cookies can not be decrypted
  * 2016-12-19 New `ninja.ReverseRouter` for validated, URL-safe reverse routing using Java 8 lambda expressions in addition to legacy Class + method name references. (jjlauer)
  * 2016-10-03 Remove `async-machine-beta` module (jjlauer)
  * 2016-09-29 Route using Java 8 lambda expressions (jjlauer)

--- a/ninja-core/src/test/java/ninja/session/SessionImplTest.java
+++ b/ninja-core/src/test/java/ninja/session/SessionImplTest.java
@@ -523,6 +523,47 @@ public class SessionImplTest {
         assertThat(cookieCaptor.getValue().getMaxAge(), CoreMatchers.equalTo(0));
     }    
 
+    @Test
+    public void testSessionEncryptionKeysMismatch() {
+
+        if (!encrypted) {
+            assertTrue("N/A for plain session cookies without encryption", true);
+            return;
+        }
+
+        // (1) create session with some data and save
+        Session session_1 = createNewSession();
+        session_1.init(context);
+        session_1.put("key", "value");
+        session_1.save(context);
+
+        // (2) verify that cookie with our data is created and added to context
+        verify(context).addCookie(cookieCaptor.capture());
+        assertEquals("value", session_1.get("key"));
+
+        // save reference to our cookie - we will use it to init sessions below
+        Cookie cookie = cookieCaptor.getValue();
+
+        // (3) create new session with the same cookie and assert that it still has our data
+        Session session_2 = createNewSession();
+        when(context.getCookie("NINJA_SESSION")).thenReturn(cookie);
+        session_2.init(context);
+        assertFalse(session_2.isEmpty());
+        assertEquals("value", session_2.get("key"));
+
+        // (4) now we change our application secret and thus our encryption key is modified
+        when(ninjaProperties.getOrDie(NinjaConstant.applicationSecret))
+                .thenReturn(SecretGenerator.generateSecret());
+        encryption = new CookieEncryption(ninjaProperties);
+
+        // (5) creating new session with the same cookie above would result in clean session
+        // because that cookie was encrypted with another key and decryption with the new key
+        // is not possible; usually such a case throws `javax.crypto.BadPaddingException`
+        Session session_3 = createNewSession();
+        session_3.init(context);
+        assertTrue(session_3.isEmpty());
+    }
+
     private Session roundTrip(Session sessionCookie1) {
         sessionCookie1.save(context);
 


### PR DESCRIPTION
As I am more or less familiar with session encryption classes, here I propose a *minimalistic* PR that fixes issue #532.
Returning empty string upon `GeneralSecurityException` (super class of `BadPaddingException` which causes the issue) would result in a clean session (session w/o any data). You can see it [here](https://github.com/ninjaframework/ninja/blob/develop/ninja-core/src/main/java/ninja/session/SessionImpl.java#L117-L118).
We already have logging in [CookieEncryption](https://github.com/ninjaframework/ninja/blob/develop/ninja-core/src/main/java/ninja/utils/CookieEncryption.java#L138) class.