### PR TITLE
Convert Guava `Optional` to standard Java 8 `Optional`

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -123,12 +123,6 @@
             <artifactId>freemarker-gae</artifactId>
         </dependency>
 
-        <!-- guava is just cool -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
         <!-- Needed for Hex transforms (security, cookies) and more... -->
         <dependency>
             <groupId>commons-codec</groupId>

--- a/ninja-core/src/main/java/ninja/Bootstrap.java
+++ b/ninja-core/src/main/java/ninja/Bootstrap.java
@@ -18,10 +18,10 @@ package ninja;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import ninja.application.ApplicationRoutes;
 import ninja.logging.LogbackConfigurator;
-import ninja.params.ParamParser;
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaProperties;
 import ninja.utils.NinjaPropertiesImpl;
@@ -29,7 +29,6 @@ import ninja.utils.NinjaPropertiesImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -37,7 +36,6 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
-import com.google.inject.multibindings.Multibinder;
 
 import ninja.conf.FrameworkModule;
 import ninja.conf.NinjaBaseModule;
@@ -72,8 +70,8 @@ public class Bootstrap {
         
         // custom base package for application modules (e.g. com.example.conf.Routes)
         this.applicationModulesBasePackage
-            = Optional.fromNullable(ninjaProperties.get(
-                    NinjaConstant.APPLICATION_MODULES_BASE_PACKAGE));
+                = Optional.ofNullable(ninjaProperties.get(
+                        NinjaConstant.APPLICATION_MODULES_BASE_PACKAGE));
         
     }
 

--- a/ninja-core/src/main/java/ninja/NinjaDefault.java
+++ b/ninja-core/src/main/java/ninja/NinjaDefault.java
@@ -17,6 +17,7 @@
 package ninja;
 
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
 
 import javax.management.RuntimeErrorException;
@@ -35,7 +36,6 @@ import ninja.utils.ResultHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.inject.Inject;
 
 public class NinjaDefault implements Ninja {
@@ -241,7 +241,7 @@ public class NinjaDefault implements Ninja {
                         NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_KEY,
                         NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_DEFAULT,
                         context,
-                        Optional.<Result>absent());
+                        Optional.<Result>empty());
         
         Message message = new Message(messageI18n);
 
@@ -276,7 +276,7 @@ public class NinjaDefault implements Ninja {
                         NinjaConstant.I18N_NINJA_SYSTEM_NOT_FOUND_TEXT_KEY,
                         NinjaConstant.I18N_NINJA_SYSTEM_NOT_FOUND_TEXT_DEFAULT,
                         context,
-                        Optional.<Result>absent());
+                        Optional.<Result>empty());
         
         Message message = new Message(messageI18n); 
         
@@ -311,7 +311,7 @@ public class NinjaDefault implements Ninja {
                         NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_KEY,
                         NinjaConstant.I18N_NINJA_SYSTEM_BAD_REQUEST_TEXT_DEFAULT,
                         context,
-                        Optional.<Result>absent());
+                        Optional.<Result>empty());
         
         Message message = new Message(messageI18n); 
            
@@ -346,7 +346,7 @@ public class NinjaDefault implements Ninja {
                         NinjaConstant.I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_KEY,
                         NinjaConstant.I18N_NINJA_SYSTEM_UNAUTHORIZED_REQUEST_TEXT_DEFAULT,
                         context,
-                        Optional.<Result>absent());
+                        Optional.<Result>empty());
 
         Message message = new Message(messageI18n);
 
@@ -385,7 +385,7 @@ public class NinjaDefault implements Ninja {
                         NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_KEY,
                         NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_DEFAULT,
                         context,
-                        Optional.<Result>absent());
+                        Optional.<Result>empty());
         
         Message message = new Message(messageI18n); 
            

--- a/ninja-core/src/main/java/ninja/Result.java
+++ b/ninja-core/src/main/java/ninja/Result.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import ninja.exceptions.InternalServerErrorException;
 import ninja.utils.DateUtil;
@@ -34,7 +35,6 @@ import ninja.utils.SwissKnife;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -119,7 +119,7 @@ public class Result {
      * header of request this fallback will be used. If it is not set 
      * a bad request exception will be thrown.
      */
-    private Optional<String> fallbackContentType = Optional.absent();
+    private Optional<String> fallbackContentType = Optional.empty();
     
     /**
      * A list of content types this result will handle. If you got a general

--- a/ninja-core/src/main/java/ninja/Results.java
+++ b/ninja-core/src/main/java/ninja/Results.java
@@ -16,9 +16,9 @@
 
 package ninja;
 
-import ninja.utils.NoHttpBody;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
+import ninja.utils.NoHttpBody;
 
 
 /**

--- a/ninja-core/src/main/java/ninja/ReverseRouter.java
+++ b/ninja-core/src/main/java/ninja/ReverseRouter.java
@@ -15,21 +15,24 @@
  */
 package ninja;
 
-import com.google.common.base.Optional;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.inject.Inject;
+import java.util.Optional;
+
 import ninja.ControllerMethods.ControllerMethod;
 import ninja.ReverseRouter.Builder;
 import ninja.utils.LambdaRoute;
 import ninja.utils.MethodReference;
 import ninja.utils.NinjaProperties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
 
 /**
  * Reverse routing. Lookup the uri associated with a controller method.

--- a/ninja-core/src/main/java/ninja/Router.java
+++ b/ninja-core/src/main/java/ninja/Router.java
@@ -18,8 +18,8 @@ package ninja;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import ninja.utils.MethodReference;
 
 public interface Router {

--- a/ninja-core/src/main/java/ninja/RouterImpl.java
+++ b/ninja-core/src/main/java/ninja/RouterImpl.java
@@ -16,15 +16,18 @@
 
 package ninja;
 
-import ninja.utils.MethodReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import ninja.utils.MethodReference;
 import ninja.utils.NinjaProperties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.base.Optional;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -71,7 +74,7 @@ public class RouterImpl implements Router {
             Class<?> controllerClass,
             String controllerMethodName) {
 
-        Optional<Map<String, Object>> parameterMap = Optional.absent();
+        Optional<Map<String, Object>> parameterMap = Optional.empty();
 
         return getReverseRoute(controllerClass, controllerMethodName, parameterMap);
 
@@ -102,7 +105,7 @@ public class RouterImpl implements Router {
             String controllerMethodName,
             Map<String, Object> parameterMap) {
         Optional<Map<String, Object>> parameterMapOptional
-                = Optional.fromNullable(parameterMap);
+                = Optional.ofNullable(parameterMap);
 
         return getReverseRoute(
                 controllerClass, controllerMethodName,
@@ -288,7 +291,7 @@ public class RouterImpl implements Router {
         
         Route route = this.reverseRoutes.get(reverseRouteKey);
         
-        return Optional.fromNullable(route);
+        return Optional.ofNullable(route);
     }
     
     private void logRoutes() {

--- a/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorRenderer.java
+++ b/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorRenderer.java
@@ -24,12 +24,14 @@ import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+
 import ninja.Context;
 import ninja.Cookie;
 import ninja.Result;
 import ninja.Route;
 import ninja.exceptions.InternalServerErrorException;
 import ninja.utils.ResponseStreams;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
@@ -361,7 +363,7 @@ public class DiagnosticErrorRenderer {
             }
         }
         
-        appendNameValue(s, "Fallback content type", result.fallbackContentType().or("None set")); 
+        appendNameValue(s, "Fallback content type", result.fallbackContentType().orElse("None set"));
         appendNameValue(s, "Json View", (result.getJsonView() != null ? result.getJsonView().getClass().getCanonicalName() : "None")); 
         
         

--- a/ninja-core/src/main/java/ninja/i18n/Lang.java
+++ b/ninja-core/src/main/java/ninja/i18n/Lang.java
@@ -17,11 +17,11 @@
 package ninja.i18n;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
 
-import com.google.common.base.Optional;
 import com.google.inject.ImplementedBy;
 
 @ImplementedBy(LangImpl.class)

--- a/ninja-core/src/main/java/ninja/i18n/LangImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/LangImpl.java
@@ -17,6 +17,7 @@
 package ninja.i18n;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Cookie;
@@ -27,7 +28,6 @@ import ninja.utils.NinjaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -120,7 +120,7 @@ public class LangImpl implements Lang {
         // Step 3: Determine language from Accept-Language header.
         String acceptLanguage = context.getAcceptLanguage(); 
         if (acceptLanguage == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
         
 
@@ -145,7 +145,7 @@ public class LangImpl implements Lang {
         }
 
         
-        return Optional.absent();
+        return Optional.empty();
         
     }
     

--- a/ninja-core/src/main/java/ninja/i18n/Messages.java
+++ b/ninja-core/src/main/java/ninja/i18n/Messages.java
@@ -18,11 +18,11 @@ package ninja.i18n;
 
 import java.text.MessageFormat;
 import java.util.Map;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
 
-import com.google.common.base.Optional;
 import com.google.inject.ImplementedBy;
 
 @ImplementedBy(MessagesImpl.class)

--- a/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
@@ -19,6 +19,7 @@ package ninja.i18n;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
@@ -34,7 +35,6 @@ import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -79,7 +79,7 @@ public class MessagesImpl implements Messages {
             MessageFormat messageFormat = getMessageFormatForLocale(value, language);
             return Optional.of(messageFormat.format(params));
         } else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
     

--- a/ninja-core/src/main/java/ninja/standalone/AbstractStandalone.java
+++ b/ninja-core/src/main/java/ninja/standalone/AbstractStandalone.java
@@ -16,22 +16,26 @@
 
 package ninja.standalone;
 
-import ninja.utils.OverlayedNinjaProperties;
-import com.google.common.base.Optional;
-import com.google.inject.CreationException;
+import static ninja.standalone.StandaloneHelper.checkContextPath;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import javax.net.ssl.SSLContext;
-import static ninja.standalone.StandaloneHelper.checkContextPath;
+import java.util.Optional;
+
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaMode;
 import ninja.utils.NinjaModeHelper;
 import ninja.utils.NinjaPropertiesImpl;
-import org.apache.commons.lang3.StringUtils;
+import ninja.utils.OverlayedNinjaProperties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.inject.CreationException;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Abstract Standalone that implements most functionality required to write
@@ -502,7 +506,7 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
         
         s.append("on ");
         
-        s.append(Optional.fromNullable(getHost()).or("<all>"));
+        s.append(Optional.ofNullable(getHost()).orElse("<all>"));
         s.append(":");
         s.append(ports);
 

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarker.java
@@ -23,11 +23,13 @@ import java.io.Writer;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import javax.inject.Singleton;
 
 import ninja.Context;
 import ninja.Result;
+import ninja.exceptions.RenderingException;
 import ninja.i18n.Lang;
 import ninja.i18n.Messages;
 import ninja.template.directives.TemplateEngineFreemarkerAuthenticityFormDirective;
@@ -39,7 +41,6 @@ import ninja.utils.ResponseStreams;
 import org.slf4j.Logger;
 
 import com.google.common.base.CaseFormat;
-import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
@@ -56,8 +57,6 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateNotFoundException;
 import freemarker.template.Version;
-import java.io.StringWriter;
-import ninja.exceptions.RenderingException;
 
 @Singleton
 public class TemplateEngineFreemarker implements TemplateEngine {

--- a/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
+++ b/ninja-core/src/main/java/ninja/template/TemplateEngineFreemarkerI18nMethod.java
@@ -17,6 +17,7 @@
 package ninja.template;
 
 import java.util.List;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
@@ -25,7 +26,6 @@ import ninja.i18n.Messages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 import freemarker.template.SimpleNumber;
@@ -61,7 +61,7 @@ public class TemplateEngineFreemarkerI18nMethod implements
 
             String messageValue = messages
                     .get(messageKey, context, result)
-                    .or(messageKey);
+                    .orElse(messageKey);
             
             logIfMessageKeyIsMissing(messageKey, messageValue);
             
@@ -91,7 +91,7 @@ public class TemplateEngineFreemarkerI18nMethod implements
                             context, 
                             result, 
                             strings.subList(1, strings.size()).toArray())
-                    .or(messageKey);
+                            .orElse(messageKey);
             
             logIfMessageKeyIsMissing(messageKey, messageValue);
             

--- a/ninja-core/src/main/java/ninja/utils/CookieEncryption.java
+++ b/ninja-core/src/main/java/ninja/utils/CookieEncryption.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -27,7 +28,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -47,7 +47,7 @@ public class CookieEncryption {
     @Inject
     public CookieEncryption(NinjaProperties properties) {
         
-        Optional<SecretKeySpec> secretKeySpec = Optional.absent();
+        Optional<SecretKeySpec> secretKeySpec = Optional.empty();
 
         if (properties.getBooleanWithDefault(NinjaConstant.applicationCookieEncrypted, false)) {
             

--- a/ninja-core/src/main/java/ninja/utils/HttpCacheToolkit.java
+++ b/ninja-core/src/main/java/ninja/utils/HttpCacheToolkit.java
@@ -16,10 +16,11 @@
 
 package ninja.utils;
 
+import java.util.Optional;
+
 import ninja.Context;
 import ninja.Result;
 
-import com.google.common.base.Optional;
 import com.google.inject.ImplementedBy;
 
 @ImplementedBy(HttpCacheToolkitImpl.class)

--- a/ninja-core/src/main/java/ninja/utils/HttpCacheToolkitImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/HttpCacheToolkitImpl.java
@@ -22,6 +22,7 @@ import static ninja.utils.NinjaConstant.HTTP_USE_ETAG;
 import static ninja.utils.NinjaConstant.HTTP_USE_ETAG_DEFAULT;
 
 import java.util.Date;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
@@ -29,7 +30,6 @@ import ninja.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.inject.Inject;
 
 public class HttpCacheToolkitImpl implements HttpCacheToolkit {
@@ -106,7 +106,7 @@ public class HttpCacheToolkitImpl implements HttpCacheToolkit {
         }
 
 
-        if (!isModified(Optional.fromNullable(etag), Optional.fromNullable(lastModified), context)) {
+        if (!isModified(Optional.ofNullable(etag), Optional.ofNullable(lastModified), context)) {
 
             if (context.getMethod().toLowerCase().equals("get")) {
                 result.status(Result.SC_304_NOT_MODIFIED);

--- a/ninja-core/src/main/java/ninja/utils/NinjaModeHelper.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaModeHelper.java
@@ -16,10 +16,10 @@
 
 package ninja.utils;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
 
 public class NinjaModeHelper {
     
@@ -62,7 +62,7 @@ public class NinjaModeHelper {
 
         }
         
-        return Optional.fromNullable(ninjaMode);
+        return Optional.ofNullable(ninjaMode);
         
     }
     

--- a/ninja-core/src/main/java/ninja/validation/Validators.java
+++ b/ninja-core/src/main/java/ninja/validation/Validators.java
@@ -16,19 +16,21 @@
 
 package ninja.validation;
 
-import com.google.common.base.Optional;
-import com.google.inject.Inject;
-import ninja.Context;
-import ninja.Result;
-import ninja.i18n.Lang;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.validation.MessageInterpolator;
 import javax.validation.ValidatorFactory;
 import javax.validation.metadata.ConstraintDescriptor;
-import java.io.Serializable;
-import java.util.Locale;
-import java.util.Set;
-import java.util.regex.Pattern;
+
+import ninja.Context;
+import ninja.Result;
+import ninja.i18n.Lang;
+
+import com.google.inject.Inject;
 
 /**
  * Built in validators.
@@ -111,7 +113,7 @@ public class Validators {
                 final ValidatorFactory validatorFactory = javax.validation.Validation.buildDefaultValidatorFactory();
                 final javax.validation.Validator validator = validatorFactory.getValidator();
                 final Set<javax.validation.ConstraintViolation<Object>> violations = validator.validate(value);
-                final Locale localeToUse = this.requestLanguage.getLocaleFromStringOrDefault(this.requestLanguage.getLanguage(context, Optional.<Result>absent()));
+                final Locale localeToUse = this.requestLanguage.getLocaleFromStringOrDefault(this.requestLanguage.getLanguage(context, Optional.<Result>empty()));
                 final Validation validation = context.getValidation();
 
                 for (final javax.validation.ConstraintViolation<Object> violation : violations) {

--- a/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
+++ b/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
@@ -17,9 +17,15 @@
 package ninja;
 
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import ninja.diagnostics.DiagnosticError;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
+import ninja.diagnostics.DiagnosticError;
 import ninja.exceptions.BadRequestException;
 import ninja.exceptions.InternalServerErrorException;
 import ninja.i18n.Messages;
@@ -30,9 +36,6 @@ import ninja.utils.NinjaProperties;
 import ninja.utils.ResultHandler;
 
 import org.hamcrest.CoreMatchers;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,11 +44,7 @@ import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.base.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NinjaDefaultTest {

--- a/ninja-core/src/test/java/ninja/i18n/LangImplTest.java
+++ b/ninja-core/src/test/java/ninja/i18n/LangImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Cookie;
@@ -37,8 +38,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.base.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LangImplTest {
@@ -152,7 +151,7 @@ public class LangImplTest {
         when(ninjaProperties.getStringArray(NinjaConstant.applicationLanguages)).thenReturn(new String[] {"en"});
         Lang lang = new LangImpl(ninjaProperties);
         
-        Optional<String> language = Optional.absent();
+        Optional<String> language = Optional.empty();
         Locale locale = lang.getLocaleFromStringOrDefault(language);
         
         assertEquals(Locale.ENGLISH, locale);
@@ -161,7 +160,7 @@ public class LangImplTest {
         when(ninjaProperties.getStringArray(NinjaConstant.applicationLanguages)).thenReturn(new String[] {"de", "en"});
         lang = new LangImpl(ninjaProperties);
         
-        language = Optional.absent();
+        language = Optional.empty();
         locale = lang.getLocaleFromStringOrDefault(language);
         
         assertEquals(Locale.GERMAN, locale);
@@ -170,7 +169,7 @@ public class LangImplTest {
         when(ninjaProperties.getStringArray(NinjaConstant.applicationLanguages)).thenReturn(new String[] {"de-DE", "en"});
         lang = new LangImpl(ninjaProperties);
         
-        language = Optional.absent();
+        language = Optional.empty();
         locale = lang.getLocaleFromStringOrDefault(language);
         
         assertEquals(Locale.GERMANY, locale);
@@ -186,7 +185,7 @@ public class LangImplTest {
         when(ninjaProperties.getStringArray(NinjaConstant.applicationLanguages)).thenReturn(new String[] {});
         Lang lang = new LangImpl(ninjaProperties);
         
-        Optional<String> language = Optional.absent();
+        Optional<String> language = Optional.empty();
         lang.getLocaleFromStringOrDefault(language);
         
         // ISE expected

--- a/ninja-core/src/test/java/ninja/i18n/MessagesImplTest.java
+++ b/ninja-core/src/test/java/ninja/i18n/MessagesImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Cookie;
@@ -36,8 +37,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.base.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessagesImplTest {
@@ -81,7 +80,7 @@ public class MessagesImplTest {
 
         assertEquals("defaultlanguage", messages.get("language", Optional.of("fr")).get());
 
-        assertEquals(Optional.absent(), messages.get("a_non_existing_key", Optional.of("fr")));
+        assertEquals(Optional.empty(), messages.get("a_non_existing_key", Optional.of("fr")));
     }
     
     @Test
@@ -243,7 +242,7 @@ public class MessagesImplTest {
         
         
         // test fallback to default (english in that case)
-        Optional<String> language = Optional.absent();
+        Optional<String> language = Optional.empty();
         Optional<String> result = messages.get("message_with_placeholder_date", language, DATE_1970_JAN);
         
         assertEquals("that's a date: Jan 1, 1970", result.get());

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerI18nMethodTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerI18nMethodTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import ninja.Context;
 import ninja.Result;
@@ -41,9 +42,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.core.Appender;
-
-import com.google.common.base.Optional;
-
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
@@ -131,7 +129,7 @@ public class TemplateEngineFreemarkerI18nMethodTest {
         
         Mockito.when(
                 messages.get("my.message.key", context, resultOptional))
-                .thenReturn(Optional.<String>absent());
+                .thenReturn(Optional.<String>empty());
         
         List args = new ArrayList();
         args.add(new SimpleScalar("my.message.key"));
@@ -188,7 +186,7 @@ public class TemplateEngineFreemarkerI18nMethodTest {
                         Matchers.eq(context), 
                         Matchers.eq(resultOptional),
                         Matchers.any(Object.class)))
-                .thenReturn(Optional.<String>absent());
+                .thenReturn(Optional.<String>empty());
         
         TemplateModel returnValue 
                 = templateEngineFreemarkerI18nMethod.exec(args);

--- a/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerTest.java
+++ b/ninja-core/src/test/java/ninja/template/TemplateEngineFreemarkerTest.java
@@ -19,6 +19,7 @@ import static ninja.template.TemplateEngineFreemarker.FREEMARKER_CONFIGURATION_F
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Singleton;
 
@@ -54,11 +56,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
-import com.google.common.base.Optional;
-
 import freemarker.template.Configuration;
-import org.junit.Assert;
-import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TemplateEngineFreemarkerTest {
@@ -121,7 +119,7 @@ public class TemplateEngineFreemarkerTest {
                         ninjaProperties);
 
         
-        when(lang.getLanguage(any(Context.class), any(Optional.class))).thenReturn(Optional.<String>absent());
+        when(lang.getLanguage(any(Context.class), any(Optional.class))).thenReturn(Optional.<String>empty());
 
         Session session = Mockito.mock(Session.class);
         when(session.isEmpty()).thenReturn(true);

--- a/ninja-core/src/test/java/ninja/utils/HttpCacheToolkitImplTest.java
+++ b/ninja-core/src/test/java/ninja/utils/HttpCacheToolkitImplTest.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
 import ninja.Context;
 import ninja.Result;
 
@@ -31,8 +34,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.base.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpCacheToolkitImplTest {

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -18,11 +18,12 @@ package controllers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
-import models.FormObject;
 import ninja.Context;
 import ninja.Result;
 import ninja.Results;
+import ninja.ReverseRouter;
 import ninja.cache.NinjaCache;
 import ninja.exceptions.BadRequestException;
 import ninja.i18n.Lang;
@@ -38,11 +39,10 @@ import ninja.validation.Validation;
 
 import org.slf4j.Logger;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import ninja.ReverseRouter;
+
+import models.FormObject;
 
 @Singleton
 public class ApplicationController {

--- a/ninja-test-utilities/src/main/java/ninja/NinjaDaoTestBase.java
+++ b/ninja-test-utilities/src/main/java/ninja/NinjaDaoTestBase.java
@@ -16,6 +16,8 @@
 
 package ninja;
 
+import java.util.Optional;
+
 import ninja.jpa.JpaInitializer;
 import ninja.jpa.JpaModule;
 import ninja.utils.NinjaMode;
@@ -25,7 +27,6 @@ import ninja.utils.NinjaPropertiesImpl;
 import org.junit.After;
 import org.junit.Before;
 
-import com.google.common.base.Optional;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 


### PR DESCRIPTION
PR for issue #538.
Please note that Guava dependency is removed from `ninja-core` module but it still lives in parent module (in case we need it future releases). Yeah, only `Optional` was being used from Guava.