### PR TITLE
#536 Bump Guice to version 4.1.0

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.0.0-beta4
 ===================
 
+ * 2017-02-27 Bump Guice to version 4.1.0 #536 (ra)
  * 2017-02-23 Fix routes w/ no path params triggering NPE in some cases #565 (jjlauer)
  * 2017-02-16 Add global filtering capabilities #547 (ra)
 

--- a/ninja-maven-plugin/pom.xml
+++ b/ninja-maven-plugin/pom.xml
@@ -31,11 +31,11 @@
     <url>http://www.ninjaframework.org</url>
     
     <prerequisites>
-        <maven>3.1.0</maven>
+        <maven>3.3.9</maven>
     </prerequisites>
 
     <properties>
-        <mavenVersion>3.1.1</mavenVersion>
+        <mavenVersion>3.3.9</mavenVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jetty.version>9.3.11.v20160721</jetty.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
         <jackson.version>2.8.1</jackson.version>
-        <guice.version>4.0</guice.version>
+        <guice.version>4.1.0</guice.version>
         <metrics.version>3.1.1</metrics.version>
         <slf4j.version>1.7.21</slf4j.version>
         <powermock.version>1.5.6</powermock.version>


### PR DESCRIPTION
Had to bump the minimum Maven version of the ninja-maven-plugin to
3.3.9. Otherwise we get strange errors because of
incompatible Guice versions in tests.