### PR TITLE
Handle empty string param parsing

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ParamParsers.java
+++ b/ninja-core/src/main/java/ninja/params/ParamParsers.java
@@ -371,7 +371,7 @@ public class ParamParsers {
     public static class StringParamParser implements ParamParser<String> {
         @Override
         public String parseParameter(String field, String parameterValue, Validation validation) {
-            if (parameterValue == null || validation.hasViolation(field)) {
+            if (parameterValue == null || parameterValue.isEmpty() || validation.hasViolation(field)) {
                 return null;
             } else {
                 return parameterValue;

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+ * 2017-04-30 Handling empty string param parsing (jlannoy)
+
 Version 6.0.0
 =============
 

--- a/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
+++ b/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
@@ -15,42 +15,250 @@
  */
 package ninja.params;
 
-import ninja.validation.Validation;
+import static org.junit.Assert.assertThat;
+
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import ninja.validation.Validation;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParamParsersTest {
-    
+
     @Mock
     Validation validation;
-    
+
     @Test
     public void testBooleanParamParser() {
-           ParamParsers.BooleanParamParser booleanParamParser = new ParamParsers.BooleanParamParser();
-           
-           assertThat(booleanParamParser.getParsedType(), Matchers.is(Boolean.class));
-           
-           assertThat(booleanParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
-           assertThat(booleanParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
-           assertThat(booleanParamParser.parseParameter("param1", "123123", validation), Matchers.nullValue());
-           assertThat(booleanParamParser.parseParameter("param1", "-", validation), Matchers.nullValue());
-           assertThat(booleanParamParser.parseParameter("param1", "+", validation), Matchers.nullValue());
-           
-           assertThat(booleanParamParser.parseParameter("param1", "true", validation), Matchers.is(Boolean.TRUE));
-           assertThat(booleanParamParser.parseParameter("param1", "TRUE", validation), Matchers.is(Boolean.TRUE));
-           
-           assertThat(booleanParamParser.parseParameter("param1", "false", validation), Matchers.is(Boolean.FALSE));
-           assertThat(booleanParamParser.parseParameter("param1", "FALSE", validation), Matchers.is(Boolean.FALSE));
+        ParamParsers.BooleanParamParser booleanParamParser = new ParamParsers.BooleanParamParser();
+
+        assertThat(booleanParamParser.getParsedType(), Matchers.is(Boolean.class));
+
+        assertThat(booleanParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(booleanParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+        assertThat(booleanParamParser.parseParameter("param1", "123123", validation), Matchers.nullValue());
+        assertThat(booleanParamParser.parseParameter("param1", "-", validation), Matchers.nullValue());
+        assertThat(booleanParamParser.parseParameter("param1", "+", validation), Matchers.nullValue());
+
+        assertThat(booleanParamParser.parseParameter("param1", "true", validation), Matchers.is(Boolean.TRUE));
+        assertThat(booleanParamParser.parseParameter("param1", "TRUE", validation), Matchers.is(Boolean.TRUE));
+
+        assertThat(booleanParamParser.parseParameter("param1", "false", validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "FALSE", validation), Matchers.is(Boolean.FALSE));
+    }
+
+    @Test
+    public void testPrimitiveBooleanParamParser() {
+        ParamParsers.PrimitiveBooleanParamParser booleanParamParser = new ParamParsers.PrimitiveBooleanParamParser();
+
+        assertThat(booleanParamParser.getParsedType(), Matchers.is(Boolean.class));
+
+        // No null for primitives
+        assertThat(booleanParamParser.parseParameter("param1", null, validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "123123", validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "-", validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "+", validation), Matchers.is(Boolean.FALSE));
+
+        assertThat(booleanParamParser.parseParameter("param1", "true", validation), Matchers.is(Boolean.TRUE));
+        assertThat(booleanParamParser.parseParameter("param1", "TRUE", validation), Matchers.is(Boolean.TRUE));
+
+        assertThat(booleanParamParser.parseParameter("param1", "false", validation), Matchers.is(Boolean.FALSE));
+        assertThat(booleanParamParser.parseParameter("param1", "FALSE", validation), Matchers.is(Boolean.FALSE));
+    }
+
+    @Test
+    public void testStringParamParser() {
+        ParamParsers.StringParamParser stringParamParser = new ParamParsers.StringParamParser();
+
+        assertThat(stringParamParser.getParsedType(), Matchers.is(String.class));
+
+        assertThat(stringParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(stringParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(stringParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(new String("asdfasdf")));
+    }
+
+    @Test
+    public void testIntegerParamParser() {
+        ParamParsers.IntegerParamParser integerParamParser = new ParamParsers.IntegerParamParser();
+
+        assertThat(integerParamParser.getParsedType(), Matchers.is(Integer.class));
+
+        assertThat(integerParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(integerParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(integerParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+
+        assertThat(integerParamParser.parseParameter("param1", "0", validation), Matchers.is(new Integer(0)));
+        assertThat(integerParamParser.parseParameter("param1", "000", validation), Matchers.is(new Integer(0)));
+        assertThat(integerParamParser.parseParameter("param1", "123", validation), Matchers.is(new Integer(123)));
+        assertThat(integerParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Integer(-123)));
+    }
+
+    @Test
+    public void testPrimitiveIntegerParamParser() {
+        ParamParsers.PrimitiveIntegerParamParser integerParamParser = new ParamParsers.PrimitiveIntegerParamParser();
+
+        assertThat(integerParamParser.getParsedType(), Matchers.is(Integer.class));
+
+        // No null form primitives
+        assertThat(integerParamParser.parseParameter("param1", null, validation), Matchers.is((int) 0));
+        assertThat(integerParamParser.parseParameter("param1", "", validation), Matchers.is((int) 0));
+        assertThat(integerParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is((int) 0));
+
+        assertThat(integerParamParser.parseParameter("param1", "0", validation), Matchers.is((int) 0));
+        assertThat(integerParamParser.parseParameter("param1", "000", validation), Matchers.is((int) 0));
+        assertThat(integerParamParser.parseParameter("param1", "123", validation), Matchers.is((int) 123));
+        assertThat(integerParamParser.parseParameter("param1", "-123", validation), Matchers.is((int) -123));
+    }
+
+    @Test
+    public void testShortParamParser() {
+        ParamParsers.ShortParamParser shortParamParser = new ParamParsers.ShortParamParser();
+
+        assertThat(shortParamParser.getParsedType(), Matchers.is(Short.class));
+
+        assertThat(shortParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(shortParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(shortParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+
+        assertThat(shortParamParser.parseParameter("param1", "0", validation), Matchers.is(new Short((short) 0)));
+        assertThat(shortParamParser.parseParameter("param1", "000", validation), Matchers.is(new Short((short) 0)));
+        assertThat(shortParamParser.parseParameter("param1", "123", validation), Matchers.is(new Short((short) 123)));
+        assertThat(shortParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Short((short) -123)));
+    }
+
+    @Test
+    public void testPrimitiveShortParamParser() {
+        ParamParsers.PrimitiveShortParamParser shortParamParser = new ParamParsers.PrimitiveShortParamParser();
+
+        assertThat(shortParamParser.getParsedType(), Matchers.is(Short.class));
+
+        // No null form primitives
+        assertThat(shortParamParser.parseParameter("param1", null, validation), Matchers.is((short) 0));
+        assertThat(shortParamParser.parseParameter("param1", "", validation), Matchers.is((short) 0));
+        assertThat(shortParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is((short) 0));
+
+        assertThat(shortParamParser.parseParameter("param1", "0", validation), Matchers.is((short) 0));
+        assertThat(shortParamParser.parseParameter("param1", "000", validation), Matchers.is((short) 0));
+        assertThat(shortParamParser.parseParameter("param1", "123", validation), Matchers.is((short) 123));
+        assertThat(shortParamParser.parseParameter("param1", "-123", validation), Matchers.is((short) -123));
     }
     
+    @Test
+    public void testLongParamParser() {
+        ParamParsers.LongParamParser longParamParser = new ParamParsers.LongParamParser();
+
+        assertThat(longParamParser.getParsedType(), Matchers.is(Long.class));
+
+        assertThat(longParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(longParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(longParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+
+        assertThat(longParamParser.parseParameter("param1", "0", validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "000", validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "123", validation), Matchers.is(new Long(123)));
+        assertThat(longParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Long(-123)));
+    }
+
+    @Test
+    public void testPrimitiveLongParamParser() {
+        ParamParsers.PrimitiveLongParamParser longParamParser = new ParamParsers.PrimitiveLongParamParser();
+
+        assertThat(longParamParser.getParsedType(), Matchers.is(Long.class));
+
+        // No null form primitives
+        assertThat(longParamParser.parseParameter("param1", null, validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "", validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(new Long(0)));
+
+        assertThat(longParamParser.parseParameter("param1", "0", validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "000", validation), Matchers.is(new Long(0)));
+        assertThat(longParamParser.parseParameter("param1", "123", validation), Matchers.is(new Long(123)));
+        assertThat(longParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Long(-123)));
+    }
+
+    @Test
+    public void testFloatParamParser() {
+        ParamParsers.FloatParamParser floatParamParser = new ParamParsers.FloatParamParser();
+
+        assertThat(floatParamParser.getParsedType(), Matchers.is(Float.class));
+
+        assertThat(floatParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(floatParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(floatParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+
+        assertThat(floatParamParser.parseParameter("param1", "0", validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "000", validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "123", validation), Matchers.is(new Float(123)));
+        assertThat(floatParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Float(-123)));
+
+        assertThat(floatParamParser.parseParameter("param1", "0.1", validation), Matchers.is(new Float(0.1)));
+        assertThat(floatParamParser.parseParameter("param1", "123.1", validation), Matchers.is(new Float(123.1)));
+        assertThat(floatParamParser.parseParameter("param1", "-123.1", validation), Matchers.is(new Float(-123.1)));
+    }
+
+    @Test
+    public void testPrimitiveFloatParamParser() {
+        ParamParsers.PrimitiveFloatParamParser floatParamParser = new ParamParsers.PrimitiveFloatParamParser();
+
+        assertThat(floatParamParser.getParsedType(), Matchers.is(Float.class));
+
+        // No null form primitives
+        assertThat(floatParamParser.parseParameter("param1", null, validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "", validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(new Float(0)));
+
+        assertThat(floatParamParser.parseParameter("param1", "0", validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "000", validation), Matchers.is(new Float(0)));
+        assertThat(floatParamParser.parseParameter("param1", "123", validation), Matchers.is(new Float(123)));
+        assertThat(floatParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Float(-123)));
+
+        assertThat(floatParamParser.parseParameter("param1", "0.1", validation), Matchers.is(new Float(0.1)));
+        assertThat(floatParamParser.parseParameter("param1", "123.1", validation), Matchers.is(new Float(123.1)));
+        assertThat(floatParamParser.parseParameter("param1", "-123.1", validation), Matchers.is(new Float(-123.1)));
+    }
+
+    @Test
+    public void testDoubleParamParser() {
+        ParamParsers.DoubleParamParser doubleParamParser = new ParamParsers.DoubleParamParser();
+
+        assertThat(doubleParamParser.getParsedType(), Matchers.is(Double.class));
+
+        assertThat(doubleParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(doubleParamParser.parseParameter("param1", "", validation), Matchers.nullValue());
+        assertThat(doubleParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.nullValue());
+
+        assertThat(doubleParamParser.parseParameter("param1", "0", validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "000", validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "123", validation), Matchers.is(new Double(123)));
+        assertThat(doubleParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Double(-123)));
+
+        assertThat(doubleParamParser.parseParameter("param1", "0.1", validation), Matchers.is(new Double(0.1)));
+        assertThat(doubleParamParser.parseParameter("param1", "123.1", validation), Matchers.is(new Double(123.1)));
+        assertThat(doubleParamParser.parseParameter("param1", "-123.1", validation), Matchers.is(new Double(-123.1)));
+    }
+
+    @Test
+    public void testPrimitiveDoubleParamParser() {
+        ParamParsers.PrimitiveDoubleParamParser doubleParamParser = new ParamParsers.PrimitiveDoubleParamParser();
+
+        assertThat(doubleParamParser.getParsedType(), Matchers.is(Double.class));
+
+        // No null form primitives
+        assertThat(doubleParamParser.parseParameter("param1", null, validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "", validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(new Double(0)));
+
+        assertThat(doubleParamParser.parseParameter("param1", "0", validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "000", validation), Matchers.is(new Double(0)));
+        assertThat(doubleParamParser.parseParameter("param1", "123", validation), Matchers.is(new Double(123)));
+        assertThat(doubleParamParser.parseParameter("param1", "-123", validation), Matchers.is(new Double(-123)));
+
+        assertThat(doubleParamParser.parseParameter("param1", "0.1", validation), Matchers.is(new Double(0.1)));
+        assertThat(doubleParamParser.parseParameter("param1", "123.1", validation), Matchers.is(new Double(123.1)));
+        assertThat(doubleParamParser.parseParameter("param1", "-123.1", validation), Matchers.is(new Double(-123.1)));
+    }
 }


### PR DESCRIPTION
For each parameter that is not a string, the parameter is checked against null and then against an empty string. In both case, the returned value for that parameter is null.

There is one exception, it's for the String parameters... An empty string (input) results in a empty string (parameter value). It could seems legit but I don't think it is. When an HTML request POST form fields that have not been filled, they appear in the request with... an empty value. Meaning that with the current version of Ninja, you have to check if your string is empty to know if user has entered a value in it. All my projects and my colleagues projects, are overriding the StringParamParser to avoid that.

There could be an side effect. Let's say we have... ?var=&var2=b 
With what I said just before, it means that the var param would be null. So you would not be able to make a difference between ?var=&var2=b and ?var2=b. But is it an issue? Does it make sense to explicitly want to pass an empty string to a parameter? I don't see any case where it could be a good use case.

I think it makes even more sense since with have Optional parameters for cleaner solutions. What do you think? 