### PR TITLE
Update to the last FluentLenium version

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+ * 2017-05-04 fluentlenium from 0.10.3 to 3.2.0 - refer to ninja doc for backward compatibility (jlannoy)
+
 Version 6.0.0
 =============
 

--- a/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_fluentlenium_test.md
+++ b/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_fluentlenium_test.md
@@ -35,3 +35,27 @@ public class ApplicationControllerFluentLeniumTest extends NinjaFluentLeniumTest
 </pre>
 
 But FluentLenium can do a lot more. Check out https://github.com/FluentLenium/FluentLenium
+
+
+From 0.10.3 to 3.2.0
+--------------------
+
+Prior to Ninja 6.0.0, FluentLenium 0.10.3 was used. Upgrading to version 3.2.0 breaks backward compatibility
+of older tests. If you are facing this case, you can either follow the migration guide proposed by FluentLenium
+(http://fluentlenium.org/migration/from-0.13.2-to-1.0-or-3.0/) ; or you can force your project to use
+the older version of FluentLenium by setting up that version in your project <code>pom.xml</code> dependencies.
+
+<pre class="prettyprint">
+<dependency>
+    <groupId>org.fluentlenium</groupId>
+    <artifactId>fluentlenium-core</artifactId>
+    <version>0.10.3</version>
+    <scope>test</scope>
+    <exclusions>
+        <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+</pre>

--- a/ninja-core/src/site/markdown/documentation/upgrade_guide.md
+++ b/ninja-core/src/site/markdown/documentation/upgrade_guide.md
@@ -6,6 +6,13 @@ into Ninja's behavior. This document describes which steps are needed to upgrade
 your application to the latest Ninja version. Simply start with your current 
 version and then work your way up to the top of the document.
 
+to 6.0.1
+--------
+
+### FluentLenium update causes backward incompatibility
+
+Refer to the FluentLenium migration guide http://fluentlenium.org/migration/from-0.13.2-to-1.0-or-3.0/ 
+or force usage of fluentlenium-core 0.10.3 in your project dependencies.
 
 to 6.0.0
 --------

--- a/ninja-servlet-integration-test/src/test/java/controllers/AuthenticityFormTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/AuthenticityFormTest.java
@@ -10,20 +10,20 @@ public class AuthenticityFormTest extends NinjaFluentLeniumTest {
     
     @Test
     public void testAuthenticitySuccess() {
-        goTo(getServerAddress() + "/authenticate");
+        goTo("/authenticate");
         assertTrue(pageSource().contains("Login"));
         
-        click("#login");
+        $("#login").click();
         
         assertTrue(pageSource().contains("only visible with valid authenticationToken"));
     }
     
     @Test
     public void testAuthenticityFails() {
-        goTo(getServerAddress() + "/notauthenticate");
+        goTo("/notauthenticate");
         assertTrue(pageSource().contains("Login"));
         
-        click("#login");
+        $("#login").click();
         
         assertTrue(!pageSource().contains("only visible with valid authenticationToken"));
     }

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/test/java/controllers/ApplicationControllerFluentLeniumTest.java
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/src/test/java/controllers/ApplicationControllerFluentLeniumTest.java
@@ -30,13 +30,13 @@ public class ApplicationControllerFluentLeniumTest extends NinjaFluentLeniumTest
     @Test
     public void testThatHomepageWorks() {
         
-        goTo(getServerAddress() + "/");
+        goTo("/");
         
-        System.out.println("title: " + title());
+        System.out.println("title: " + window().title());
         
-        assertTrue(title().contains("Home page"));
+        assertTrue(window().title().contains("Home page"));
         
-        click("${symbol_pound}login");
+        $("${symbol_pound}login").click();
         
         assertTrue(url().contains("login"));
 

--- a/ninja-servlet-jpa-blog-integration-test/src/test/java/controllers/ApplicationControllerFluentLeniumTest.java
+++ b/ninja-servlet-jpa-blog-integration-test/src/test/java/controllers/ApplicationControllerFluentLeniumTest.java
@@ -26,13 +26,13 @@ public class ApplicationControllerFluentLeniumTest extends NinjaFluentLeniumTest
     @Test
     public void testThatHomepageWorks() {
         
-        goTo(getServerAddress() + "/");
+        goTo("/");
         
-        System.out.println("title: " + title());
+        System.out.println("title: " + window().title());
         
-        assertTrue(title().contains("Home page"));
+        assertTrue(window().title().contains("Home page"));
         
-        click("#login");
+        $("#login").click();
         
         assertTrue(url().contains("login"));
 

--- a/ninja-test-utilities/pom.xml
+++ b/ninja-test-utilities/pom.xml
@@ -70,7 +70,12 @@
         <!-- A very nice abstraction for making selenum tests: -->
         <dependency>
             <groupId>org.fluentlenium</groupId>
-            <artifactId>fluentlenium-core</artifactId>
+            <artifactId>fluentlenium-junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>htmlunit-driver</artifactId>
             <scope>compile</scope>
         </dependency>
         

--- a/ninja-test-utilities/src/main/java/ninja/NinjaFluentLeniumTest.java
+++ b/ninja-test-utilities/src/main/java/ninja/NinjaFluentLeniumTest.java
@@ -16,15 +16,15 @@
 
 package ninja;
 
-import ninja.utils.NinjaTestServer;
-
-import org.fluentlenium.adapter.FluentTest;
+import org.fluentlenium.adapter.junit.FluentTest;
 import org.junit.After;
 import org.junit.Before;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import com.google.inject.Injector;
+
+import ninja.utils.NinjaTestServer;
 
 public abstract class NinjaFluentLeniumTest extends FluentTest {
 
@@ -37,16 +37,47 @@ public abstract class NinjaFluentLeniumTest extends FluentTest {
         ninjaTestServer = new NinjaTestServer();
     }
 	
-	
-    @Override
+	  /**
+	   * @deprecated Updating to FluentLenium 3.2.0, the driver to use is now either a string,
+	   * returned by overriding the {@link #getWebDriver()} method, or the driver implementation,
+	   * by overriding the {@link #newWebDriver()} method.
+	   * @see #getWebDriver()
+	   * @see #newWebDriver()
+	   */
+	  @Deprecated
     public WebDriver getDefaultDriver() {
         return webDriver;
     }
     
+    /**
+     * @see org.fluentlenium.adapter.FluentAdapter#newWebDriver()
+     */
+    @Override
+    public WebDriver newWebDriver() {
+        return getDefaultDriver();
+    }
+    
+    /**
+     * @see #getBaseUrl()
+     */
+    @Deprecated
     public String getServerAddress() {
     	return ninjaTestServer.getServerAddress();
     }
 
+    /**
+     * Will be automatically used within the goTo() method.
+     * @see org.fluentlenium.adapter.FluentAdapter#getBaseUrl()
+     */
+    @Override
+    public String getBaseUrl() {
+        return ninjaTestServer.getBaseUrl();
+    }
+    
+    public String getServerUrl() {
+        return ninjaTestServer.getServerUrl();
+    }
+    
     @After
     public void shutdownServer() {
         ninjaTestServer.shutdown();

--- a/pom.xml
+++ b/pom.xml
@@ -770,14 +770,19 @@
             <!-- A very nice abstraction for making selenum tests: -->
             <dependency>
                 <groupId>org.fluentlenium</groupId>
-                <artifactId>fluentlenium-core</artifactId>
-                <version>0.10.3</version>
+                <artifactId>fluentlenium-junit</artifactId>
+                <version>3.2.0</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>
                         <groupId>commons-logging</groupId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>htmlunit-driver</artifactId>
+                <version>2.25</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -737,7 +737,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.4</version>
+                <version>4.5.2</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>
@@ -782,7 +782,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>htmlunit-driver</artifactId>
-                <version>2.25</version>
+                <version>2.26</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -783,6 +783,12 @@
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>htmlunit-driver</artifactId>
                 <version>2.25</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Hi.

I would have done this prior to 6.0.0 release but I had not time for it. Actual version of Ninja is not up to date with the current FluentLenium version. Sadly... It was not possible to handle a backward compatibility ; it would have been too much work (like creating old Fluent proxy classes and rewrite a lot of methods locally to the Ninja test class).

But it seems possible to keep old tests running by getting back the old version of FluentLenium in a project (I tested it). Or, as I mention it too in the documentation, FluentLenium have written a migration guide : http://fluentlenium.org/migration/from-0.13.2-to-1.0-or-3.0/

Jonathan