### PR TITLE
System properties (as well as prefixed system properties) can override config keys

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaPropertiesImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2017 the original author or authors.
+ * Copyright (C) 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Binder;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import org.apache.commons.configuration.SystemConfiguration;
 
 @Singleton
 public class NinjaPropertiesImpl implements NinjaProperties {
@@ -83,6 +84,12 @@ public class NinjaPropertiesImpl implements NinjaProperties {
         // (Optional) Config of prefixed mode corresponding to current mode (eg.
         // %test.myproperty=...)
         Configuration prefixedExternalConfiguration = null;
+        
+        // (Optional) Config of keys via system property
+        Configuration systemPropertiesConfiguration = null;
+        
+        // (Optional) Config of prefixed keys via system property
+        Configuration prefixedSystemPropertiesConfiguration = null;
 
         // First step => load application.conf and also merge properties that
         // correspond to a mode into the configuration.
@@ -162,13 +169,29 @@ public class NinjaPropertiesImpl implements NinjaProperties {
             }
 
         }
+        
+        // fourth step: system properties ultimate override of any key
+        systemPropertiesConfiguration = new SystemConfiguration();
+        
+        prefixedSystemPropertiesConfiguration = systemPropertiesConfiguration
+            .subset("%" + ninjaMode.name());
 
         // /////////////////////////////////////////////////////////////////////
         // Finally add the stuff to the composite configuration
         // Note: Configurations added earlier will overwrite configurations
         // added later.
         // /////////////////////////////////////////////////////////////////////
-
+        
+        if (prefixedSystemPropertiesConfiguration != null) {
+            compositeConfiguration
+                    .addConfiguration(prefixedSystemPropertiesConfiguration);
+        }
+        
+        if (systemPropertiesConfiguration != null) {
+            compositeConfiguration
+                    .addConfiguration(systemPropertiesConfiguration);
+        }
+        
         if (prefixedExternalConfiguration != null) {
             compositeConfiguration
                     .addConfiguration(prefixedExternalConfiguration);

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version 6.1.x
+=============
+
+ * 2017-08-22 System properties (as well as prefixed system properties) can override any configuration keys (jjlauer)
+
 Version 6.1.0
 =============
  * 2017-04-30 Handling empty string param parsing (jlannoy)

--- a/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
+++ b/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
@@ -242,6 +242,26 @@ It tries to load in the following order:
 Ninja uses the excellent Apache Configurations library to do the loading. Please refer to
 [their manual](http://commons.apache.org/configuration/userguide/howto_filebased.html#Loading) for more information.
 
+
+System properties to override
+-------------------------------------
+
+As of Ninja v6.1.1, system properties can override any configuration key set
+with your standard conf/application.conf or external configuration file. For
+example, if you have a key `db.connection.password` set to `mypass` in `conf/production.conf`,
+then you can override it via a system property to `otherpass` at runtime like so:
+
+<pre class="prettyprint">
+java -Dninja.external.configuration=conf/production.conf -Ddb.connection.password=otherpass
+</pre>
+
+Prefixed system properties are honored as well.  Using the previous example, if you only
+wanted the property to take effect while in `test` mode you can do this:
+
+<pre class="prettyprint">
+java -Dninja.external.configuration=conf/production.conf -D%test.db.connection.password=otherpass
+</pre>
+
 Hot-reloading external configuration
 ------------------------------------
 
@@ -253,13 +273,13 @@ useful to hot-reload this config instead of restarting your application.
 This tells Ninja to reload your configuration if it is modified during runtime.
 
 
-Referencing system properties in configuration files
-----------------------------------------------------
+Referencing environment variables in configuration files
+--------------------------------------------------------
 
 You can reference system properties inside your configuration files by
 using the default apache commons configuration syntax:
 
-    %prod.db.connection.password=${env:db.connection.password}
+    %prod.db.connection.password=${env:DB_PASSWORD}
 
 That's especially handy when it comes to production credentials 
 that should not be known inside your application code.

--- a/ninja-core/src/test/java/ninja/utils/NinjaPropertiesImplTest.java
+++ b/ninja-core/src/test/java/ninja/utils/NinjaPropertiesImplTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class NinjaPropertiesImplTest {
 
@@ -339,6 +341,33 @@ public class NinjaPropertiesImplTest {
                 ninjaProperties
                         .getStringArray("getMultipleElementStringArrayWithoutSpaces")[1]);
 
+    }
+    
+    @Test
+    public void systemProperties() {
+        // verify property in external conf is set
+        NinjaProperties ninjaProperties = new NinjaPropertiesImpl(NinjaMode.dev, "conf/system_property.conf");
+        
+        assertThat(ninjaProperties.get("unit.test.123"), is("123-value-via-external-conf"));
+        
+        // verify system property overrides it
+        System.setProperty("unit.test.123", "123-value-via-system-property");
+        try {
+            ninjaProperties = new NinjaPropertiesImpl(NinjaMode.dev, "conf/system_property.conf");
+            assertThat(ninjaProperties.get("unit.test.123"), is("123-value-via-system-property"));
+        } finally {
+            System.clearProperty("unit.test.123");
+        }
+        
+        // verify prefixed system property overrides both
+        System.setProperty("unit.test.123", "123-value-via-system-property");
+        System.setProperty("%dev.unit.test.123", "123-value-via-prefixed-system-property");
+        try {
+            ninjaProperties = new NinjaPropertiesImpl(NinjaMode.dev, "conf/system_property.conf");
+            assertThat(ninjaProperties.get("unit.test.123"), is("123-value-via-prefixed-system-property"));
+        } finally {
+            System.clearProperty("unit.test.123");
+        }
     }
 
 }

--- a/ninja-core/src/test/resources/conf/system_property.conf
+++ b/ninja-core/src/test/resources/conf/system_property.conf
@@ -1,0 +1,2 @@
+# for testing system properties override config
+unit.test.123 = 123-value-via-external-conf


### PR DESCRIPTION
While some properties (e.g. ninja.mode or ninja.port) have always allowed system properties to be the ultimate override a value set in configuration files, others have not.  I was trying to override a value the other day on the command-line and realized it wasn't supported in ninja.  Many other web frameworks support this concept and I think it'd be a useful addition to ninja.