### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
+before_install:
+  - unset _JAVA_OPTIONS
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Travis CI started setting the _JAVA_OPTIONS env var in their recent images.  Unfortunately, this prints out something to STDOUT when any java process is spun up and that breaks our maven plugin unit tests.  This unsets the variable to get rid of it.