### PR TITLE
added option to use custom graphite prefix

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.2.0
 =============
 
+ * 2017-12-12 Added `metrics.graphite.prefix` property for custom graphite prefix (christiangroth)
  * 2017-08-30 WebSockets support across Jetty standalone and any JSR-356
               compatible servlet container such as Jetty 9.3.15+, Tomcat 7+,
               Wildfly, WebLogic, Undertow, etc. (jjlauer)

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/metrics.md
@@ -143,6 +143,10 @@ Add the following settings to your `application.conf`.
     metrics.graphite.pickled = false
     metrics.graphite.period = 60s
 
+By default all metrics will be prefixed with the hostname. To specify a custom prefix add the following setting.
+
+    metrics.graphite.prefix = my.custom.prefix
+    
 ### Reporting Metrics to Ganglia
 
 Ninja Metrics supports reporting to [Ganglia](http://ganglia.info).

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -76,6 +76,7 @@ contributed to Ninja. In some random order:
  * Mark Watson (watsonmw)
  * Nate Kingsley (nate-kingsley)
  * Jens Fendler (jfendler)
+ * Christian Groth (christiangroth)
  
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
+++ b/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
@@ -1,74 +1,88 @@
 /**
- * Copyright (C) 2012-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed
- * to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing permissions and limitations under the License.
+ * Copyright (C) 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package ninja.build;
 
-import static ninja.maven.NinjaMavenPluginConstants.DEFAULT_EXCLUDE_PATTERNS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 
 import java.io.File;
+
+import org.junit.Test;
+
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.junit.Test;
+import static ninja.maven.NinjaMavenPluginConstants.DEFAULT_EXCLUDE_PATTERNS;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WatchAndRestartMachineTest {
-
+    
     @Test
     public void run() throws Exception {
-
+        
         File watchDir = new File("target/fake-watch-dir");
         watchDir.mkdirs();
-
+        
         File assetsDir = new File(watchDir, "assets");
         assetsDir.mkdirs();
-
+        
         // make sure file does not yet exist
         File newTxtFile = new File(watchDir, "test.txt");
         newTxtFile.delete();
-
+        
         // file that would be excluded in assets directory, but we'll include a rule to include it
         File newIncludedTxtFile = new File(assetsDir, "included.txt");
         newIncludedTxtFile.delete();
-
+        
         // make sure file does not yet exist
         File newPngFile = new File(assetsDir, "test.png");
         newPngFile.delete();
-
+        
         DelayedRestartTrigger restartTrigger = mock(DelayedRestartTrigger.class);
-
-        final WatchAndRestartMachine watcher = new WatchAndRestartMachine(watchDir.toPath(), new HashSet<>(Arrays.asList("(.*)included.txt")),
-                new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS)), restartTrigger);
-
+        
+        final WatchAndRestartMachine watcher = new WatchAndRestartMachine(
+            watchDir.toPath(),
+            new HashSet<>(Arrays.asList("(.*)included.txt")),
+            new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS)),
+            restartTrigger
+        );
+        
         Thread watcherThread = new Thread(watcher);
         watcherThread.start();
-
-        try {
+        
+        try {  
             // add a new file
             OutputStream os = new FileOutputStream(newTxtFile);
             os.close();
 
             // trigger should have been called soon
             verify(restartTrigger, timeout(10000)).trigger();
-
+            
             Mockito.reset(restartTrigger);
-
+            
             // modify the file
             os = new FileOutputStream(newTxtFile);
             os.write("Hello!".getBytes());
@@ -79,24 +93,24 @@ public class WatchAndRestartMachineTest {
             verify(restartTrigger, atMost(2)).trigger();
 
             Mockito.reset(restartTrigger);
-
+            
             // use an excluded file and verify restart not called
-
+            
             // add a new file
             os = new FileOutputStream(newPngFile);
             os.close();
 
             // indicates exclusion rule for new files didn't work
-            verify(restartTrigger, Mockito.after(10000).never()).trigger();
-
+            verify(restartTrigger, timeout(10000).never()).trigger();
+            
             // modify the file
             os = new FileOutputStream(newPngFile);
             os.write("Hello!".getBytes());
             os.close();
 
             // indicates exclusion rule for modified files didn't work
-            verify(restartTrigger, Mockito.after(10000).never()).trigger();
-
+            verify(restartTrigger, timeout(10000).never()).trigger();
+            
             // add a new file
             os = new FileOutputStream(newIncludedTxtFile);
             os.close();
@@ -105,50 +119,103 @@ public class WatchAndRestartMachineTest {
             // windows may do 2 mods so we need to check range
             verify(restartTrigger, timeout(10000).atLeast(1)).trigger();
             verify(restartTrigger, atMost(2)).trigger();
-
+            
         } finally {
             watcher.shutdown();
             watcherThread.interrupt();
         }
     }
-
+    
+    
     /**
      * Test of checkIfMatchesPattern method, of class WatchAndRestartMachine.
      */
     @Test
     public void testCheckIfMatchesPatternAndAssetsAreIgnored() {
-
-        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-
-        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
-                "target" + File.separator + "classes" + File.separator + "assets" + File.separator + "js" + File.separator + "script.js"), is(true));
-
-        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns, File.separator + "assets" + File.separator), is(true));
-
+        
+        Set<String> patterns 
+                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+        
+        assertThat(
+                WatchAndRestartMachine.checkIfWouldBeExcluded(
+                        patterns, 
+                        "target" 
+                        + File.separator 
+                        + "classes" 
+                        + File.separator 
+                        + "assets" 
+                        + File.separator 
+                        + "js" 
+                        + File.separator 
+                        + "script.js"),
+                is(true));
+        
+        assertThat(
+                WatchAndRestartMachine.checkIfWouldBeExcluded(
+                        patterns, 
+                        File.separator 
+                        + "assets" 
+                        + File.separator),
+                is(true));
+        
     }
-
+    
+    
     @Test
     public void testCheckIfMatchesPatternMachtesOfOtherStuff() {
+        
+        Set<String> patterns 
+                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+        
+        assertThat(
+                WatchAndRestartMachine.checkIfWouldBeExcluded(
+                        patterns, 
+                        "target" 
+                        + File.separator 
+                        + "classes" 
+                        + File.separator 
+                        + "completelyDifferentPath"),
+                is(false));
 
-        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-
-        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns, "target" + File.separator + "classes" + File.separator + "completelyDifferentPath"), is(false));
-
+        
     }
-
+    
+    
     @Test
     public void testCheckIfMatchesPatternAndFtlHtmlFilesAreIgnored() {
 
-        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-
-        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
-                "target" + File.separator + "classes" + File.separator + "views" + File.separator + "ApplicationController" + File.separator + "index.ftl.html"), is(true));
-
+        Set<String> patterns 
+                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+        
         assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
-                        "target" + File.separator + "classes" + File.separator + "views" + File.separator + "ApplicationController" + File.separator + "index.ftl.html.bam"),
+                WatchAndRestartMachine.checkIfWouldBeExcluded(
+                        patterns, 
+                        "target" 
+                        + File.separator 
+                        + "classes" 
+                        + File.separator 
+                        + "views" 
+                        + File.separator 
+                        + "ApplicationController" 
+                        + File.separator 
+                        + "index.ftl.html"),
+                is(true));
+        
+        assertThat(
+                WatchAndRestartMachine.checkIfWouldBeExcluded(
+                        patterns, 
+                        "target" 
+                        + File.separator 
+                        + "classes" 
+                        + File.separator 
+                        + "views" 
+                        + File.separator 
+                        + "ApplicationController" 
+                        + File.separator 
+                        + "index.ftl.html.bam"),
                 is(false));
-
+ 
+        
     }
-
+    
 }

--- a/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
+++ b/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
@@ -1,88 +1,74 @@
 /**
- * Copyright (C) 2012-2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2012-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
 package ninja.build;
 
+import static ninja.maven.NinjaMavenPluginConstants.DEFAULT_EXCLUDE_PATTERNS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
-
-import org.junit.Test;
-
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import static ninja.maven.NinjaMavenPluginConstants.DEFAULT_EXCLUDE_PATTERNS;
+
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WatchAndRestartMachineTest {
-    
+
     @Test
     public void run() throws Exception {
-        
+
         File watchDir = new File("target/fake-watch-dir");
         watchDir.mkdirs();
-        
+
         File assetsDir = new File(watchDir, "assets");
         assetsDir.mkdirs();
-        
+
         // make sure file does not yet exist
         File newTxtFile = new File(watchDir, "test.txt");
         newTxtFile.delete();
-        
+
         // file that would be excluded in assets directory, but we'll include a rule to include it
         File newIncludedTxtFile = new File(assetsDir, "included.txt");
         newIncludedTxtFile.delete();
-        
+
         // make sure file does not yet exist
         File newPngFile = new File(assetsDir, "test.png");
         newPngFile.delete();
-        
+
         DelayedRestartTrigger restartTrigger = mock(DelayedRestartTrigger.class);
-        
-        final WatchAndRestartMachine watcher = new WatchAndRestartMachine(
-            watchDir.toPath(),
-            new HashSet<>(Arrays.asList("(.*)included.txt")),
-            new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS)),
-            restartTrigger
-        );
-        
+
+        final WatchAndRestartMachine watcher = new WatchAndRestartMachine(watchDir.toPath(), new HashSet<>(Arrays.asList("(.*)included.txt")),
+                new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS)), restartTrigger);
+
         Thread watcherThread = new Thread(watcher);
         watcherThread.start();
-        
-        try {  
+
+        try {
             // add a new file
             OutputStream os = new FileOutputStream(newTxtFile);
             os.close();
 
             // trigger should have been called soon
             verify(restartTrigger, timeout(10000)).trigger();
-            
+
             Mockito.reset(restartTrigger);
-            
+
             // modify the file
             os = new FileOutputStream(newTxtFile);
             os.write("Hello!".getBytes());
@@ -93,24 +79,24 @@ public class WatchAndRestartMachineTest {
             verify(restartTrigger, atMost(2)).trigger();
 
             Mockito.reset(restartTrigger);
-            
+
             // use an excluded file and verify restart not called
-            
+
             // add a new file
             os = new FileOutputStream(newPngFile);
             os.close();
 
             // indicates exclusion rule for new files didn't work
-            verify(restartTrigger, timeout(10000).never()).trigger();
-            
+            verify(restartTrigger, Mockito.after(10000).never()).trigger();
+
             // modify the file
             os = new FileOutputStream(newPngFile);
             os.write("Hello!".getBytes());
             os.close();
 
             // indicates exclusion rule for modified files didn't work
-            verify(restartTrigger, timeout(10000).never()).trigger();
-            
+            verify(restartTrigger, Mockito.after(10000).never()).trigger();
+
             // add a new file
             os = new FileOutputStream(newIncludedTxtFile);
             os.close();
@@ -119,103 +105,50 @@ public class WatchAndRestartMachineTest {
             // windows may do 2 mods so we need to check range
             verify(restartTrigger, timeout(10000).atLeast(1)).trigger();
             verify(restartTrigger, atMost(2)).trigger();
-            
+
         } finally {
             watcher.shutdown();
             watcherThread.interrupt();
         }
     }
-    
-    
+
     /**
      * Test of checkIfMatchesPattern method, of class WatchAndRestartMachine.
      */
     @Test
     public void testCheckIfMatchesPatternAndAssetsAreIgnored() {
-        
-        Set<String> patterns 
-                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-        
-        assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(
-                        patterns, 
-                        "target" 
-                        + File.separator 
-                        + "classes" 
-                        + File.separator 
-                        + "assets" 
-                        + File.separator 
-                        + "js" 
-                        + File.separator 
-                        + "script.js"),
-                is(true));
-        
-        assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(
-                        patterns, 
-                        File.separator 
-                        + "assets" 
-                        + File.separator),
-                is(true));
-        
+
+        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+
+        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
+                "target" + File.separator + "classes" + File.separator + "assets" + File.separator + "js" + File.separator + "script.js"), is(true));
+
+        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns, File.separator + "assets" + File.separator), is(true));
+
     }
-    
-    
+
     @Test
     public void testCheckIfMatchesPatternMachtesOfOtherStuff() {
-        
-        Set<String> patterns 
-                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-        
-        assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(
-                        patterns, 
-                        "target" 
-                        + File.separator 
-                        + "classes" 
-                        + File.separator 
-                        + "completelyDifferentPath"),
-                is(false));
 
-        
+        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+
+        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns, "target" + File.separator + "classes" + File.separator + "completelyDifferentPath"), is(false));
+
     }
-    
-    
+
     @Test
     public void testCheckIfMatchesPatternAndFtlHtmlFilesAreIgnored() {
 
-        Set<String> patterns 
-                = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
-        
+        Set<String> patterns = new HashSet<>(Arrays.asList(DEFAULT_EXCLUDE_PATTERNS));
+
+        assertThat(WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
+                "target" + File.separator + "classes" + File.separator + "views" + File.separator + "ApplicationController" + File.separator + "index.ftl.html"), is(true));
+
         assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(
-                        patterns, 
-                        "target" 
-                        + File.separator 
-                        + "classes" 
-                        + File.separator 
-                        + "views" 
-                        + File.separator 
-                        + "ApplicationController" 
-                        + File.separator 
-                        + "index.ftl.html"),
-                is(true));
-        
-        assertThat(
-                WatchAndRestartMachine.checkIfWouldBeExcluded(
-                        patterns, 
-                        "target" 
-                        + File.separator 
-                        + "classes" 
-                        + File.separator 
-                        + "views" 
-                        + File.separator 
-                        + "ApplicationController" 
-                        + File.separator 
-                        + "index.ftl.html.bam"),
+                WatchAndRestartMachine.checkIfWouldBeExcluded(patterns,
+                        "target" + File.separator + "classes" + File.separator + "views" + File.separator + "ApplicationController" + File.separator + "index.ftl.html.bam"),
                 is(false));
- 
-        
+
     }
-    
+
 }

--- a/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
+++ b/ninja-maven-plugin/src/test/java/ninja/build/WatchAndRestartMachineTest.java
@@ -101,7 +101,7 @@ public class WatchAndRestartMachineTest {
             os.close();
 
             // indicates exclusion rule for new files didn't work
-            verify(restartTrigger, timeout(10000).never()).trigger();
+            verify(restartTrigger, Mockito.after(10000).never()).trigger();
             
             // modify the file
             os = new FileOutputStream(newPngFile);
@@ -109,7 +109,7 @@ public class WatchAndRestartMachineTest {
             os.close();
 
             // indicates exclusion rule for modified files didn't work
-            verify(restartTrigger, timeout(10000).never()).trigger();
+            verify(restartTrigger, Mockito.after(10000).never()).trigger();
             
             // add a new file
             os = new FileOutputStream(newIncludedTxtFile);

--- a/ninja-metrics-graphite/pom.xml
+++ b/ninja-metrics-graphite/pom.xml
@@ -69,13 +69,13 @@
 			<artifactId>mockito-core</artifactId>
 		</dependency>
 		<dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/ninja-metrics-graphite/pom.xml
+++ b/ninja-metrics-graphite/pom.xml
@@ -68,6 +68,14 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>
+		<dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
+++ b/ninja-metrics-graphite/src/main/java/ninja/metrics/graphite/NinjaGraphite.java
@@ -25,6 +25,7 @@ import ninja.metrics.MetricsService;
 import ninja.utils.NinjaProperties;
 import ninja.utils.TimeUtil;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,10 @@ public class NinjaGraphite {
         if (ninjaProperties.getBooleanWithDefault("metrics.graphite.enabled",
                 false)) {
 
+            final String customPrefix = ninjaProperties.get("metrics.graphite.prefix");
             final String hostname = metricsService.getHostname();
+            final String prefix = StringUtils.isNotBlank(customPrefix) ? customPrefix : hostname;
+
             final String address = ninjaProperties
                     .getOrDie("metrics.graphite.address");
             final int port = ninjaProperties.getIntegerWithDefault(
@@ -87,7 +91,7 @@ public class NinjaGraphite {
 
             reporter = GraphiteReporter
                     .forRegistry(metricsService.getMetricRegistry())
-                    .prefixedWith(hostname).convertRatesTo(TimeUnit.SECONDS)
+                    .prefixedWith(prefix).convertRatesTo(TimeUnit.SECONDS)
                     .convertDurationsTo(TimeUnit.MILLISECONDS)
                     .filter(MetricFilter.ALL).build(sender);
 
@@ -95,7 +99,7 @@ public class NinjaGraphite {
 
             log.info(
                     "Started Graphite Metrics reporter for '{}', updating every {}",
-                    hostname, period);
+                    prefix, period);
 
         }
     }

--- a/ninja-metrics-graphite/src/test/java/ninja/metrics/graphite/NinjaGraphiteTest.java
+++ b/ninja-metrics-graphite/src/test/java/ninja/metrics/graphite/NinjaGraphiteTest.java
@@ -62,28 +62,23 @@ public class NinjaGraphiteTest {
 
     @Test
     public void testWithoutCustomPrefix() {
-        mockPrefix(null);
+        Mockito.when(ninjaProperties.get(Mockito.eq("metrics.graphite.prefix"))).thenReturn(null);
         ninjaGraphite.start();
         Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_HOSTNAME);
     }
 
     @Test
     public void testWithEmptyCustomPrefix() {
-        mockPrefix("");
+        Mockito.when(ninjaProperties.get(Mockito.eq("metrics.graphite.prefix"))).thenReturn("");
         ninjaGraphite.start();
         Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_HOSTNAME);
     }
 
     @Test
-
     public void testWithCustomPrefix() {
-        mockPrefix(TEST_PREFIX);
+        Mockito.when(ninjaProperties.get(Mockito.eq("metrics.graphite.prefix"))).thenReturn(TEST_PREFIX);
         ninjaGraphite.start();
         Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_PREFIX);
-    }
-
-    private void mockPrefix(String prefix) {
-        Mockito.when(ninjaProperties.get(Mockito.eq("metrics.graphite.prefix"))).thenReturn(prefix);
     }
 
     @After

--- a/ninja-metrics-graphite/src/test/java/ninja/metrics/graphite/NinjaGraphiteTest.java
+++ b/ninja-metrics-graphite/src/test/java/ninja/metrics/graphite/NinjaGraphiteTest.java
@@ -1,0 +1,93 @@
+package ninja.metrics.graphite;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.graphite.GraphiteReporter.Builder;
+import com.codahale.metrics.graphite.GraphiteSender;
+
+import ninja.metrics.MetricsService;
+import ninja.utils.NinjaPropertiesImpl;
+
+@PrepareForTest(GraphiteReporter.class)
+@RunWith(PowerMockRunner.class)
+public class NinjaGraphiteTest {
+
+    private static final String TEST_HOSTNAME = "test.hostname";
+    private static final String TEST_PREFIX = "my.prefix";
+
+    @Mock
+    private NinjaPropertiesImpl ninjaProperties;
+
+    @Mock
+    private MetricsService metricsService;
+
+    @Mock
+    private Builder builder;
+
+    private NinjaGraphite ninjaGraphite;
+
+    @Before
+    public void setup() {
+
+        // configure mocks
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(metricsService.getHostname()).thenReturn(TEST_HOSTNAME);
+        Mockito.when(ninjaProperties.getBooleanWithDefault(Mockito.eq("metrics.graphite.enabled"), Mockito.anyBoolean())).thenReturn(Boolean.TRUE);
+        Mockito.when(ninjaProperties.getOrDie(Mockito.eq("metrics.graphite.address"))).thenReturn("localhost");
+        Mockito.when(ninjaProperties.getIntegerWithDefault(Mockito.eq("metrics.graphite.port"), Mockito.anyInt())).thenReturn(2003);
+        Mockito.when(ninjaProperties.getBooleanWithDefault(Mockito.eq("metrics.graphite.pickled"), Mockito.anyBoolean())).thenReturn(Boolean.FALSE);
+        Mockito.when(ninjaProperties.getWithDefault(Mockito.eq("metrics.graphite.period"), Mockito.anyString())).thenReturn("60s");
+
+        PowerMockito.mockStatic(GraphiteReporter.class);
+        PowerMockito.when(GraphiteReporter.forRegistry(Mockito.any())).thenReturn(builder);
+        Mockito.when(builder.prefixedWith(Mockito.anyString())).thenCallRealMethod();
+        Mockito.when(builder.convertRatesTo(Mockito.any())).thenCallRealMethod();
+        Mockito.when(builder.convertDurationsTo(Mockito.any())).thenCallRealMethod();
+        Mockito.when(builder.filter(Mockito.any())).thenCallRealMethod();
+        Mockito.when(builder.build(Mockito.any(GraphiteSender.class))).thenCallRealMethod();
+
+        // create instance under test
+        ninjaGraphite = new NinjaGraphite(ninjaProperties, metricsService);
+    }
+
+    @Test
+    public void testWithoutCustomPrefix() {
+        mockPrefix(null);
+        ninjaGraphite.start();
+        Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_HOSTNAME);
+    }
+
+    @Test
+    public void testWithEmptyCustomPrefix() {
+        mockPrefix("");
+        ninjaGraphite.start();
+        Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_HOSTNAME);
+    }
+
+    @Test
+
+    public void testWithCustomPrefix() {
+        mockPrefix(TEST_PREFIX);
+        ninjaGraphite.start();
+        Mockito.verify(builder, Mockito.times(1)).prefixedWith(TEST_PREFIX);
+    }
+
+    private void mockPrefix(String prefix) {
+        Mockito.when(ninjaProperties.get(Mockito.eq("metrics.graphite.prefix"))).thenReturn(prefix);
+    }
+
+    @After
+    public void teardown() {
+        ninjaGraphite.stop();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <guice.version>4.1.0</guice.version>
         <metrics.version>3.1.1</metrics.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <powermock.version>1.5.6</powermock.version>
+        <powermock.version>1.6.5</powermock.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
@@ -830,14 +830,14 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
                         
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
+                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
             

--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
                         

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <guice.version>4.1.0</guice.version>
         <metrics.version>3.1.1</metrics.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <powermock.version>1.6.5</powermock.version>
+        <powermock.version>1.5.6</powermock.version>
         <!-- Formatting options for Netbeans IDE -->
         <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
@@ -830,14 +830,14 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
                         
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>1.9.5</version>
                 <scope>test</scope>
             </dependency>
             


### PR DESCRIPTION
It would be great to be able to configure a custom prefix for graphite metrics. I'm running more than one ninja app on the same host and thus need to keep graphite metrics separated. This pull request is a simple solution to prefix each application and does not change anything if no configuration is made at all, using the hostname as fallback as it was before.