### PR TITLE
Fix issue where servlet container without websocket support crashes.

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,9 +1,13 @@
+Version 6.2.2
+=============
+
+ * 2018-01-08 Fix issue where servlet container without websocket support crashes. (ra)
+
 Version 6.2.1
 =============
 
  * 2017-12-13 Fixed duplicate count for timed metrics (christiangroth)
  * 2017-12-12 Added `metrics.graphite.prefix` property for custom graphite prefix (christiangroth)
-
 
 Version 6.2.0
 =============

--- a/ninja-servlet/pom.xml
+++ b/ninja-servlet/pom.xml
@@ -67,6 +67,16 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
 
     </dependencies>
     

--- a/ninja-servlet/src/test/java/ninja/servlet/NinjaServletListenerPowerMockTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/NinjaServletListenerPowerMockTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2012- the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.servlet;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import ninja.websockets.jsr356.Jsr356WebSockets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import javax.websocket.server.ServerContainer;
+import static org.junit.Assert.*;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PrepareForTest(Class.class)
+@RunWith(PowerMockRunner.class)
+public class NinjaServletListenerPowerMockTest {
+
+    @Mock
+    ServletContextEvent servletContextEvent;
+
+    @Mock
+    ServletContext servletContext;
+
+    String CONTEXT_PATH = "/contextpath";
+
+    @Before
+    public void before() {
+        Mockito.when(servletContextEvent.getServletContext()).thenReturn(servletContext);
+        Mockito.when(servletContext.getContextPath()).thenReturn(CONTEXT_PATH);
+    }
+
+    @Test
+    public void makeSureContextInitializedWorksWhenJettyThrowsException() throws Exception {
+        // GIVEN 
+        // we simulate an environment that does not have any websocket classes
+        // on the classpath.
+        PowerMockito.mockStatic(Class.class);
+        PowerMockito
+                .when(Class.forName(Mockito.eq("javax.websocket.server.ServerContainer"), Mockito.eq(false), Mockito.any()))
+                .thenThrow(new ClassNotFoundException("Exception triggered by test"));
+        
+        // WHEN
+        NinjaServletListener ninjaServletListener = new NinjaServletListener();
+        ninjaServletListener.contextInitialized(servletContextEvent);
+       
+        // THEN
+        // we expect that no websocket class has been configured in guice
+        Injector injector = ninjaServletListener.getInjector();
+        
+        assertFalse(classAvailableFromInjector(ServerContainer.class, injector));
+        assertFalse(classAvailableFromInjector(Jsr356WebSockets.class, injector));
+    }
+    
+    private boolean classAvailableFromInjector(Class<?> clazz, Injector injector) { 
+        try {
+            injector.getInstance(clazz);
+            return true;
+        } catch (ConfigurationException c) {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
App Engine's Jetty for instance crashed when we do not first check
via Class.forName(...) whether websocket classes exist on the classpath.