### PR TITLE
Support for running a Ninja console (server-free) application

### DIFF
--- a/ninja-core/src/main/java/ninja/standalone/AbstractConsole.java
+++ b/ninja-core/src/main/java/ninja/standalone/AbstractConsole.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.standalone;
+
+import com.google.inject.CreationException;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaModeHelper;
+import ninja.utils.NinjaPropertiesImpl;
+import ninja.utils.OverlayedNinjaProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract Console that implements most functionality required to write
+ * a concrete Console.  See NinjaConsole for example concrete implementation.
+ * @param <T> The concrete console implementation
+ */
+public abstract class AbstractConsole<T extends AbstractConsole> implements Console<T> {
+    // allow logger to take on persona of concrete class
+    final protected Logger logger = LoggerFactory.getLogger(this.getClass());
+    
+    // can all be changed prior to configure()
+    protected NinjaMode ninjaMode;
+    protected String externalConfigurationPath;
+    protected String name;
+    // internal state
+    protected boolean configured;
+    protected boolean started;
+    protected NinjaPropertiesImpl ninjaProperties; // after configure()
+    protected OverlayedNinjaProperties overlayedNinjaProperties; // after configure()
+
+    public AbstractConsole(String name) {
+        // set mode as quickly as possible (can still be changed before configure())
+        this.ninjaMode = NinjaModeHelper.determineModeFromSystemPropertiesOrProdIfNotSet();
+        this.name = name;
+        this.configured = false;
+        this.started = false;
+    }
+
+    @Override
+    public final T configure() throws Exception {
+        checkNotConfigured();
+        
+        // create ninja properties & overlayed view
+        this.ninjaProperties = new NinjaPropertiesImpl(this.ninjaMode, this.externalConfigurationPath);
+        this.overlayedNinjaProperties = new OverlayedNinjaProperties(this.ninjaProperties);
+        
+        this.doPreConfigure();
+        this.doConfigure();
+        
+        this.configured = true;
+        
+        this.doPostConfigure();
+        
+        return (T) this;
+    }
+    
+    @Override
+    public final T start() throws Exception {
+        if (!this.configured) {
+            this.configure();
+        }
+        
+        this.doStart();
+        
+        this.started = true;
+        
+        this.logStarted();
+        
+        return (T) this;
+    }
+
+    @Override
+    public final T shutdown() {
+        this.doShutdown();
+        return (T) this;
+    }
+
+    protected void doPreConfigure() throws Exception {
+        
+    }
+    
+    protected void doPostConfigure() throws Exception {
+        
+    }
+    
+    protected abstract void doConfigure() throws Exception;
+
+    protected abstract void doStart() throws Exception;
+
+    protected abstract void doShutdown();
+
+    protected void logStarted() {
+        logger.info("-------------------------------------------------------");
+        logger.info("Ninja console application running...");
+        logger.info("-------------------------------------------------------");
+    }
+    
+    protected void checkNotConfigured() {
+        if (this.configured) {
+            throw new IllegalStateException(this.getClass().getCanonicalName() + ".configure() already called");
+        }
+    }
+
+    protected void checkConfigured() {
+        if (!this.configured) {
+            throw new IllegalStateException(this.getClass().getCanonicalName() + ".configure() not called yet");
+        }
+    }
+
+    protected void checkStarted() {
+        if (!this.started) {
+            throw new IllegalStateException(this.getClass().getCanonicalName() + ".start() not called yet");
+        }
+    }
+
+    // semi-builder pattern
+    @Override
+    public NinjaMode getNinjaMode() {
+        return ninjaMode;
+    }
+
+    @Override
+    public T ninjaMode(NinjaMode ninjaMode) {
+        this.ninjaMode = ninjaMode;
+        return (T) this;
+    }
+
+    @Override
+    public String getExternalConfigurationPath() {
+        return this.externalConfigurationPath;
+    }
+
+    @Override
+    public T externalConfigurationPath(String externalConfigurationPath) {
+        this.externalConfigurationPath = externalConfigurationPath;
+        return (T) this;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public T name(String name) {
+        this.name = name;
+        return (T) this;
+    }
+
+    @Override
+    public NinjaPropertiesImpl getNinjaProperties() {
+        // only available after configure()
+        checkConfigured();
+        return ninjaProperties;
+    }
+
+    protected Exception tryToUnwrapInjectorException(Exception exception) {
+        Throwable cause = exception.getCause();
+        if (cause != null && cause instanceof CreationException) {
+            return (CreationException) cause;
+        } else {
+            return exception;
+        }
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/standalone/AbstractStandalone.java
+++ b/ninja-core/src/main/java/ninja/standalone/AbstractStandalone.java
@@ -22,19 +22,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaMode;
-import ninja.utils.NinjaModeHelper;
-import ninja.utils.NinjaPropertiesImpl;
-import ninja.utils.OverlayedNinjaProperties;
-
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.inject.CreationException;
-
 import javax.net.ssl.SSLContext;
 
 /**
@@ -45,14 +35,9 @@ import javax.net.ssl.SSLContext;
  * specific to your Standalone.  See NinjaJetty for example concrete implementation.
  * @param <T> The concrete standalone implementation
  */
-abstract public class AbstractStandalone<T extends AbstractStandalone> implements Standalone<T>, Runnable {
-    // allow logger to take on persona of concrete class
-    final protected Logger logger = LoggerFactory.getLogger(this.getClass());
-
+abstract public class AbstractStandalone<T extends AbstractStandalone> extends AbstractConsole<T> implements Standalone<T>, Runnable {
+    
     // can all be changed prior to configure()
-    protected NinjaMode ninjaMode;
-    protected String externalConfigurationPath;
-    protected String name;
     protected String host;
     protected Integer port;
     protected String contextPath;
@@ -62,21 +47,51 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
     protected String sslKeystorePassword;
     protected URI sslTruststoreUri;
     protected String sslTruststorePassword;
-    
     // internal state
-    protected boolean configured;
-    protected boolean started;
-    protected NinjaPropertiesImpl ninjaProperties;                      // after configure()
-    protected OverlayedNinjaProperties overlayedNinjaProperties;        // after configure()
     protected List<String> serverUrls;
     protected List<String> baseUrls;
     
     public AbstractStandalone(String name) {
-        // set mode as quickly as possible (can still be changed before configure())
-        this.ninjaMode = NinjaModeHelper.determineModeFromSystemPropertiesOrProdIfNotSet();
-        this.name = name;
-        this.configured = false;
-        this.started = false;
+        super(name);
+    }
+    
+    @Override
+    protected void doPreConfigure() throws Exception {
+        // current value or system property or conf/application.conf or default value
+        host(overlayedNinjaProperties.get(Standalone.KEY_NINJA_HOST, this.host, Standalone.DEFAULT_HOST));
+        port(overlayedNinjaProperties.getInteger(Standalone.KEY_NINJA_PORT, this.port, Standalone.DEFAULT_PORT));
+        contextPath(overlayedNinjaProperties.get(Standalone.KEY_NINJA_CONTEXT_PATH, this.contextPath, Standalone.DEFAULT_CONTEXT_PATH));
+        idleTimeout(overlayedNinjaProperties.getLong(Standalone.KEY_NINJA_IDLE_TIMEOUT, this.idleTimeout, Standalone.DEFAULT_IDLE_TIMEOUT));
+        sslPort(overlayedNinjaProperties.getInteger(Standalone.KEY_NINJA_SSL_PORT, this.sslPort, Standalone.DEFAULT_SSL_PORT));
+        // defaults below (with self-signed cert) only valid in dev & test modes
+        sslKeystoreUri(overlayedNinjaProperties.getURI(Standalone.KEY_NINJA_SSL_KEYSTORE_URI, this.sslKeystoreUri, this.ninjaMode == NinjaMode.prod ? null : new URI(Standalone.DEFAULT_DEV_NINJA_SSL_KEYSTORE_URI)));
+        sslKeystorePassword(overlayedNinjaProperties.get(Standalone.KEY_NINJA_SSL_KEYSTORE_PASSWORD, this.sslKeystorePassword, this.ninjaMode == NinjaMode.prod ? null : Standalone.DEFAULT_DEV_NINJA_SSL_KEYSTORE_PASSWORD));
+        sslTruststoreUri(overlayedNinjaProperties.getURI(Standalone.KEY_NINJA_SSL_TRUSTSTORE_URI, this.sslTruststoreUri, this.ninjaMode == NinjaMode.prod ? null : new URI(Standalone.DEFAULT_DEV_NINJA_SSL_TRUSTSTORE_URI)));
+        sslTruststorePassword(overlayedNinjaProperties.get(Standalone.KEY_NINJA_SSL_TRUSTSTORE_PASSWORD, this.sslTruststorePassword, this.ninjaMode == NinjaMode.prod ? null : Standalone.DEFAULT_DEV_NINJA_SSL_TRUSTSTORE_PASSWORD));
+        // assign random ports if needed
+        if (getPort() == null || getPort() == 0) {
+            port(StandaloneHelper.findAvailablePort(8000, 9000));
+        }
+        if (getSslPort() == null || getSslPort() == 0) {
+            sslPort(StandaloneHelper.findAvailablePort(9001, 9999));
+        }
+    }
+    
+    @Override
+    protected void doPostConfigure() throws Exception {
+        // build configured urls
+        this.serverUrls = createServerUrls();
+        this.baseUrls = createBaseUrls();
+        // is there at least one url?
+        if (this.serverUrls == null || this.serverUrls.isEmpty()) {
+            throw new IllegalStateException("All server ports were disabled." + " Check the 'ninja.port' property and possibly others depending your standalone.");
+        }
+        // save generated server name as ninja property if its not yet set
+        String serverName = this.ninjaProperties.get(NinjaConstant.serverName);
+        if (StringUtils.isEmpty(serverName)) {
+            // grab the first one
+            this.ninjaProperties.setProperty(NinjaConstant.serverName, getServerUrls().get(0));
+        }
     }
     
     /**
@@ -117,97 +132,6 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
     }
     
     @Override
-    final public T configure() throws Exception {
-        checkNotConfigured();
-        
-        // create ninja properties & overlayed view
-        this.ninjaProperties = new NinjaPropertiesImpl(this.ninjaMode, this.externalConfigurationPath);
-        
-        this.overlayedNinjaProperties = new OverlayedNinjaProperties(this.ninjaProperties);
-        
-        // current value or system property or conf/application.conf or default value
-        host(overlayedNinjaProperties.get(
-                KEY_NINJA_HOST, this.host, DEFAULT_HOST));
-        
-        port(overlayedNinjaProperties.getInteger(
-                KEY_NINJA_PORT, this.port, DEFAULT_PORT));
-        
-        contextPath(overlayedNinjaProperties.get(
-                KEY_NINJA_CONTEXT_PATH, this.contextPath, DEFAULT_CONTEXT_PATH));
-        
-        idleTimeout(overlayedNinjaProperties.getLong(
-                KEY_NINJA_IDLE_TIMEOUT, this.idleTimeout, DEFAULT_IDLE_TIMEOUT));
-        
-        sslPort(overlayedNinjaProperties.getInteger(
-                KEY_NINJA_SSL_PORT, this.sslPort, DEFAULT_SSL_PORT));
-        
-        // defaults below (with self-signed cert) only valid in dev & test modes
-        
-        sslKeystoreUri(overlayedNinjaProperties.getURI(KEY_NINJA_SSL_KEYSTORE_URI, this.sslKeystoreUri, 
-                (this.ninjaMode == NinjaMode.prod ? null : new URI(DEFAULT_DEV_NINJA_SSL_KEYSTORE_URI))));
-        
-        sslKeystorePassword(overlayedNinjaProperties.get(
-                KEY_NINJA_SSL_KEYSTORE_PASSWORD, this.sslKeystorePassword, 
-                (this.ninjaMode == NinjaMode.prod ? null : DEFAULT_DEV_NINJA_SSL_KEYSTORE_PASSWORD)));
-        
-        sslTruststoreUri(overlayedNinjaProperties.getURI(KEY_NINJA_SSL_TRUSTSTORE_URI, this.sslTruststoreUri, 
-                (this.ninjaMode == NinjaMode.prod ? null : new URI(DEFAULT_DEV_NINJA_SSL_TRUSTSTORE_URI))));
-        
-        sslTruststorePassword(overlayedNinjaProperties.get(
-                KEY_NINJA_SSL_TRUSTSTORE_PASSWORD, this.sslTruststorePassword, 
-                (this.ninjaMode == NinjaMode.prod ? null : DEFAULT_DEV_NINJA_SSL_TRUSTSTORE_PASSWORD)));
-        
-        
-        // assign random ports if needed
-        if (getPort() == null || getPort() == 0) {
-            port(StandaloneHelper.findAvailablePort(8000, 9000));
-        }
-        
-        if (getSslPort() == null || getSslPort() == 0) {
-            sslPort(StandaloneHelper.findAvailablePort(9001, 9999));
-        }
-        
-        doConfigure();
-        
-        this.configured = true;
-        
-        // build configured urls
-        this.serverUrls = createServerUrls();
-        this.baseUrls = createBaseUrls();
-        
-        // is there at least one url?
-        if (this.serverUrls == null || this.serverUrls.isEmpty()) {
-            throw new IllegalStateException("All server ports were disabled." + 
-                    " Check the 'ninja.port' property and possibly others depending your standalone.");
-        }
-        
-        // save generated server name as ninja property if its not yet set
-        String serverName = this.ninjaProperties.get(NinjaConstant.serverName);
-        
-        if (StringUtils.isEmpty(serverName)) {
-            // grab the first one
-            this.ninjaProperties.setProperty(NinjaConstant.serverName, getServerUrls().get(0));
-        }
-        
-        return (T)this;
-    }
-    
-    @Override
-    final public T start() throws Exception {
-        if (!this.configured) {
-            configure();
-        }
-        
-        doStart();
-        
-        this.started = true;
-        
-        logBaseUrls();
-        
-        return (T)this;
-    }
-    
-    @Override
     final public T join() throws Exception{
         checkStarted();
         
@@ -216,72 +140,7 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
         return (T)this;
     }
     
-    @Override
-    final public T shutdown() {
-        doShutdown();
-        return (T)this;
-    }
-    
-    abstract protected void doConfigure() throws Exception;
-    
-    abstract protected void doStart() throws Exception;
-    
     abstract protected void doJoin() throws Exception;
-    
-    abstract protected void doShutdown();
-    
-    protected void checkNotConfigured() {
-        if (this.configured) {
-            throw new IllegalStateException(this.getClass().getCanonicalName() + ".configure() already called");
-        }
-    }
-    
-    protected void checkConfigured() {
-        if (!this.configured) {
-            throw new IllegalStateException(this.getClass().getCanonicalName() + ".configure() not called yet");
-        }
-    }
-    
-    protected void checkStarted() {
-        if (!this.started) {
-            throw new IllegalStateException(this.getClass().getCanonicalName() + ".start() not called yet");
-        }
-    }
-    
-    // semi-builder pattern
-    
-    @Override
-    public NinjaMode getNinjaMode() {
-        return ninjaMode;
-    }
-    
-    @Override
-    public T ninjaMode(NinjaMode ninjaMode) {
-        this.ninjaMode = ninjaMode;
-        return (T)this;
-    }
-    
-    @Override
-    public String getExternalConfigurationPath() {
-        return this.externalConfigurationPath;
-    }
-    
-    @Override
-    public T externalConfigurationPath(String externalConfigurationPath) {
-        this.externalConfigurationPath = externalConfigurationPath;
-        return (T)this;
-    }
-    
-    @Override
-    public String getName() {
-        return name;
-    }
-    
-    @Override
-    public T name(String name) {
-        this.name = name;
-        return (T)this;
-    }
     
     @Override
     public Integer getPort() {
@@ -384,13 +243,6 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
     }
     
     @Override
-    public NinjaPropertiesImpl getNinjaProperties() {
-        // only available after configure()
-        checkConfigured();
-        return ninjaProperties;
-    }
-    
-    @Override
     public List<String> getServerUrls() {
         // only available after configure()
         checkConfigured();
@@ -477,14 +329,6 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
         return sb.toString();
     }
     
-    protected Exception tryToUnwrapInjectorException(Exception exception) {
-        Throwable cause = exception.getCause();
-        if (cause != null && cause instanceof CreationException) {
-            return (CreationException)cause;
-        } else {
-            return exception;
-        }
-    }
     
     protected String getLoggableIdentifier() {
         // build list of ports
@@ -513,13 +357,16 @@ abstract public class AbstractStandalone<T extends AbstractStandalone> implement
         return s.toString();
     }
     
-    protected void logBaseUrls() {
+    @Override
+    protected void logStarted() {
         logger.info("-------------------------------------------------------");
         logger.info("Ninja application running at");
         
-        List<String> uris = getBaseUrls();
-        for (String uri : uris) {
-            logger.info(" => {}", uri);
+        List<String> uris = this.getBaseUrls();
+        if (uris != null) {
+            uris.forEach(uri -> {
+                logger.info(" => {}", uri);
+            });
         }
         
         logger.info("-------------------------------------------------------");

--- a/ninja-core/src/main/java/ninja/standalone/Console.java
+++ b/ninja-core/src/main/java/ninja/standalone/Console.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.standalone;
+
+import com.google.inject.Injector;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaPropertiesImpl;
+
+/**
+ *
+ * @author jjlauer
+ */
+public interface Console<T extends Console> {
+
+    /**
+     * Configures the standalone to prepare for being started.
+     * @return This standalone
+     * @throws Exception Thrown if an exception occurs during configuration
+     */
+    T configure() throws Exception;
+
+    T externalConfigurationPath(String externalConfigurationPath);
+
+    String getExternalConfigurationPath();
+
+    /**
+     * Gets the Guice injector that booted the Ninja application. This value
+     * is only accessible after start() is successfully called.
+     * @return The guice injector
+     * @throws IllegalStateException Thrown if attempting to access this variable
+     *      before start() is successfully called.
+     */
+    Injector getInjector();
+
+    String getName();
+
+    NinjaMode getNinjaMode();
+
+    /**
+     * Gets the NinjaProperties that were used to configure Ninja. This value
+     * is only accessible after configure() is successfully called.
+     * @return The NinjaProperties implementation
+     * @throws IllegalStateException Thrown if attempting to access this variable
+     *      before configure() is successfully called.
+     */
+    NinjaPropertiesImpl getNinjaProperties();
+
+    T name(String name);
+
+    T ninjaMode(NinjaMode ninjaMode);
+
+    /**
+     * Shutdown Ninja and underlying server as safely as possible (tries not
+     * to cause exceptions to be thrown).
+     * @return This standalone
+     */
+    T shutdown();
+
+    /**
+     * Configures (if not yet done), boots Ninja application and starts the
+     * underlying server.
+     * @return This standalone
+     * @throws Exception Thrown if an exception occurs during Ninja boot or
+     *      server start
+     */
+    T start() throws Exception;
+    
+}

--- a/ninja-core/src/main/java/ninja/standalone/NinjaConsole.java
+++ b/ninja-core/src/main/java/ninja/standalone/NinjaConsole.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 ninjaframework.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.standalone;
+
+import com.google.inject.Injector;
+import ninja.Bootstrap;
+import ninja.utils.NinjaPropertiesImpl;
+
+public class NinjaConsole extends AbstractConsole<NinjaConsole> {
+    
+    private ConsoleBootstrap bootstrap;
+    
+    public NinjaConsole() {
+        super("NinjaConsole");
+    }
+    
+    public static void main(String [] args) throws Exception {
+        // create new instance and run it
+        new NinjaConsole().start();
+    }
+    
+    @Override
+    public Injector getInjector() {
+        checkStarted();
+        return this.bootstrap.getInjector();
+    }
+    
+    @Override
+    public void doConfigure() throws Exception {
+        // create new bootstrap to kickoff ninja
+        this.bootstrap = new ConsoleBootstrap(ninjaProperties);
+    }
+    
+    @Override
+    public void doStart() throws Exception {
+        try {
+            this.bootstrap.boot();
+        } catch (Exception e) {
+            throw tryToUnwrapInjectorException(e);
+        }
+    }
+
+    @Override
+    public void doShutdown() {
+        if (this.bootstrap != null) {
+            this.bootstrap.shutdown();
+            this.bootstrap = null;
+        }
+    }
+    
+    static public class ConsoleBootstrap extends Bootstrap {
+
+        public ConsoleBootstrap(NinjaPropertiesImpl ninjaProperties) {
+            super(ninjaProperties);
+        }
+
+        @Override
+        public void initRoutes() throws Exception {
+            // do nothing in console apps
+        }
+
+    }
+    
+}

--- a/ninja-core/src/main/java/ninja/standalone/Standalone.java
+++ b/ninja-core/src/main/java/ninja/standalone/Standalone.java
@@ -16,11 +16,8 @@
 
 package ninja.standalone;
 
-import com.google.inject.Injector;
 import java.net.URI;
 import java.util.List;
-import ninja.utils.NinjaMode;
-import ninja.utils.NinjaPropertiesImpl;
 
 /**
  * Interface for wrapping an underlying server (e.g. Jetty) to bootstrap Ninja
@@ -28,7 +25,7 @@ import ninja.utils.NinjaPropertiesImpl;
  * @param <T> The concrete standalone implementation (to make the builder
  *      pattern work correctly during compilation)
  */
-public interface Standalone<T extends Standalone> {
+public interface Standalone<T extends Standalone> extends Console<T> {
     
     String KEY_NINJA_STANDALONE_CLASS                   = "ninja.standalone.class";
     String KEY_NINJA_CONTEXT_PATH                       = "ninja.context";
@@ -55,13 +52,6 @@ public interface Standalone<T extends Standalone> {
     String DEFAULT_DEV_NINJA_SSL_TRUSTSTORE_PASSWORD    = "password";
 
     /**
-     * Configures the standalone to prepare for being started.
-     * @return This standalone
-     * @throws Exception Thrown if an exception occurs during configuration
-     */
-    T configure() throws Exception;
-    
-    /**
      * Configure, start, add shutdown hook, and join.  Since this
      * method joins the underlying server (e.g. Jetty), it does not exit until
      * interrupted.
@@ -69,39 +59,11 @@ public interface Standalone<T extends Standalone> {
     void run();
 
     /**
-     * Configures (if not yet done), boots Ninja application and starts the
-     * underlying server.
-     * @return This standalone
-     * @throws Exception Thrown if an exception occurs during Ninja boot or
-     *      server start
-     */
-    T start() throws Exception;
-    
-    /**
      * Joins the underlying server to wait until its finished.
      * @return This standalone
      * @throws Exception Thrown if an exception occurs while waiting
      */
-    T join() throws Exception;
-    
-    /**
-     * Shutdown Ninja and underlying server as safely as possible (tries not
-     * to cause exceptions to be thrown).
-     * @return This standalone
-     */
-    T shutdown();
-
-    NinjaMode getNinjaMode();
-    
-    T ninjaMode(NinjaMode ninjaMode);
-    
-    String getExternalConfigurationPath();
-    
-    T externalConfigurationPath(String externalConfigurationPath);
-    
-    String getName();
-    
-    T name(String name);
+    T join() throws Exception;    
     
     String getHost();
     
@@ -147,23 +109,6 @@ public interface Standalone<T extends Standalone> {
 
     T sslTruststorePassword(String truststorePassword);
     
-    /**
-     * Gets the NinjaProperties that were used to configure Ninja. This value
-     * is only accessible after configure() is successfully called.
-     * @return The NinjaProperties implementation
-     * @throws IllegalStateException Thrown if attempting to access this variable
-     *      before configure() is successfully called.
-     */
-    NinjaPropertiesImpl getNinjaProperties();
-    
-    /**
-     * Gets the Guice injector that booted the Ninja application. This value
-     * is only accessible after start() is successfully called.
-     * @return The guice injector
-     * @throws IllegalStateException Thrown if attempting to access this variable
-     *      before start() is successfully called.
-     */
-    Injector getInjector();
     
     /**
      * Get the urls for the servers that are configured to start. This value

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version 6.3.x
+=============
+
+ * 2018-01-29 Feature to run Ninja as console (server-less) application
+
 Version 6.2.2
 =============
 

--- a/ninja-core/src/site/markdown/documentation/console.md
+++ b/ninja-core/src/site/markdown/documentation/console.md
@@ -1,0 +1,47 @@
+Console Application
+===================
+
+## Introduction
+
+Ninja is designed to be a web framework, but if you want to leverage its 
+excellent dependency injection or configuration for running a webserver-less
+console application, Ninja v6.3.0+ added support for `ninja.standalone.NinjaConsole`
+as a main entry point.
+
+Your application will start like it normally would if running in a web server
+container like Jetty, but will not start a web server and will not initialize
+your `conf.Router`. All other Guice configuration and lifecycle methods will
+be started as they normally would if running as a standard Ninja web application.
+
+## Usage
+
+You can either start the JVM directly or customize `ninja.standalone.NinjaConsole`.
+Since it includes a main method, the following would start your console-based
+Ninja application:
+
+<pre class="prettyprint">
+java -cp &lt;classpath-here&gt; ninja.standalone.NinjaConsole
+</pre>
+
+Or you can write your own main method and customize `NinjaConsole` as much
+as you need:
+
+<pre class="prettyprint">
+import ninja.standalone.NinjaConsole;
+import ninja.utils.NinjaMode;
+
+public class MyMain {
+ 
+    static public void main(String[] args) throws Exception {
+        NinjaConsole ninja = new NinjaConsole()
+            .ninjaMode(NinjaMode.prod)
+            .start();
+
+        // other code (e.g. access guice injector)
+        // ninja.getInjector();
+
+        ninja.shutdown();
+    }
+    
+}
+</pre>

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -119,6 +119,8 @@
             <item name="Custom routing" href="./documentation/custom_routing.html"/>
 
             <item name="Servlet bridge" href="./documentation/servlet_bridge.html"/>
+            
+            <item name="Console application" href="./documentation/console.html"/>
 
             <item name="Testing" collapse="true" href="./documentation/testing_your_application/getting_started.html">
                 <item name="Mocked tests" href="./documentation/testing_your_application/mocked_tests.html"/>

--- a/ninja-core/src/test/java/ninja/standalone/AbstractStandaloneTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/AbstractStandaloneTest.java
@@ -20,12 +20,7 @@ import ninja.utils.NinjaConstant;
 import ninja.utils.NinjaMode;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;

--- a/ninja-core/src/test/java/ninja/standalone/NinjaConsoleTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/NinjaConsoleTest.java
@@ -25,40 +25,40 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class NinjaStandaloneTest {
+public class NinjaConsoleTest {
     
     @Test
     public void ninjaPropertiesThrowsExceptionUntilConfigured() throws Exception {
-        NinjaConsole standalone = new NinjaConsole();
+        NinjaConsole console = new NinjaConsole();
         
         try {
-            standalone.getNinjaProperties();
+            console.getNinjaProperties();
             fail("exception expected");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("configure() not called"));
         }
         
-        standalone.configure();
+        console.configure();
         
-        assertThat(standalone.getNinjaProperties(), is(not(nullValue())));
+        assertThat(console.getNinjaProperties(), is(not(nullValue())));
     }
     
     @Test
     public void start() throws Exception {
-        NinjaConsole standalone = new NinjaConsole();
+        NinjaConsole console = new NinjaConsole();
 
         try {
-            standalone.getInjector();
+            console.getInjector();
             fail("exception expected");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("start() not called"));
         }
         
-        standalone.start();
+        console.start();
         try {
-            assertThat(standalone.getInjector(), is(not(nullValue())));
+            assertThat(console.getInjector(), is(not(nullValue())));
         } finally {
-            standalone.shutdown();
+            console.shutdown();
         }
     }
     

--- a/ninja-core/src/test/java/ninja/standalone/NinjaStandaloneTest.java
+++ b/ninja-core/src/test/java/ninja/standalone/NinjaStandaloneTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.standalone;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class NinjaStandaloneTest {
+    
+    @Test
+    public void ninjaPropertiesThrowsExceptionUntilConfigured() throws Exception {
+        NinjaConsole standalone = new NinjaConsole();
+        
+        try {
+            standalone.getNinjaProperties();
+            fail("exception expected");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), containsString("configure() not called"));
+        }
+        
+        standalone.configure();
+        
+        assertThat(standalone.getNinjaProperties(), is(not(nullValue())));
+    }
+    
+    @Test
+    public void start() throws Exception {
+        NinjaConsole standalone = new NinjaConsole();
+
+        try {
+            standalone.getInjector();
+            fail("exception expected");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), containsString("start() not called"));
+        }
+        
+        standalone.start();
+        try {
+            assertThat(standalone.getInjector(), is(not(nullValue())));
+        } finally {
+            standalone.shutdown();
+        }
+    }
+    
+}


### PR DESCRIPTION
In most applications I generally need to do something administrative -- and reuse my Ninja application code to do it.  For now I've always hacked it by firing up Ninja in a web server in a custom main() method.  Doesn't work so well if you already have a web server running.  This PR makes launching a console-only Ninja application part of the framework itself.  Open to naming it something other than `console` if there a better name for it.