### PR TITLE
Make UUID a first class citizen

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ParamParsers.java
+++ b/ninja-core/src/main/java/ninja/params/ParamParsers.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.UUID;
 
 import ninja.validation.ConstraintViolation;
 import ninja.validation.IsDate;
@@ -64,6 +65,7 @@ public class ParamParsers {
                     .put(Character.class, new CharacterParamParser())
                     .put(char.class, new PrimitiveCharacterParamParser())
                     .put(Date.class, new DateParamParser())
+                    .put(UUID.class, new UUIDParamParser())
                     .build();
 
     private final Set<ParamParser> customParsers;
@@ -504,6 +506,27 @@ public class ParamParsers {
         }
     }
 
+    public static class UUIDParamParser implements ParamParser<UUID> {
+        @Override
+        public UUID parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || parameterValue.isEmpty() || validation.hasViolation(field)) {
+                return null;
+            } else {
+                try {
+                    return UUID.fromString(parameterValue);
+                } catch (IllegalArgumentException e) {
+                    validation.addViolation(new ConstraintViolation(
+                            IsInteger.KEY, field, IsInteger.MESSAGE, parameterValue));
+                    return null;
+                }
+            }
+        }
+
+        @Override
+        public Class<UUID> getParsedType() {
+            return UUID.class;
+        }
+    }
     
     public static class GenericEnumParamParser<E extends Enum<E>> implements ParamParser<E> {
 

--- a/ninja-core/src/main/java/ninja/validation/IsUUID.java
+++ b/ninja-core/src/main/java/ninja/validation/IsUUID.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@WithValidator(Validators.UUIDValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface IsUUID {
+    /**
+     * The key for the violation message
+     * 
+     * @return The key of the violation message
+     */
+    String key() default KEY;
+
+    /**
+     * Default message if the key isn't found
+     * 
+     * @return The default message
+     */
+    String message() default MESSAGE;
+
+    /**
+     * The key for formatting the field
+     * 
+     * @return The key
+     */
+    String fieldKey() default "";
+
+    public static final String KEY = "validation.is.uuid.violation";
+    public static final String MESSAGE = "{0} must be a valid uuid";
+}

--- a/ninja-core/src/main/java/ninja/validation/Validators.java
+++ b/ninja-core/src/main/java/ninja/validation/Validators.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import java.util.UUID;
 
 import ninja.Context;
 import ninja.Result;
@@ -298,6 +299,40 @@ public class Validators {
                             new ConstraintViolation(this.isDate.key(),
                                     fieldKey(field, this.isDate.fieldKey()),
                                     this.isDate.message(), value));
+                }
+            }
+        }
+
+        @Override
+        public Class<String> getValidatedType() {
+            return String.class;
+        }
+    }
+    
+    public static class UUIDValidator implements Validator<String> {
+
+        private final IsUUID isUUID;
+
+        public UUIDValidator(IsUUID isUUID) {
+            this.isUUID = isUUID;
+        }
+
+        /**
+         * Validate the given value
+         *
+         * @param value   The value, may be null
+         * @param field   The name of the field being validated, if applicable
+         * @param context The Ninja request context
+         */
+        @Override
+        public void validate(String value, String field, Context context) {
+            if (value != null) {
+                try {
+                    UUID.fromString(value);
+                } catch (IllegalArgumentException e) {
+                    context.getValidation().addViolation(new ConstraintViolation(this.isUUID.key(),
+                                    fieldKey(field, this.isUUID.fieldKey()),
+                                    this.isUUID.message(), value));
                 }
             }
         }

--- a/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
+++ b/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
@@ -15,6 +15,7 @@
  */
 package ninja.params;
 
+import java.util.UUID;
 import static org.junit.Assert.assertThat;
 
 import org.hamcrest.Matchers;
@@ -24,6 +25,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import ninja.validation.Validation;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParamParsersTest {
@@ -261,4 +264,17 @@ public class ParamParsersTest {
         assertThat(doubleParamParser.parseParameter("param1", "123.1", validation), Matchers.is(new Double(123.1)));
         assertThat(doubleParamParser.parseParameter("param1", "-123.1", validation), Matchers.is(new Double(-123.1)));
     }
+    
+    @Test
+    public void testUUIDParamParser() {
+        ParamParsers.UUIDParamParser uuidParamParser = new ParamParsers.UUIDParamParser();
+
+        assertThat(uuidParamParser.getParsedType(), Matchers.is(UUID.class));
+        assertThat(uuidParamParser.parseParameter("param1", null, validation), is(nullValue()));
+        assertThat(uuidParamParser.parseParameter("param1", "", validation), is(nullValue()));
+        assertThat(uuidParamParser.parseParameter("param1", "asdfasdf", validation), is(nullValue()));
+        assertThat(uuidParamParser.parseParameter("param1", "fe45481f-ed31-40e4-9bca-9cec383302c2", validation),
+            is(UUID.fromString("fe45481f-ed31-40e4-9bca-9cec383302c2")));
+    }
+    
 }


### PR DESCRIPTION
Make a UUID a first class citizen for parameter parsing.  Invalid UUIDs will be rejected.