### PR TITLE
Error handling : ForbiddenRequestException + i18n message

### DIFF
--- a/ninja-core/src/main/java/ninja/Ninja.java
+++ b/ninja-core/src/main/java/ninja/Ninja.java
@@ -16,6 +16,10 @@
 
 package ninja;
 
+import ninja.exceptions.BadRequestException;
+import ninja.exceptions.ForbiddenRequestException;
+import ninja.exceptions.RenderingException;
+
 public interface Ninja {
 
 	/**
@@ -40,12 +44,10 @@ public interface Ninja {
      * handling is required, simply:
      * 
      * <code>
-     *   return getInternalServerErrorResult(context, exception);
+     *   return getInternalServerErrorResult(context, exception, underlyingResult);
      * </code>
      */
-    /** NOT REQUIRED YET IN ORDER TO NOT BREAK COMPATIBILITY...
-    Result getRenderingExceptionResult(Context context, RenderingException exception);
-    */
+    Result getRenderingExceptionResult(Context context, RenderingException exception, Result underlyingResult);
     
     /**
      * Should handle cases where an exception is thrown
@@ -56,7 +58,7 @@ public interface Ninja {
      * 
      * Usually used by onRouteRequest(...).
      */
-    Result getInternalServerErrorResult(Context context, Exception exception);
+    Result getInternalServerErrorResult(Context context, Exception exception, Result underlyingResult);
     
     /**
      * Should handle cases where the client sent strange date that
@@ -67,7 +69,7 @@ public interface Ninja {
      * 
      * Usually used by onRouteRequest(...).
      */
-    Result getBadRequestResult(Context context, Exception exception);
+    Result getBadRequestResult(Context context, BadRequestException exception);
     
     /**
      * Should handle cases where no route can be found for a given request.
@@ -100,6 +102,17 @@ public interface Ninja {
      * Usually used by SecureFilter for instance(...).
      */
     Result getForbiddenResult(Context context);
+    
+    /**
+     * Should handle cases where access is forbidden
+     *
+     * Should lead to a html error 403 - forbidden
+     * (and be used with the same mindset).
+     * 
+     * Usually used by onRouteRequest(...).
+     */
+    Result getForbiddenResult(Context context, ForbiddenRequestException exception);
+
 
     /**
      * Invoked when the framework starts. Usually inits stuff like the scheduler

--- a/ninja-core/src/main/java/ninja/Ninja.java
+++ b/ninja-core/src/main/java/ninja/Ninja.java
@@ -19,6 +19,7 @@ package ninja;
 import ninja.exceptions.BadRequestException;
 import ninja.exceptions.ForbiddenRequestException;
 import ninja.exceptions.RenderingException;
+import ninja.exceptions.RequestNotFoundException;
 
 public interface Ninja {
 
@@ -80,6 +81,16 @@ public interface Ninja {
      * Usually used by onRouteRequest(...).
      */
     Result getNotFoundResult(Context context);
+    
+    /**
+     * Should handle cases where no route can be found for a given request.
+     * 
+     * Should lead to a html error 404 - not found
+     * (and be used with the same mindset).
+     * 
+     * Usually used by onRouteRequest(...).
+     */
+    Result getNotFoundResult(Context context, RequestNotFoundException exception);
     
     /**
      * Should handle cases where access is unauthorized

--- a/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorBuilder.java
+++ b/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorBuilder.java
@@ -63,6 +63,16 @@ public class DiagnosticErrorBuilder {
             null, false, null);
     }
     
+    static public DiagnosticError build403ForbiddenDiagnosticError(
+            Throwable cause,
+            boolean tryToReadLinesFromSourceCode) {
+
+        return buildDiagnosticError(
+                "Forbidden",
+                cause,
+                tryToReadLinesFromSourceCode, null);
+        }
+    
     static public DiagnosticError build401UnauthorizedDiagnosticError() {
         return buildDiagnosticError(
             "Not authorized",

--- a/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorBuilder.java
+++ b/ninja-core/src/main/java/ninja/diagnostics/DiagnosticErrorBuilder.java
@@ -57,6 +57,16 @@ public class DiagnosticErrorBuilder {
             null);
     }
     
+    static public DiagnosticError build404NotFoundDiagnosticError(
+            Throwable cause,
+            boolean tryToReadLinesFromSourceCode) {
+
+        return buildDiagnosticError(
+            "Route not found",
+            cause,
+            tryToReadLinesFromSourceCode, null);
+    }
+    
     static public DiagnosticError build403ForbiddenDiagnosticError() {
         return buildDiagnosticError(
             "Forbidden",
@@ -68,10 +78,10 @@ public class DiagnosticErrorBuilder {
             boolean tryToReadLinesFromSourceCode) {
 
         return buildDiagnosticError(
-                "Forbidden",
-                cause,
-                tryToReadLinesFromSourceCode, null);
-        }
+            "Forbidden",
+            cause,
+            tryToReadLinesFromSourceCode, null);
+    }
     
     static public DiagnosticError build401UnauthorizedDiagnosticError() {
         return buildDiagnosticError(

--- a/ninja-core/src/main/java/ninja/exceptions/ForbiddenRequestException.java
+++ b/ninja-core/src/main/java/ninja/exceptions/ForbiddenRequestException.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.exceptions;
+
+import ninja.Result;
+
+/**
+ * A convenience unchecked exception. 
+ * Allows you to wrap any exception (checked or unchecked) and throw it.
+ * 
+ * Should signal a html error 403 - forbidden (the client attempts something forbidden).
+ * 
+ * Useful inside controllers or filters for instance.
+ * 
+ * Ninja is supposed to pick it up and render an appropriate error page.
+ * 
+ */
+public class ForbiddenRequestException extends NinjaException {  
+    
+    final static String DEFAULT_MESSAGE = "That's a forbidden request and all we know.";
+    
+    public ForbiddenRequestException() {
+        super(Result.SC_403_FORBIDDEN, DEFAULT_MESSAGE);
+    }
+
+    public ForbiddenRequestException(String message) {
+        super(Result.SC_403_FORBIDDEN, message);
+    }
+   
+    public ForbiddenRequestException(String message, Throwable cause) {
+        super(Result.SC_403_FORBIDDEN, message, cause);
+    }
+
+    public ForbiddenRequestException(Throwable cause) {
+        super(Result.SC_403_FORBIDDEN, DEFAULT_MESSAGE, cause);
+    }
+}

--- a/ninja-core/src/main/java/ninja/exceptions/RequestNotFoundException.java
+++ b/ninja-core/src/main/java/ninja/exceptions/RequestNotFoundException.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ninja.exceptions;
+
+import ninja.Result;
+
+/**
+ * A convenience unchecked exception. 
+ * Allows you to wrap any exception (checked or unchecked) and throw it.
+ * 
+ * Should signal a html error 404 - not found (the client attempts something unknown).
+ * 
+ * Useful inside controllers or filters for instance.
+ * 
+ * Ninja is supposed to pick it up and render an appropriate error page.
+ * 
+ */
+public class RequestNotFoundException extends NinjaException {  
+    
+    final static String DEFAULT_MESSAGE = "That request could not be found.";
+    
+    public RequestNotFoundException() {
+        super(Result.SC_404_NOT_FOUND, DEFAULT_MESSAGE);
+    }
+
+    public RequestNotFoundException(String message) {
+        super(Result.SC_404_NOT_FOUND, message);
+    }
+   
+    public RequestNotFoundException(String message, Throwable cause) {
+        super(Result.SC_404_NOT_FOUND, message, cause);
+    }
+
+    public RequestNotFoundException(Throwable cause) {
+        super(Result.SC_404_NOT_FOUND, DEFAULT_MESSAGE, cause);
+    }
+}

--- a/ninja-core/src/main/java/ninja/utils/Message.java
+++ b/ninja-core/src/main/java/ninja/utils/Message.java
@@ -24,11 +24,17 @@ public  class Message {
 
     public String text;
     
+    public String error;
+    
     // Default constructor needed by Jackson.
     public Message() {}
 
     public Message(String text) {
-        this.text = text;
+        this(text, null);
     }
 
+    public Message(String text, String error) {
+        this.text = text;
+        this.error = error;
+    }
 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,4 @@
+* 2018-09-01 `ForbiddenRequestException` and i18n exception message keys (jlannoy)
 * 2018-08-23 Updated libraries (jlannoy)
     * com.fasterxml.jackson.core:jackson-* ...................... 2.8.1 -> 2.9.6
     * com.google.guava:guava .................................... 19.0 -> 26.0-jre

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,4 +1,4 @@
-* 2018-09-01 `ForbiddenRequestException` and i18n exception message keys (jlannoy)
+* 2018-09-01 `ForbiddenRequestException`, `RequestNotFoundException` and i18n message keys (jlannoy)
 * 2018-08-23 Updated libraries (jlannoy)
     * com.fasterxml.jackson.core:jackson-* ...................... 2.8.1 -> 2.9.6
     * com.google.guava:guava .................................... 19.0 -> 26.0-jre

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
@@ -106,7 +106,10 @@ Keys and default values are defined in <code>ninja.NinjaConstant</code>.
 
 Exception messages can also be defined as keys in your 
 <code>conf/messages.properties</code>, while the localized exception 
-message will be used if no translation exists.
+message will be used if no translation exists. So for 
+example <code>throw new BadRequestException("error.invalidData");</code> 
+will result in a translation of `error.invalidData` in your error page 
+rendering context.
 
 More
 ----

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
@@ -8,11 +8,17 @@ handle them via HTML views.
 Ninja's exceptions
 ------------------
 
-Ninja provides two types of exceptions: <code>BadRequestException</code> and 
- <code>InternalServerErrorException</code>.
+Ninja provides three types of exceptions: 
 
-A  <code>BadRequestException</code> should signal a faulty request by the user. It is
+ * <code>BadRequestException</code> 
+ * <code>ForbiddenRequestException</code> 
+ * <code>InternalServerErrorException</code>
+
+A <code>BadRequestException</code> should signal a faulty request by the user. It is
 similar in mindset as the HTTP error 400.
+
+A <code>ForbiddenRequestException</code> should signal a unauthorized request by the user. It is
+similar in mindset as the HTTP error 403.
 
 An <code>InternalServerErrorException</code> signals that something went wrong
 inside your application - pretty much like the HTTP error 500.
@@ -46,9 +52,12 @@ The default HTML views for errors can be found here:
 You can overwrite the views by creating the appropriate files in your application
 at the very same locations (<code>views/system/...</code>).
 
-This allows you to use your own styling and messages for the error views.
+This allows you to use your own styling and messages for the error views. The rendering 
+context will contain a `Message` object, containing a `text` description of the error type, 
+and an `error` message from the corresponding exception (if any).
 
 You can also change their locations using the following ninja properties:
+
  * <code>application.views.400badRequest</code>
  * <code>application.views.404notFound</code>
  * <code>application.views.403forbidden</code>
@@ -68,7 +77,8 @@ The error itself based on ninja.util.Message which contains one field called "te
 By default the JSON error as Message will look like:
 <pre class="prettyprint">
 {
-    "text": "Oops. The requested route cannot be found."
+    "text": "Oops. The requested route cannot be found.",
+    "error": "My exception localized message."
 }
 </pre>
 
@@ -76,6 +86,7 @@ And XML Message looks like:
 <pre class="prettyprint">
 &lt;Message&gt;
     &lt;text&gt;Oops. The requested route cannot be found.&lt;/text&gt;
+    &lt;error&gt;My exception localized message.&lt;/text&gt;
 &lt;/Message&gt;
 </pre>
 
@@ -84,14 +95,18 @@ Internationalization of errors
 ------------------------------
 
 There are basic default error messages defined. You can define your own and 
-translate them by adding the following keys to you
- <code>conf/messages.properties</code> files:
+translate them by adding the following keys to your 
+<code>conf/messages.properties</code> files:
 
 * Bad request: <code>ninja.system.bad_request.text</code>
 * Internal server error: <code>ninja.system.internal_server_error.text</code>
 * Route not found: <code>ninja.system.not_found.text</code>
 
 Keys and default values are defined in <code>ninja.NinjaConstant</code>.
+
+Exception messages can also be defined as keys in your 
+<code>conf/messages.properties</code>, while the localized exception 
+message will be used if no translation exists.
 
 More
 ----

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/error_handling.md
@@ -8,10 +8,11 @@ handle them via HTML views.
 Ninja's exceptions
 ------------------
 
-Ninja provides three types of exceptions: 
+Ninja provides four types of exceptions: 
 
  * <code>BadRequestException</code> 
  * <code>ForbiddenRequestException</code> 
+ * <code>RequestNotFoundException</code> 
  * <code>InternalServerErrorException</code>
 
 A <code>BadRequestException</code> should signal a faulty request by the user. It is
@@ -19,6 +20,9 @@ similar in mindset as the HTTP error 400.
 
 A <code>ForbiddenRequestException</code> should signal a unauthorized request by the user. It is
 similar in mindset as the HTTP error 403.
+
+A <code>RequestNotFoundException</code> should signal a unauthorized request by the user. It is
+similar in mindset as the HTTP error 404.
 
 An <code>InternalServerErrorException</code> signals that something went wrong
 inside your application - pretty much like the HTTP error 500.
@@ -44,8 +48,8 @@ HTML error representation
 The default HTML views for errors can be found here:
 
  * <code>views/system/400badRequest.ftl.html</code>
- * <code>views/system/404notFound.ftl.html</code> (If a route cannot be found).
- * <code>views/system/403forbidden.ftl.html</code> (If a route cannot be found).
+ * <code>views/system/404notFound.ftl.html</code>
+ * <code>views/system/403forbidden.ftl.html</code>
  * <code>views/system/500internalServerError.ftl.html</code>
  * <code>views/system/401unauthorized.ftl.html</code> (if an authorization is required)
 

--- a/ninja-core/src/site/markdown/documentation/upgrade_guide.md
+++ b/ninja-core/src/site/markdown/documentation/upgrade_guide.md
@@ -7,6 +7,14 @@ your application to the latest Ninja version. Simply start with your current
 version and then work your way up to the top of the document.
 
 
+to 6.3.X
+--------
+
+Some inner methods of the `Ninja` base class have a new signature, with more 
+precise exception types. If you overrided some of them, or if you implemented 
+your own `Ninja` class without extending the `NinjaDefault` one, you should be 
+able to fix them easily.
+
 to 6.3.0
 --------
 

--- a/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
+++ b/ninja-core/src/test/java/ninja/NinjaDefaultTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import ninja.diagnostics.DiagnosticError;
 import ninja.exceptions.BadRequestException;
+import ninja.exceptions.ForbiddenRequestException;
 import ninja.exceptions.InternalServerErrorException;
 import ninja.i18n.Messages;
 import ninja.lifecycle.LifecycleService;
@@ -125,14 +126,18 @@ public class NinjaDefaultTest {
         verify(contextImpl).setRoute(route);
         verify(resultHandler).handleResult(result, contextImpl);
 
-        verify(ninjaDefault, Mockito.never()).getInternalServerErrorResult(any(Context.class), any(Exception.class));
-        verify(ninjaDefault, Mockito.never()).getBadRequestResult(any(Context.class), any(Exception.class));
+        verify(ninjaDefault, Mockito.never()).getInternalServerErrorResult(any(Context.class), any(Exception.class), any(Result.class));
+        verify(ninjaDefault, Mockito.never()).getBadRequestResult(any(Context.class), any(BadRequestException.class));
+        verify(ninjaDefault, Mockito.never()).getForbiddenResult(any(Context.class), any(ForbiddenRequestException.class));
         verify(ninjaDefault, Mockito.never()).getNotFoundResult(any(Context.class));
     }
     
     @Test
     public void testOnRouteRequestWhenException() throws Exception {
-        
+
+        Exception exception 
+              = new RuntimeException("That's a very generic exception that should be handled by onError!");
+
         Mockito.when(
                 messages.getWithDefault(
                         Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_KEY), 
@@ -140,12 +145,16 @@ public class NinjaDefaultTest {
                         any(Optional.class)))
                 .thenReturn(NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_DEFAULT);
     
+        Mockito.when(
+                messages.getWithDefault(
+                        Matchers.eq(exception.getMessage()), 
+                        Matchers.eq(exception.getLocalizedMessage()), 
+                        any(Optional.class)))
+                .thenReturn(exception.getLocalizedMessage());
+        
         FilterChain filterChain = Mockito.mock(FilterChain.class);
         Mockito.when(route.getFilterChain()).thenReturn(filterChain);
-          
-        Exception exception 
-                = new RuntimeException("That's a very generic exception that should be handled by onError!");
-        
+
         Mockito.when(filterChain.next(contextImpl)).thenThrow(exception);
         
         ninjaDefault.onRouteRequest(contextImpl);
@@ -186,7 +195,7 @@ public class NinjaDefaultTest {
         
         ninjaDefault.onRouteRequest(contextImpl);
         
-        Result localResult = ninjaDefault.getInternalServerErrorResult(contextImpl, internalServerErrorException);
+        Result localResult = ninjaDefault.getInternalServerErrorResult(contextImpl, internalServerErrorException, null);
         
         assertThat(localResult.getRenderable(), CoreMatchers.instanceOf(DiagnosticError.class));
     }
@@ -215,7 +224,7 @@ public class NinjaDefaultTest {
         Mockito.when(route.getFilterChain()).thenReturn(filterChain);
           
         BadRequestException badRequest 
-                = new BadRequestException("That's a BadRequest that should be handled by onBadRequest");;
+                = new BadRequestException("That's a BadRequest that should be handled by onBadRequest");
         
         Mockito.when(filterChain.next(contextImpl)).thenThrow(badRequest);
         when(ninjaProperties.isDev()).thenReturn(true);
@@ -224,6 +233,43 @@ public class NinjaDefaultTest {
         ninjaDefault.onRouteRequest(contextImpl);
         
         Result localResult = ninjaDefault.getBadRequestResult(contextImpl, badRequest);
+        
+        assertThat(localResult.getRenderable(), CoreMatchers.instanceOf(DiagnosticError.class));
+    }
+    
+    @Test
+    public void testOnRouteRequestWhenForbiddenRequest() throws Exception {
+    
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+        Mockito.when(route.getFilterChain()).thenReturn(filterChain);
+          
+        ForbiddenRequestException forbiddenRequest 
+                = new ForbiddenRequestException("That's a ForbiddenRequest that should be handled by onForbiddenRequest");
+        
+        Mockito.when(filterChain.next(contextImpl)).thenThrow(forbiddenRequest);
+        
+        ninjaDefault.onRouteRequest(contextImpl);
+        
+        verify(ninjaDefault).getForbiddenResult(contextImpl, forbiddenRequest);
+    
+    }
+    
+    @Test
+    public void testOnRouteRequestWhenForbiddenRequestInDiagnosticMode() throws Exception {
+
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+        Mockito.when(route.getFilterChain()).thenReturn(filterChain);
+          
+        ForbiddenRequestException forbiddenRequest 
+                = new ForbiddenRequestException("That's a ForbiddenRequest that should be handled by onForbiddenRequest");
+        
+        Mockito.when(filterChain.next(contextImpl)).thenThrow(forbiddenRequest);
+        when(ninjaProperties.isDev()).thenReturn(true);
+        when(ninjaProperties.getBooleanWithDefault(NinjaConstant.DIAGNOSTICS_KEY_NAME, true)).thenReturn(true);
+        
+        ninjaDefault.onRouteRequest(contextImpl);
+        
+        Result localResult = ninjaDefault.getForbiddenResult(contextImpl, forbiddenRequest);
         
         assertThat(localResult.getRenderable(), CoreMatchers.instanceOf(DiagnosticError.class));
     }
@@ -276,12 +322,24 @@ public class NinjaDefaultTest {
     @Test
     public void testOnExceptionBadRequest() {
         
-        Exception badRequestException = new BadRequestException();
+        BadRequestException badRequestException = new BadRequestException();
     
         Result result = ninjaDefault.onException(contextImpl, badRequestException);
         
         verify(ninjaDefault).getBadRequestResult(contextImpl, badRequestException);
         assertThat(result.getStatusCode(), equalTo(Result.SC_400_BAD_REQUEST));
+    
+    }
+    
+    @Test
+    public void testOnExceptionForbiddenRequest() {
+        
+        ForbiddenRequestException forbiddenRequestException = new ForbiddenRequestException();
+    
+        Result result = ninjaDefault.onException(contextImpl, forbiddenRequestException);
+        
+        verify(ninjaDefault).getForbiddenResult(contextImpl, forbiddenRequestException);
+        assertThat(result.getStatusCode(), equalTo(Result.SC_403_FORBIDDEN));
     
     }
     
@@ -301,7 +359,7 @@ public class NinjaDefaultTest {
     @Test
     public void testThatGetInternalServerErrorContentNegotiation() throws Exception {
        Mockito.when(contextImpl.getAcceptContentType()).thenReturn(Result.APPLICATION_JSON);
-       Result result = ninjaDefault.getInternalServerErrorResult(contextImpl, new Exception("not important"));
+       Result result = ninjaDefault.getInternalServerErrorResult(contextImpl, new Exception("not important"), null);
        assertThat(result.getContentType(), equalTo(null));
        assertThat(result.supportedContentTypes().size(), equalTo(3));
 
@@ -310,7 +368,7 @@ public class NinjaDefaultTest {
     @Test
     public void testThatGetInternalServerErrorDoesFallsBackToHtml() throws Exception {
         Mockito.when(contextImpl.getAcceptContentType()).thenReturn("not_supported");
-        Result result = ninjaDefault.getInternalServerErrorResult(contextImpl, new Exception("not important"));
+        Result result = ninjaDefault.getInternalServerErrorResult(contextImpl, new Exception("not important"), null);
         assertThat(result.fallbackContentType().get(), equalTo(Result.TEXT_HTML));
     }
 
@@ -322,10 +380,12 @@ public class NinjaDefaultTest {
                 Matchers.eq(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR)))
                 .thenReturn(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR);
         
+        Exception exception = new Exception("not important");
+        
         // real test:
         Result result = ninjaDefault.getInternalServerErrorResult(
                 contextImpl,
-                new Exception("not important"));
+                exception, null);
         
         assertThat(result.getStatusCode(), equalTo(Result.SC_500_INTERNAL_SERVER_ERROR));
         assertThat(result.getTemplate(), equalTo(NinjaConstant.LOCATION_VIEW_FTL_HTML_INTERNAL_SERVER_ERROR));
@@ -336,6 +396,12 @@ public class NinjaDefaultTest {
             Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_INTERNAL_SERVER_ERROR_TEXT_DEFAULT), 
             Matchers.eq(contextImpl),
             any(Optional.class));
+
+        verify(messages).getWithDefault(
+                Matchers.eq(exception.getMessage()), 
+                Matchers.eq(exception.getLocalizedMessage()), 
+                Matchers.eq(contextImpl),
+                any(Optional.class));
         
         verify(ninjaProperties).getWithDefault(
                 Matchers.eq(NinjaConstant.LOCATION_VIEW_HTML_INTERNAL_SERVER_ERROR_KEY), 
@@ -346,7 +412,7 @@ public class NinjaDefaultTest {
     @Test
     public void testThatGetBadRequestContentNegotiation() throws Exception {
        Mockito.when(contextImpl.getAcceptContentType()).thenReturn(Result.APPLICATION_JSON);
-       Result result = ninjaDefault.getBadRequestResult(contextImpl, new Exception("not important"));
+       Result result = ninjaDefault.getBadRequestResult(contextImpl, new BadRequestException("not important"));
        assertThat(result.getContentType(), equalTo(null));
        assertThat(result.supportedContentTypes().size(), equalTo(3));
 
@@ -355,7 +421,7 @@ public class NinjaDefaultTest {
     @Test
     public void testThatGetBadRequestDoesFallsBackToHtml() throws Exception {
         Mockito.when(contextImpl.getAcceptContentType()).thenReturn("not_supported");
-        Result result = ninjaDefault.getBadRequestResult(contextImpl, new Exception("not important"));
+        Result result = ninjaDefault.getBadRequestResult(contextImpl, new BadRequestException("not important"));
         assertThat(result.fallbackContentType().get(), equalTo(Result.TEXT_HTML));
     }
     
@@ -367,10 +433,12 @@ public class NinjaDefaultTest {
                 Matchers.eq(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST)))
                 .thenReturn(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST);
 
+        BadRequestException exception = new BadRequestException("not important");
+        
         // real test:
         Result result = ninjaDefault.getBadRequestResult(
                 contextImpl,
-                new BadRequestException("not important"));
+                exception);
         
         assertThat(result.getStatusCode(), equalTo(Result.SC_400_BAD_REQUEST));
         assertThat(result.getTemplate(), equalTo(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST));
@@ -382,9 +450,69 @@ public class NinjaDefaultTest {
             Matchers.eq(contextImpl),
             any(Optional.class));
         
+        verify(messages).getWithDefault(
+                Matchers.eq(exception.getMessage()), 
+                Matchers.eq(exception.getLocalizedMessage()), 
+                Matchers.eq(contextImpl),
+                any(Optional.class));
+        
         verify(ninjaProperties).getWithDefault(
                 Matchers.eq(NinjaConstant.LOCATION_VIEW_HTML_BAD_REQUEST_KEY), 
                 Matchers.eq(NinjaConstant.LOCATION_VIEW_FTL_HTML_BAD_REQUEST));
+                
+    }
+    
+
+    @Test
+    public void testThatGetForbiddenRequestContentNegotiation() throws Exception {
+       Mockito.when(contextImpl.getAcceptContentType()).thenReturn(Result.APPLICATION_JSON);
+       Result result = ninjaDefault.getForbiddenResult(contextImpl, new ForbiddenRequestException("not important"));
+       assertThat(result.getContentType(), equalTo(null));
+       assertThat(result.supportedContentTypes().size(), equalTo(3));
+
+    }
+        
+    @Test
+    public void testThatGetForbiddenRequestDoesFallsBackToHtml() throws Exception {
+        Mockito.when(contextImpl.getAcceptContentType()).thenReturn("not_supported");
+        Result result = ninjaDefault.getForbiddenResult(contextImpl, new ForbiddenRequestException("not important"));
+        assertThat(result.fallbackContentType().get(), equalTo(Result.TEXT_HTML));
+    }
+    
+    @Test
+    public void testGetForbiddenRequest() throws Exception {
+        
+        when(ninjaProperties.getWithDefault(
+                Matchers.eq(NinjaConstant.LOCATION_VIEW_HTML_FORBIDDEN_KEY), 
+                Matchers.eq(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN)))
+                .thenReturn(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN);
+
+        ForbiddenRequestException exception = new ForbiddenRequestException("not important");
+        
+        // real test:
+        Result result = ninjaDefault.getForbiddenResult(
+                contextImpl,
+                exception);
+        
+        assertThat(result.getStatusCode(), equalTo(Result.SC_403_FORBIDDEN));
+        assertThat(result.getTemplate(), equalTo(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN));
+        assertTrue(result.getRenderable() instanceof Message);
+
+        verify(messages).getWithDefault(
+            Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_KEY), 
+            Matchers.eq(NinjaConstant.I18N_NINJA_SYSTEM_FORBIDDEN_REQUEST_TEXT_DEFAULT), 
+            Matchers.eq(contextImpl),
+            any(Optional.class));
+        
+        verify(messages).getWithDefault(
+                Matchers.eq(exception.getMessage()), 
+                Matchers.eq(exception.getLocalizedMessage()), 
+                Matchers.eq(contextImpl),
+                any(Optional.class));
+        
+        verify(ninjaProperties).getWithDefault(
+                Matchers.eq(NinjaConstant.LOCATION_VIEW_HTML_FORBIDDEN_KEY), 
+                Matchers.eq(NinjaConstant.LOCATION_VIEW_FTL_HTML_FORBIDDEN));
                 
     }
     

--- a/ninja-core/src/test/java/ninja/diagnostics/DiagnosticErrorRendererTest.java
+++ b/ninja-core/src/test/java/ninja/diagnostics/DiagnosticErrorRendererTest.java
@@ -80,7 +80,7 @@ public class DiagnosticErrorRendererTest {
         when(context.getContextPath()).thenReturn("/");
         when(context.getAttributes()).thenReturn(ImmutableMap.of("TEST-ATTR", (Object)"Attribute with < > & entities"));
         
-        Result testResult = ninja.getInternalServerErrorResult(context, new Exception("Exception message with < > & entities"));
+        Result testResult = ninja.getInternalServerErrorResult(context, new Exception("Exception message with < > & entities"), null);
         
         // renderable in testResult is the DiagnosticError
         


### PR DESCRIPTION
Here is some work on the error management part.

- I added the **ForbiddenRequestException** type, along with the BadRequest and InternalError ; so that it's possible to fire a 403 error at any time, potentially with a root cause. Without this it's only possible to *return* forbidden results, which sometimes could lead to a strange code structure (when doing access check at lower levels).

- I added an error attribute in the Message POJO (used to display errors) that will handle the exception message, so that it can be displayed on the error page. (But not the default behavior.)

- Furthermore, this exception message can be a message key that will be taken from the messages.properties files. You can now throw an exception with an message key as message, to find it back translated in your error page, along with the generic error page text.

Doc updated to represent these changes. I don't see any backward incompatibility, as all parts are additions. Except for method signatures changed in the main Ninja interface, but it's not a big deal I think.

What do you think? :-)