### PR TITLE
Empty String parser "shortcut"

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ParamParsers.java
+++ b/ninja-core/src/main/java/ninja/params/ParamParsers.java
@@ -386,6 +386,22 @@ public class ParamParsers {
             return String.class;
         }
     }
+    
+    public static class EmptyStringParamParser implements ParamParser<String> {
+        @Override
+        public String parseParameter(String field, String parameterValue, Validation validation) {
+            if (parameterValue == null || validation.hasViolation(field)) {
+                return null;
+            } else {
+                return parameterValue;
+            }
+        }
+
+        @Override
+        public Class<String> getParsedType() {
+            return String.class;
+        }
+    }
 
     public static class ByteParamParser implements ParamParser<Byte> {
         @Override

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
@@ -42,7 +42,7 @@ explicitely need empty strings for empty given parameters, register the
 `ParamParsers.EmptyStringParamParser` in your conf.Module <code>configure()</code> method:
 
 <pre class="prettyprint">
-Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+Multibinder&lt;ParamParser&gt; parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
 parsersBinder.addBinding().to(ParamParsers.EmptyStringParamParser.class);
 </pre>
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
@@ -31,10 +31,20 @@ This allows you to process a request, extract things
 - Arrays of all these types (e.g. String[], int[], Enum[])
 
 **NOTES:**
+
 Enums do not require anymore a registration in conf.Module. Values are 
 converted automatically, ignoring case. Collections and generics are not 
 supported for parameter injection. Types must be explicitly declared 
 and basic arrays must be used to ensure runtime type-safety.
+
+By default, empty String parameters will be treated as null values. If you 
+explicitely need empty strings for empty given parameters, register the 
+`ParamParsers.EmptyStringParamParser` in your conf.Module <code>configure()</code> method:
+
+<pre class="prettyprint">
+Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+parsersBinder.addBinding().to(ParamParsers.EmptyStringParamParser.class);
+</pre>
 
 ### Custom Parameter Types
 

--- a/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
+++ b/ninja-core/src/test/java/ninja/params/ParamParsersTest.java
@@ -85,6 +85,17 @@ public class ParamParsersTest {
     }
 
     @Test
+    public void testEmptyStringParamParser() {
+        ParamParsers.EmptyStringParamParser stringParamParser = new ParamParsers.EmptyStringParamParser();
+
+        assertThat(stringParamParser.getParsedType(), Matchers.is(String.class));
+
+        assertThat(stringParamParser.parseParameter("param1", null, validation), Matchers.nullValue());
+        assertThat(stringParamParser.parseParameter("param1", "", validation), Matchers.emptyString());
+        assertThat(stringParamParser.parseParameter("param1", "asdfasdf", validation), Matchers.is(new String("asdfasdf")));
+    }
+    
+    @Test
     public void testIntegerParamParser() {
         ParamParsers.IntegerParamParser integerParamParser = new ParamParsers.IntegerParamParser();
 


### PR DESCRIPTION
As it has been discussed twice (once in the PR, once in an open issue), I thought it was better to document (on the main site) the fact that empty string parameters would give null values by default... And providing a quick shortcut (2 lines now) to change that behavior.