### PR TITLE
BodyParserEngine for multipart/form-data

### DIFF
--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipartPost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipartPost.java
@@ -1,0 +1,20 @@
+package ninja.bodyparser;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import ninja.params.ParamParsers;
+
+@Singleton
+public class BodyParserEngineMultipartPost extends BodyParserEnginePost {
+
+    @Inject
+    public BodyParserEngineMultipartPost(ParamParsers paramParsers) {
+        super(paramParsers);
+    }
+
+    public String getContentType() {
+        return "multipart/form-data";
+    }
+
+}

--- a/ninja-core/src/main/java/ninja/conf/NinjaClassicModule.java
+++ b/ninja-core/src/main/java/ninja/conf/NinjaClassicModule.java
@@ -29,6 +29,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.OptionalBinder;
 import ninja.bodyparser.BodyParserEngineJson;
+import ninja.bodyparser.BodyParserEngineMultipartPost;
 import ninja.bodyparser.BodyParserEnginePost;
 import ninja.bodyparser.BodyParserEngineXml;
 import ninja.migrations.MigrationEngine;
@@ -114,6 +115,7 @@ public class NinjaClassicModule extends AbstractModule {
         // Text & post require no 3rd party libs
         bind(TemplateEngineText.class);
         bind(BodyParserEnginePost.class);
+        bind(BodyParserEngineMultipartPost.class);
         
         // Freemarker
         if (freemarker) {

--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -273,7 +273,7 @@ abstract public class AbstractContext implements Context.Impl {
                 .getBodyParserEngineForContentType(contentTypeOnly);
 
         if (bodyParserEngine == null) {
-            logger.debug("No BodyParserEngine found for Content-Type {} at route {}", CONTENT_TYPE, getRequestPath());
+            logger.debug("No BodyParserEngine found for Content-Type {} at route {}", contentTypeOnly, getRequestPath());
             return null;
         }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,4 @@
+* 2018-09-05 Added `BodyParserEngineMultipartPost` (jlannoy)
 * 2018-08-23 Updated libraries (jlannoy)
     * com.fasterxml.jackson.core:jackson-* ...................... 2.8.1 -> 2.9.6
     * com.google.guava:guava .................................... 19.0 -> 26.0-jre

--- a/ninja-core/src/site/markdown/documentation/uploading_files.md
+++ b/ninja-core/src/site/markdown/documentation/uploading_files.md
@@ -12,14 +12,17 @@ files.
 
 
 Usually you render a form that links to the controller that will handle the
-upload. In the following case we are using a route to <code>/uploadFinish</code>.
+upload. In the following case we are using a route to <code>/upload</code>.
 
 <pre class="prettyprint">
-&lt;form method=&quot;post&quot; enctype=&quot;multipart/form-data&quot; action=&quot;/uploadFinish&quot;&gt;
+&lt;form method=&quot;post&quot; enctype=&quot;multipart/form-data&quot; action=&quot;/upload&quot;&gt;
     Please specify file to upload: &lt;input type=&quot;file&quot; name=&quot;upfile&quot;&gt;&lt;br /&gt;
     &lt;input type=&quot;submit&quot; value=&quot;submit&quot;&gt;
 &lt;/form&gt;
 </pre>
+
+Note that you'll be able to still get your other form values inside a proper DTO : 
+<code>public Result upload(Context context, MyDto formObject, @Param("file") File file) { ... }</code>.
 
 The manual default way
 --------------

--- a/ninja-servlet-integration-test/src/main/java/conf/Routes.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Routes.java
@@ -179,6 +179,7 @@ public class Routes implements ApplicationRoutes {
         router.GET().route("/upload").with(UploadController::upload);
         router.POST().route("/uploadFinish").with(UploadController::uploadFinish);
         router.POST().route("/uploadFinishAuto").with(UploadControllerAuto::uploadFinishAuto);
+        router.POST().route("/uploadWithForm").with(UploadControllerAuto::postFormWithFile);
         
         // /////////////////////////////////////////////////////////////////////
         // Authenticity

--- a/ninja-servlet-integration-test/src/main/java/controllers/UploadControllerAuto.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/UploadControllerAuto.java
@@ -46,6 +46,9 @@ import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import models.FormObject;
+import models.FormWithFile;
+
 @Singleton
 public class UploadControllerAuto {
 
@@ -102,6 +105,16 @@ public class UploadControllerAuto {
 
         return Results.ok().renderRaw(sb.toString().getBytes());
 
+    }
+    
+    /**
+     * This upload method expects a form with one file and simply sends back the form as a json object,
+     * with the fact that a file have been received too.
+     */
+    @FileProvider(DiskFileItemProvider.class)
+    public Result postFormWithFile(Context context, FormWithFile formObject, @Param("file") File file) {
+        formObject.fileReceived = file != null ? file.exists() : Boolean.FALSE;
+        return Results.json().render(formObject);
     }
 
 }

--- a/ninja-servlet-integration-test/src/main/java/models/FormWithFile.java
+++ b/ninja-servlet-integration-test/src/main/java/models/FormWithFile.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models;
+
+public class FormWithFile {
+
+    public String name;
+
+    public String email;
+
+    public boolean fileReceived;
+
+}

--- a/ninja-servlet-integration-test/src/test/java/controllers/UploadControllerAutoTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/UploadControllerAutoTest.java
@@ -17,34 +17,42 @@
 package controllers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Map;
 
 import ninja.NinjaTest;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+
+import models.FormWithFile;
+
 public class UploadControllerAutoTest extends NinjaTest {
-	
-	@Test
-	public void testThatUploadWorks() throws FileNotFoundException, IOException {
-		
+
+    @Test
+    public void testThatUploadWorks()
+            throws FileNotFoundException, IOException {
+
         File file = new File("src/test/resources/test_for_upload.txt");
         File file2 = new File("src/test/resources/test_for_upload_2.txt");
-		
-		// Let's upload a simple txt file...
-		String result = ninjaTestBrowser
-				.uploadFiles(getServerAddress() + "uploadFinishAuto",
-				        new String[] {"file","file","file2"},
-				        new File[] { file, file2, file2 } );
 
-		// compute excepted result
+        // Let's upload a simple txt file...
+        String result = ninjaTestBrowser.uploadFiles(
+                getServerAddress() + "uploadFinishAuto",
+                new String[] { "file", "file", "file2" },
+                new File[] { file, file2, file2 });
+
+        // compute excepted result
         StringBuilder sb = new StringBuilder();
-        
+
         String strFile = IOUtils.toString(new FileInputStream(file));
         String strFile2 = IOUtils.toString(new FileInputStream(file2));
         // file
@@ -67,11 +75,38 @@ public class UploadControllerAutoTest extends NinjaTest {
         // file2
         sb.append("file2\n").append(strFile2).append("\n");
 
-		// The upload simply displays back the file we uploaded.
-		// Let's see if that has worked...
-        
-		assertEquals(sb.toString(), result);
+        // The upload simply displays back the file we uploaded.
+        // Let's see if that has worked...
 
-	}
-	
+        assertEquals(sb.toString(), result);
+
+    }
+
+
+    @Test
+    public void testPostFormWithFile() throws IOException {
+
+        File file = new File("src/test/resources/test_for_upload.txt");
+
+        Map<String, String> formParameters = Maps.newHashMap();
+
+        formParameters.put("name", "tester");
+        formParameters.put("email", "test@email.com");
+        
+        // Let's upload a simple txt file...
+        String result = ninjaTestBrowser
+                .uploadFileWithForm(getServerAddress() + "uploadWithForm", 
+                        "file", file, formParameters);
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        FormWithFile returnedObject = objectMapper.readValue(result, FormWithFile.class);
+
+        // And assert that returned object has same values
+        assertEquals("tester", returnedObject.name);
+        assertEquals("test@email.com", returnedObject.email);
+        assertTrue(returnedObject.fileReceived);
+        
+    }
+
+
 }

--- a/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/NinjaTestBrowser.java
@@ -35,9 +35,12 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.mime.FormBodyPart;
+import org.apache.http.entity.mime.FormBodyPartBuilder;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.CoreProtocolPNames;
@@ -249,6 +252,48 @@ public class NinjaTestBrowser {
             // For File parameters
             entity.addPart(paramName, new FileBody((File) fileToUpload));
 
+            post.setEntity(entity);
+
+            // Here we go!
+            response = EntityUtils.toString(httpClient.execute(post)
+                    .getEntity(), "UTF-8");
+            post.releaseConnection();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return response;
+
+    }
+    
+    public String uploadFileWithForm(String url, String paramName, File fileToUpload, Map<String, String> formParameters) {
+
+        String response = null;
+
+        try {
+
+            httpClient.getParams().setParameter(
+                    CoreProtocolPNames.PROTOCOL_VERSION, HttpVersion.HTTP_1_1);
+
+            HttpPost post = new HttpPost(url);
+
+            MultipartEntity entity = new MultipartEntity(
+                    HttpMultipartMode.BROWSER_COMPATIBLE);
+
+            // For File parameters
+            entity.addPart(paramName, new FileBody((File) fileToUpload));
+
+            // add form parameters:
+            if (formParameters != null) {
+
+                for (Entry<String, String> parameter : formParameters
+                        .entrySet()) {
+                    entity.addPart(parameter.getKey(), new StringBody(parameter.getValue()));
+                }
+
+            }
+            
             post.setEntity(entity);
 
             // Here we go!


### PR DESCRIPTION
Quick addition that allow to parse a posted object (like the original BodyParserEnginePost, which I extended) but with uploaded files in the same request.