### PR TITLE
Ninja's main site update (via markdown processor)

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -179,7 +179,7 @@ Version 5.2.2
 Version 5.2.1
 =============
 
- * 2015-10-16 Context.getParameterFileItems() now returns Map<String, List<FileItem>> (jjlauer)
+ * 2015-10-16 Context.getParameterFileItems() now returns `Map<String, List<FileItem>>` (jjlauer)
 
 Version 5.2.0
 =============

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/argument_extractors.md
@@ -43,7 +43,7 @@ simply by implementing the <code>ParamParser</code> interface and binding it
 with Guice in your conf.Module <code>configure()</code> method:
 
 <pre class="prettyprint">
-Multibinder<ParamParser> parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
+Multibinder&lt;ParamParser&gt; parsersBinder = Multibinder.newSetBinder(binder(), ParamParser.class);
 parsersBinder.addBinding().to(MyParamParser.class);
 </pre>
  

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/controllers.md
@@ -23,7 +23,6 @@ public class AppController {
         return Results.html();
     }
 
-
 }
 </pre>
 
@@ -56,7 +55,7 @@ in the routing section).
 Let's say and the user visits the following URL...
 
 <pre class="prettyprint">
-/user/12345/my@email.com/userDashboard?debug=false&filters=new&filters=urgent
+/user/12345/my@email.com/userDashboard?debug=false&amp;filters=new&amp;filters=urgent
 </pre>
 
 ... and we got a route definition like that:
@@ -180,8 +179,8 @@ ninja.strict_argument_extractors=true         # redirects to Bad Request page if
 
 Then
 
-* use Optional (eg Optional&lt;String&gt; debug) when the parameter may be supplied by the user - or not.
-* don't use Optional (eg Boolean isAdmin) if you expect the parameter to be there.
+* use Optional (eg `Optional<String> debug`) when the parameter may be supplied by the user - or not.
+* don't use Optional (eg `Boolean isAdmin`) if you expect the parameter to be there.
   If the parameter is not supplied by a user request then Ninja issues a Bad Request. Your controller method
   code will never be executed.
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/filters.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/filters.md
@@ -208,7 +208,7 @@ public class Module extends AbstractModule {
 
 			@Override
 			public boolean validateCredentials(String username, String password) {
-				return "user".equals(username) && "password".equals(password);
+				return "user".equals(username) &amp;&amp; "password".equals(password);
 			}
 		});
     }

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
@@ -248,6 +248,7 @@ will be handled by the second route.
 Values of variable parts of a route are injected into our controller (explained above)
 and are implicitly validated with regular expressions.
 So our controller for routes above would be like that (look at <code>@PathParam</code> argument types):
+
 <pre class="prettyprint">
 package controllers;
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/sessions.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/sessions.md
@@ -109,7 +109,7 @@ also be set in code using <code>setExpiryTime()</code>:
 public Result login(@Param("rememberMe") Boolean rememberMe,
                     Session session) {
 
-    if (rememberMe != null && rememberMe) {
+    if (rememberMe != null &amp;&amp; rememberMe) {
         // Set the expiry time 30 days (in milliseconds) in the future
         session.setExpiryTime(30 * 24 * 60 * 60 * 1000L);
     } else {

--- a/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
+++ b/ninja-core/src/site/markdown/documentation/configuration_and_modes.md
@@ -194,19 +194,23 @@ public class Ninja extends NinjaDefault {
 </pre>
 
 Configuring application's base package
-------------------------------------
+--------------------------------------
 
 If you'd like to keep all Java code in specific package you can define
 <pre class="prettyprint">
 application.modules.package=com.someorganinization.somepackage
 </pre>
 
-In this case you must put your Routes at<br>
-<code>com.someorganization.somepackage.conf.Routes.java</code>
+In this case you must put your Routes at 
 
-and Guice application configuration modules at<br>
+<code>com.someorganization.somepackage.conf.Routes.java</code> 
+
+and Guice application configuration modules at
+
 <code>com.someorganization.somepackage.conf.Module.java</code>
+
 <code>com.someorganization.somepackage.conf.ServletModule.java</code>
+
 accordingly.
 
 

--- a/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_recycled_tester.md
+++ b/ninja-core/src/site/markdown/documentation/testing_your_application/ninja_recycled_tester.md
@@ -31,5 +31,3 @@ public class MyControllerTest extends RecycledNinjaServerTester {
 
 If you want to revert back to a single Ninja test server for each test method,
 you can simply extend your class from FreshNinjaServerTester.
-
-</pre>

--- a/ninja-core/src/site/markdown/documentation/websockets.md
+++ b/ninja-core/src/site/markdown/documentation/websockets.md
@@ -80,7 +80,7 @@ can then accept/reject the handshake request or save any variables you'll want
 to access later once the WebSocket session is established.
 
 <pre class="prettyprint">
-public class ChatWebSocket extends Endpoint implements MessageHandler.Whole<String> {
+public class ChatWebSocket extends Endpoint implements MessageHandler.Whole&lt;String&gt; {
     
     public Result handshake(Context context, WebSocketHandshake handshake) {
         // negotiate the protocol (not always used by clients)

--- a/ninja-core/src/site/markdown/index.md
+++ b/ninja-core/src/site/markdown/index.md
@@ -1,3 +1,5 @@
+Java web framework
+==================
 
 <div class="hero-unit">
 	<p><b>Ninja</b> is a <b>full stack web framework</b> for <b>Java</b>.</p>

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -17,7 +17,7 @@ That leadership role is currently performed by:
 
 Ninja is proudly sponsored by <a href="https://www.greenback.com">Greenback</a>
 
-<a href="https://www.greenback.com" title="Greenback - Expenses made simple"><img src="https://www.greenback.com/assets/images/logo-greenback.png" height="48" width="166" alt="Greenback"></a>
+<a href="https://www.greenback.com" title="Greenback - Expenses made simple"><img src="https://www.greenback.com/assets/images/logo-greenback.png" height="48" width="166" alt="Greenback" /></a>
 
 <a href="https://www.greenback.com" title="Greenback - Expenses made simple">More engineering. Less paperwork. Expenses made simple.</a>
 
@@ -64,7 +64,7 @@ contributed to Ninja. In some random order:
  * Pedro Sena Tanaka (pedro-stanaka)
  * Azilet Beishenaliev (bazi)
  * Andrew Berglund (t3hc13h)
- * Jonathan Lannoy (jlannoy)
+ * Jonathan Lannoy [(jlannoy)](https://github.com/jlannoy)
  * Matthias Lemmer (raptaml)
  * Lukas Eichler (lukaseichler)
  * Sven Kubiak (svenkubiak)

--- a/ninja-core/src/site/site.xml
+++ b/ninja-core/src/site/site.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/DECORATION/1.1.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/DECORATION/1.1.0 http://maven.apache.org/xsd/decoration-1.1.0.xsd"
-         name="Ninja - full stack web framework for Java">
+         name="Ninja">
 
 
     <publishDate position="right"/>

--- a/pom.xml
+++ b/pom.xml
@@ -194,9 +194,9 @@
 
                     <dependencies>
                         <dependency>
-                            <groupId>net.ju-n.maven.doxia</groupId>
+                            <groupId>org.apache.maven.doxia</groupId>
                             <artifactId>doxia-module-markdown</artifactId>
-                            <version>1.0.0</version>
+                            <version>1.5</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
By upgrading to the version 1.5 of the markdown processor (for the maven site plugin), it will allow to have dynamic page titles (better for search/index/tabs) along with an anchor for each subtitle.

This update was requiring some fixes, as the new version is more strict with the html special characters not in _code_ tags. Btw, I generated the site locally to check that it wasn't broking any existing layout or content.