### PR TITLE
Fix jetty context path config

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,4 @@
+* 2018-09-09 Jetty context configuration fixed (jlannoy)
 * 2018-08-23 Updated libraries (jlannoy)
     * com.fasterxml.jackson.core:jackson-* ...................... 2.8.1 -> 2.9.6
     * com.google.guava:guava .................................... 19.0 -> 26.0-jre

--- a/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-archetype-simple/src/main/resources/archetype-resources/pom.xml
@@ -58,7 +58,9 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>
-                    <contextPath>/</contextPath>
+                    <webApp>
+                        <contextPath>/</contextPath>
+                    </webApp>
                     <stopKey>stop</stopKey>
                     <stopPort>8889</stopPort>
                     <scanIntervalSeconds>1</scanIntervalSeconds>

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -48,7 +48,9 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <contextPath>/</contextPath>
+                    <webApp>
+                        <contextPath>/</contextPath>
+                    </webApp>
                     <stopKey>stop</stopKey>
                     <stopPort>8889</stopPort>					
                     <scanIntervalSeconds>1</scanIntervalSeconds>

--- a/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-servlet-jpa-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -57,7 +57,9 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>
-                    <contextPath>/</contextPath>
+                    <webApp>
+                        <contextPath>/</contextPath>
+                    </webApp>
                     <stopKey>stop</stopKey>
                     <stopPort>8889</stopPort>
                     <scanIntervalSeconds>1</scanIntervalSeconds>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -54,7 +54,9 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <contextPath>/</contextPath>
+                    <webApp>
+                        <contextPath>/</contextPath>
+                    </webApp>
                     <stopKey>stop</stopKey>
                     <stopPort>8889</stopPort>
                     <scanIntervalSeconds>1</scanIntervalSeconds>


### PR DESCRIPTION
According to the documentation, the contextPath was misplaced, and anyone trying to change it would have no effect. https://www.eclipse.org/jetty/documentation/9.4.x/jetty-maven-plugin.html
Replace PR #276 