### PR TITLE
Postoffice STARTTLS support

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -3,6 +3,7 @@ Version 6.4.1
 
 * Bumping Jetty to latest version (See CVE-2017-7658)
 * Tiny fix to allow compilation and tests to work on Mac OS X Mojave (smtp port too low)
+* 2018-11-08 Added STARTTLS support to the default Postoffice implementation (pi0tr)
 
 Version 6.4.0
 =============

--- a/ninja-core/src/site/markdown/documentation/sending_mail.md
+++ b/ninja-core/src/site/markdown/documentation/sending_mail.md
@@ -45,12 +45,14 @@ Configuration and basic usage
 onfigure your mail server in application.conf via the following parameters:
 
 <pre class="prettyprint">
-smtp.host=...     // Hostname of the smtp server (e.g. smtp.mycompany.com)
-smtp.port=...     // Port of the smtp server  (e.g. 465).
-smtp.ssl=...      // Whether to enable ssl (true or false)
-smtp.user=...     // Username to access the smtp server
-smtp.password=... // The password
-smtp.debug=...    // Enable logging of a huge amount of debug information (true or false)
+smtp.host=...               // Hostname of the smtp server (e.g. smtp.mycompany.com)
+smtp.port=...               // Port of the smtp server  (e.g. 465).
+smtp.ssl=...                // Whether to enable SSL (true or false, default is false)
+smtp.starttls=...           // Whether to enable STARTTLS (true or false, default is false)
+smtp.starttls.required=...  // Whether to enforce using STARTTLS (true or false, default is false)
+smtp.user=...               // Username to access the smtp server
+smtp.password=...           // The password
+smtp.debug=...              // Enable logging of a huge amount of debug information (true or false)
 </pre>
 
 

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -77,6 +77,7 @@ contributed to Ninja. In some random order:
  * Nate Kingsley (nate-kingsley)
  * Jens Fendler (jfendler)
  * Christian Groth (christiangroth)
+ * Piotr Kuciapski (pi0tr)
  
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-postoffice/src/main/java/ninja/postoffice/PostofficeConstant.java
+++ b/ninja-postoffice/src/main/java/ninja/postoffice/PostofficeConstant.java
@@ -27,6 +27,10 @@ public interface PostofficeConstant {
 
     public static final String smtpSsl = "smtp.ssl";
 
+    public static final String smtpStartTLS = "smtp.starttls";
+
+    public static final String smtpStartTLSRequired = "smtp.starttls.required";
+
     public static final String smtpUser = "smtp.user";
 
     public static final String smtpPassword = "smtp.password";

--- a/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/CommonsmailHelper.java
+++ b/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/CommonsmailHelper.java
@@ -44,7 +44,8 @@ public interface CommonsmailHelper {
     public MultiPartEmail createMultiPartEmailWithContent(Mail mail) throws EmailException;
 
     public void doSetServerParameter(MultiPartEmail multiPartEmail, String smtpHost,
-            Integer smtpPort, Boolean smtpSsl, String smtpUser, String smtpPassword,
+            Integer smtpPort, Boolean smtpSsl, Boolean smtpStartTLS, Boolean smtpStartTLSRequired,
+            String smtpUser, String smtpPassword,
             Boolean smtpDebug);
 
     public List<Tuple<String, String>> createListOfAddresses(Collection<String> emails)

--- a/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/CommonsmailHelperImpl.java
+++ b/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/CommonsmailHelperImpl.java
@@ -143,13 +143,16 @@ public class CommonsmailHelperImpl implements CommonsmailHelper {
 
     @Override
     public void doSetServerParameter(MultiPartEmail multiPartEmail, String smtpHost,
-            Integer smtpPort, Boolean smtpSsl, String smtpUser, String smtpPassword,
+            Integer smtpPort, Boolean smtpSsl, Boolean smtpStartTLS, Boolean smtpStartTLSRequired,
+            String smtpUser, String smtpPassword,
             Boolean smtpDebug) {
 
         // /set config params:
         multiPartEmail.setHostName(smtpHost);
         multiPartEmail.setSmtpPort(smtpPort);
         multiPartEmail.setSSLOnConnect(smtpSsl);
+        multiPartEmail.setStartTLSEnabled(smtpStartTLS);
+        multiPartEmail.setStartTLSRequired(smtpStartTLSRequired);
 
         if (smtpUser != null) {
             multiPartEmail.setAuthentication(smtpUser, smtpPassword);

--- a/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/PostofficeCommonsmailImpl.java
+++ b/ninja-postoffice/src/main/java/ninja/postoffice/commonsmail/PostofficeCommonsmailImpl.java
@@ -35,6 +35,8 @@ public class PostofficeCommonsmailImpl implements Postoffice {
     private final String smtpHost;
     private final int smtpPort;
     private final boolean smtpSsl;
+    private final boolean smtpStartTLS;
+    private final boolean smtpStartTLSRequired;
     private final String smtpUser;
     private final String smtpPassword;
     private final boolean smtpDebug;
@@ -60,6 +62,9 @@ public class PostofficeCommonsmailImpl implements Postoffice {
             this.smtpSsl = smtpSsl;
         }
 
+        this.smtpStartTLS = props.getBooleanWithDefault(PostofficeConstant.smtpStartTLS, false);
+        this.smtpStartTLSRequired = props.getBooleanWithDefault(PostofficeConstant.smtpStartTLSRequired, false);
+
         this.smtpUser = props.get(PostofficeConstant.smtpUser);
         this.smtpPassword = props.get(PostofficeConstant.smtpPassword);
 
@@ -73,12 +78,15 @@ public class PostofficeCommonsmailImpl implements Postoffice {
 
     // May be used for testing
     PostofficeCommonsmailImpl(CommonsmailHelper commonsmailHelper, String smtpHost,
-            int smtpPort, boolean smtpSsl, String smtpUser, String smtpPassword,
+            int smtpPort, boolean smtpSsl, boolean smtpStartTLS, boolean smtpStartTLSRequired,
+            String smtpUser, String smtpPassword,
             boolean smtpDebug) {
         this.commonsmailHelper = commonsmailHelper;
         this.smtpHost = smtpHost;
         this.smtpPort = smtpPort;
         this.smtpSsl = smtpSsl;
+        this.smtpStartTLS = smtpStartTLS;
+        this.smtpStartTLSRequired = smtpStartTLSRequired;
         this.smtpUser = smtpUser;
         this.smtpPassword = smtpPassword;
         this.smtpDebug = smtpDebug;
@@ -95,6 +103,7 @@ public class PostofficeCommonsmailImpl implements Postoffice {
 
         // set server parameters so we can send the MultiPartEmail:
         commonsmailHelper.doSetServerParameter(multiPartEmail, smtpHost, smtpPort, smtpSsl,
+                smtpStartTLS, smtpStartTLSRequired,
                 smtpUser, smtpPassword, smtpDebug);
 
         // And send it:

--- a/ninja-postoffice/src/test/java/ninja/postoffice/commonsmail/CommonsMailHelperImplGreenmailIntegrationTest.java
+++ b/ninja-postoffice/src/test/java/ninja/postoffice/commonsmail/CommonsMailHelperImplGreenmailIntegrationTest.java
@@ -72,8 +72,8 @@ public class CommonsMailHelperImplGreenmailIntegrationTest {
         // setup the postoffice:
         CommonsmailHelper commonsmailHelper = new CommonsmailHelperImpl();
         Postoffice postoffice =
-                new PostofficeCommonsmailImpl(commonsmailHelper, "localhost", SMTP_TEST_PORT, false, null, null,
-                        false);
+                new PostofficeCommonsmailImpl(commonsmailHelper, "localhost", SMTP_TEST_PORT, false, false, false,
+                        null, null, false);
 
         postoffice.send(mail);
 

--- a/ninja-postoffice/src/test/java/ninja/postoffice/commonsmail/CommonsMailHelperImplTest.java
+++ b/ninja-postoffice/src/test/java/ninja/postoffice/commonsmail/CommonsMailHelperImplTest.java
@@ -148,6 +148,8 @@ public class CommonsMailHelperImplTest {
                 "mail.superserver.com",
                 33,
                 true,
+                false,
+                false,
                 "username",
                 "password",
                 true);
@@ -156,6 +158,28 @@ public class CommonsMailHelperImplTest {
         assertEquals("mail.superserver.com", multiPartEmail.getHostName());
         assertEquals(true, multiPartEmail.getMailSession().getDebug());
 
+    }
+
+    @Test
+    public void testDoSetServerParameterStartTLSEnabled() throws Exception {
+
+        Mail mail = MailImplTestHelper.getMailImplWithDemoContent();
+
+        MultiPartEmail multiPartEmail = commonsmailHelper.createMultiPartEmailWithContent(mail);
+
+        commonsmailHelper.doSetServerParameter(
+                multiPartEmail,
+                "mail.superserver.com",
+                33,
+                true,
+                true,
+                true,
+                "username",
+                "password",
+                true);
+
+        assertEquals(true, multiPartEmail.isStartTLSEnabled());
+        assertEquals(true, multiPartEmail.isStartTLSRequired());
 
     }
 


### PR DESCRIPTION
I added the option to enable STARTTLS in the default Postoffice CommonsMail implementation.