### PR TITLE
Fixing JaxyRoutes Reflections usage

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+* 2019-01-19 Fixing JaxyRoutes reflections scan, restricted to your `application.modules.package`
+
 Version 6.4.1
 =============
 

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -219,9 +219,9 @@ public class JaxyRoutes implements ApplicationRoutes {
      * Configures the set of packages to scan for annotated controller methods.
      */
     private void configureReflections() {
-        Optional<String> basePackage = Optional.of(ninjaProperties.get(NinjaConstant.APPLICATION_MODULES_BASE_PACKAGE));
+        Optional<String> basePackage = Optional.ofNullable(ninjaProperties.get(NinjaConstant.APPLICATION_MODULES_BASE_PACKAGE));
         
-        if(basePackage.isPresent()) {
+        if (basePackage.isPresent()) {
             reflections = new Reflections(
                     basePackage.get() + "." + NinjaConstant.CONTROLLERS_DIR, 
                     new MethodAnnotationsScanner());

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -18,7 +18,6 @@ package ninja.jaxy;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,20 +25,13 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-
-import ninja.Router;
-import ninja.application.ApplicationRoutes;
-import ninja.utils.NinjaConstant;
-import ninja.utils.NinjaMode;
-import ninja.utils.NinjaProperties;
 
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +39,12 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import ninja.Router;
+import ninja.application.ApplicationRoutes;
+import ninja.utils.NinjaConstant;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaProperties;
 
 /**
  * Implementation of a JAX-RS style route builder.
@@ -217,14 +215,21 @@ public class JaxyRoutes implements ApplicationRoutes {
         return methods;
     }
 
+    /**
+     * Configures the set of packages to scan for annotated controller methods.
+     */
     private void configureReflections() {
-        ConfigurationBuilder builder = new ConfigurationBuilder();
-
-        Set<URL> packagesToScan = getPackagesToScanForRoutes();
-        builder.addUrls(packagesToScan);
-
-        builder.addScanners(new MethodAnnotationsScanner());
-        reflections = new Reflections(builder);
+        Optional<String> basePackage = Optional.of(ninjaProperties.get(NinjaConstant.APPLICATION_MODULES_BASE_PACKAGE));
+        
+        if(basePackage.isPresent()) {
+            reflections = new Reflections(
+                    basePackage.get() + "." + NinjaConstant.CONTROLLERS_DIR, 
+                    new MethodAnnotationsScanner());
+        } else {
+            reflections = new Reflections(
+                    NinjaConstant.CONTROLLERS_DIR, 
+                    new MethodAnnotationsScanner()); 
+        }
     }
 
     /**
@@ -265,22 +270,6 @@ public class JaxyRoutes implements ApplicationRoutes {
         }
 
         return paths;
-    }
-
-    /**
-     * Returns the set of packages to scan for annotated controller methods.
-     *
-     * @return the set of packages to scan
-     */
-    public Set<URL> getPackagesToScanForRoutes() {
-
-        Set<URL> packagesToScanForRoutes = Sets.newHashSet();
-
-        packagesToScanForRoutes.addAll(ClasspathHelper
-                .forPackage(NinjaConstant.CONTROLLERS_DIR));
-
-        return packagesToScanForRoutes;
-
     }
 
     /**

--- a/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-jaxy-routes/src/test/java/controllers/ApplicationControllerTest.java
@@ -312,4 +312,24 @@ public class ApplicationControllerTest extends NinjaDocTester {
                 testServerUrl().path("/base/middle/app/")));
         Assert.assertThat(response.payload, CoreMatchers.equalTo("route without method path works."));
     }
+    
+    @Test
+    public void testShouldNotExistRoute() {
+
+        Response response = makeRequest(Request.GET().url(
+                testServerUrl().path("/not/get")));
+
+        Assert.assertThat(response.httpStatus, CoreMatchers.equalTo(404));
+
+    }
+    
+    @Test
+    public void testSubPackageControllerGet() {
+
+        Response response = makeRequest(Request.GET().url(
+                testServerUrl().path("/sub/get")));
+
+        Assert.assertThat(response.payload, CoreMatchers.equalTo("sub get works."));
+
+    }
 }

--- a/ninja-jaxy-routes/src/test/java/not/test/application/ForbiddenController.java
+++ b/ninja-jaxy-routes/src/test/java/not/test/application/ForbiddenController.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package not.test.application;
+
+import com.google.inject.Singleton;
+
+import ninja.Result;
+import ninja.Results;
+import ninja.jaxy.GET;
+import ninja.jaxy.Path;
+
+@Singleton
+@Path("/not")
+public class ForbiddenController {
+
+    @Path("/get")
+    @GET
+    public Result testAnnotatedGetRoute() {
+
+        return Results.text().render("should not exist");
+
+    }
+
+}

--- a/ninja-jaxy-routes/src/test/java/testapplication/controllers/sub/SubPackageController.java
+++ b/ninja-jaxy-routes/src/test/java/testapplication/controllers/sub/SubPackageController.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testapplication.controllers.sub;
+
+import com.google.inject.Singleton;
+
+import ninja.Result;
+import ninja.Results;
+import ninja.jaxy.GET;
+import ninja.jaxy.Path;
+
+@Singleton
+@Path("/sub")
+public class SubPackageController {
+
+    @Path("/get")
+    @GET
+    public Result testAnnotatedGetRoute() {
+
+        return Results.text().render("sub get works.");
+
+    }
+
+}


### PR DESCRIPTION
I discovered in my last project, using JaxyRoutes, that the scan for annotated route was going through the whole application (including all classes from all libraries exploded in the shaded jar). Causing a slower boot time and also reflection warnings.

After looking down to the Reflections library, I found [that PR](https://github.com/ronmamo/reflections/issues/178) explaining exactly the problem while using `ClasspathHelper.forPackage()` method. This pull request applies the indicated work around to ninja-jaxy-routes.

To test it right, one Controller was added **not** in the `application.modules.package` but outside it, then checking that the route doesn't exist.