### PR TITLE
Optional custom http methods

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+* 2019-02-14 Configuration property `ninja.jaxy.custom_http_methods` is now required to use custom HTTP methods annotations (jlannoy)
+
 Version 6.4.2
 =============
 

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
@@ -511,7 +511,7 @@ The following common HTTP method annotations are available:
 
 If the built-in methods are insufficient :
 
-1. Sets the key `ninja.jaxy.custom_http_methods` to `true` in your `conf/application.conf`.
+1. Set the key `ninja.jaxy.custom_http_methods` to `true` in your `conf/application.conf`.
 2. Then implement your own custom HTTP method:
 
     @Target(ElementType.METHOD)

--- a/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
+++ b/ninja-core/src/site/markdown/documentation/basic_concepts/routing.md
@@ -509,7 +509,10 @@ The following common HTTP method annotations are available:
 - `@POST`
 - `@PUT`
 
-If the built-in methods are insufficient, you may implement your own custom HTTP methods:
+If the built-in methods are insufficient :
+
+1. Sets the key `ninja.jaxy.custom_http_methods` to `true` in your `conf/application.conf`.
+2. Then implement your own custom HTTP method:
 
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -211,12 +211,24 @@ public class JaxyRoutes implements ApplicationRoutes {
         boolean enableCustomHttpMethods = ninjaProperties.getBooleanWithDefault(NINJA_CUSTOM_HTTP_METHODS, false);
         
         if (enableCustomHttpMethods) {
+            
             Reflections annotationReflections = new Reflections("", new TypeAnnotationsScanner(), new SubTypesScanner());
             for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
                 if (httpMethod.isAnnotation()) {
                     methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));
                 }
             }
+            
+        } else {
+            
+            // Only look for standard HTTP methods annotations
+            Reflections annotationReflections = new Reflections("ninja.jaxy", new TypeAnnotationsScanner(), new SubTypesScanner());
+            for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
+                if (httpMethod.isAnnotation()) {
+                    methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));
+                }
+            }
+            
         }
 
         return methods;

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -55,6 +55,8 @@ import ninja.utils.NinjaProperties;
 @Singleton
 public class JaxyRoutes implements ApplicationRoutes {
 
+    String NINJA_CUSTOM_HTTP_METHODS = "ninja.jaxy.custom_http_methods";
+    
     final static Logger logger = LoggerFactory.getLogger(JaxyRoutes.class);
 
     final NinjaProperties ninjaProperties;
@@ -205,10 +207,15 @@ public class JaxyRoutes implements ApplicationRoutes {
         Set<Method> methods = Sets.newLinkedHashSet();
 
         methods.addAll(reflections.getMethodsAnnotatedWith(Path.class));
-        Reflections annotationReflections = new Reflections("", new TypeAnnotationsScanner(), new SubTypesScanner());
-        for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
-            if (httpMethod.isAnnotation()) {
-                methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));
+        
+        boolean enableCustomHttpMethods = ninjaProperties.getBooleanWithDefault(NINJA_CUSTOM_HTTP_METHODS, false);
+        
+        if (enableCustomHttpMethods) {
+            Reflections annotationReflections = new Reflections("", new TypeAnnotationsScanner(), new SubTypesScanner());
+            for (Class<?> httpMethod : annotationReflections.getTypesAnnotatedWith(HttpMethod.class)) {
+                if (httpMethod.isAnnotation()) {
+                    methods.addAll(reflections.getMethodsAnnotatedWith((Class<? extends Annotation>) httpMethod));
+                }
             }
         }
 

--- a/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
+++ b/ninja-jaxy-routes/src/main/java/ninja/jaxy/JaxyRoutes.java
@@ -55,7 +55,7 @@ import ninja.utils.NinjaProperties;
 @Singleton
 public class JaxyRoutes implements ApplicationRoutes {
 
-    String NINJA_CUSTOM_HTTP_METHODS = "ninja.jaxy.custom_http_methods";
+    final static String NINJA_CUSTOM_HTTP_METHODS = "ninja.jaxy.custom_http_methods";
     
     final static Logger logger = LoggerFactory.getLogger(JaxyRoutes.class);
 


### PR DESCRIPTION
Following my last PR #647 ; restricting scan for methods was not sufficient. 

Jaxy Routes module also has a scanner used to look at custom HTTP methods annotations (if anyone needs more than the standard ones). But has there is no predicted package for theses annotations, the scanner looks through the whole application. It means that on the shaded JAR version of the application, the scanner go through a lot of classes, producing some warnings and time lost at boot time.

I think that the usage of custom http methods annotations is really a special use case, not needed in most case. It's even more true that this part is not covered by unit tests... And can not be ; as the doctester client can only execute requests with standard http methods.

To improve boot performance and avoid unnecessary warnings, I propose to set this Jaxy Route feature as optional, covered by a boolean configuration property.