### PR TITLE
Automatic CDN usage option

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,5 @@
+* 2019-02-15 Added `application.webjars.prefer_cdn` conf property to use JSDeliver for WebJars (jlannoy)
+
 Version 6.4.2
 =============
 

--- a/ninja-core/src/site/markdown/documentation/html_templating/implicit_functions.md
+++ b/ninja-core/src/site/markdown/documentation/html_templating/implicit_functions.md
@@ -110,12 +110,17 @@ This would then result in the following output: <code>/assets/css/custom.css</co
 
 ### webJarsAt(...)
 
-webJarsAt allows you to render webjar contents. For instance
+webJarsAt allows you to render webjar contents (see [Static assets](/documentation/static_assets.html) 
+for more information about WebJars. For instance 
 <code>${webJarsAt("bootstrap/3.3.4/css/bootstrap.min.css")}</code> would render
 a css file from a webJars jar. The corresponding route could be 
 <code>router.GET().route("/assets/webjars/{fileName: .*}").with(AssetsController.class, "serveWebJars");</code>.
 
-This would then result in the following output: <code>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</code>.
+This would then result in the following output: <code>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</code> 
+or <code>//cdn.jsdelivr.net/webjars/bootstrap/3.3.4/css/bootstrap.min.css</code> ; depending on your 
+<code>application.webjars.prefer_cdn</code> configuration property. You can always pass <code>true</code> as 
+a second argument of <code>webJarsAt</code> to force usage of a local webjar content. 
+
 
 ### i18n(...)
 

--- a/ninja-core/src/site/markdown/documentation/static_assets.md
+++ b/ninja-core/src/site/markdown/documentation/static_assets.md
@@ -78,7 +78,11 @@ You can reference Bootstrap from your HTML pages via the following URL:
 And Bootstrap is only an example. There are a lot more WebJars available at your
 disposal: jQuery, Ember.js, AngularJS and much more. 
 And everything without the need for downloading and updating stuff inside 
-your assets directory.
+your assets directory. 
+Furthermore, all classic WebJars are hosted on a public CDN via [jsDeliver](http://www.jsdelivr.com/). 
+Following [WebJars documentation](https://www.webjars.org/documentation), simply prefix your asset URL with 
+<code>//cdn.jsdelivr.net/webjars/</code> to use it. If you are using the Freemarker template engine, 
+the implicit function <code>webJarsAt</code> will manage both URL types creation based on a configuration property.
 
 <div class="alert alert-info">
 Actually WebJars do nothing magic. 

--- a/ninja-servlet-integration-test/src/main/java/conf/application.conf
+++ b/ninja-servlet-integration-test/src/main/java/conf/application.conf
@@ -15,6 +15,8 @@
 ##############################################################################
 application.name=ninja demo application
 
+application.webjars.prefer_cdn=true
+
 application.cookie.prefix=NINJA
 
 #ISO Language Code, optionally followed by a valid ISO Country Code. 

--- a/ninja-servlet-integration-test/src/main/java/views/ApplicationController/testReverseRouting.ftl.html
+++ b/ninja-servlet-integration-test/src/main/java/views/ApplicationController/testReverseRouting.ftl.html
@@ -3,6 +3,7 @@
         <ul>
             <li>${reverseRoute("controllers.ApplicationController", "userDashboard", "email", email, "id", id)}</li>
             <li>${webJarsAt("bootstrap/3.3.4/css/bootstrap.min.css")}</li>
+            <li>${webJarsAt("bootstrap/3.3.4/css/bootstrap.css", true)}</li>
             <li>${assetsAt("css/custom.css")}</li>    
         </ul>
     </body>

--- a/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/ApplicationControllerTest.java
@@ -311,7 +311,8 @@ public class ApplicationControllerTest extends RecycledNinjaServerTester {
                 ninjaTestBrowser.makeRequest(withBaseUrl("/test_reverse_routing"));
     
         assertThat(response, containsString("<li>/user/100000/me@me.com/userDashboard</li>"));
-        assertThat(response, containsString("<li>/assets/webjars/bootstrap/3.3.4/css/bootstrap.min.css</li>"));
+        assertThat(response, containsString("<li>//cdn.jsdelivr.net/webjars/bootstrap/3.3.4/css/bootstrap.min.css</li>"));
+        assertThat(response, containsString("<li>/assets/webjars/bootstrap/3.3.4/css/bootstrap.css</li>"));
         assertThat(response, containsString("<li>/assets/css/custom.css</li>"));
     }
     


### PR DESCRIPTION
Here is an option added to the webJarsAt implicit function allowing to use JSDeliver CDN in place of webjar dependency with only one boolean property.

All **classic** webjars (not bower ones) are hosted on public CDN js delivery with the same referring URL. I'm already using it on my projects, but it's quite simple to provide this as a base feature of Ninja (thanks to the webJarsAt implicit function).

https://www.webjars.org/documentation