### PR TITLE
Fix dependency conflict issue

### DIFF
--- a/ninja-metrics-librato/pom.xml
+++ b/ninja-metrics-librato/pom.xml
@@ -55,7 +55,7 @@ and limitations under the License. -->
         <dependency>
             <groupId>com.librato.metrics</groupId>
             <artifactId>metrics-librato</artifactId>
-            <version>4.0.1.7</version>
+            <version>4.1.2.0</version>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
Fix dependency conflict issue #654 by upgrading metrics-librato to 4.1.2.0.
Thanks.
