### PR TITLE
`Accept` content type fix

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -44,8 +44,6 @@ import ninja.Cookie;
 import ninja.Result;
 import ninja.Route;
 
-import javax.print.attribute.standard.Media;
-
 /**
  * Abstract Context.Impl that implements features that are not reliant
  * on the concrete Context implementation.  For example, a concrete implementation

--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -19,6 +19,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 
+import com.google.common.base.Strings;
 import ninja.bodyparser.BodyParserEngine;
 import ninja.bodyparser.BodyParserEngineManager;
 import ninja.params.ParamParsers;
@@ -332,7 +333,7 @@ abstract public class AbstractContext implements Context.Impl {
     public String getAcceptContentType() {
         String contentType = getHeader("accept");
 
-        if (contentType == null) {
+        if (Strings.isNullOrEmpty(contentType)) {
             return Result.TEXT_HTML;
         }
 
@@ -364,7 +365,7 @@ abstract public class AbstractContext implements Context.Impl {
             return Result.TEXT_HTML;
         }
 
-        return Result.TEXT_HTML;
+        return contentType;
     }
 
     @Override

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version x.x.x
 =============
 
+* 2019-09-20 Use customized content types in Accept header (fallback to text/html preserved for null and empty string)
 * 2019-07-20 New migration properties: `ninja.migration.locations` and `ninja.migration.schemas` (pi0tr)
 * 2019-05-05 Website now compatible with new maven site / doxia plugins
 

--- a/ninja-core/src/site/markdown/team.md
+++ b/ninja-core/src/site/markdown/team.md
@@ -78,6 +78,7 @@ contributed to Ninja. In some random order:
  * Jens Fendler (jfendler)
  * Christian Groth (christiangroth)
  * Piotr Kuciapski (pi0tr)
+ * Zalan Meggyesi (zmeggyesi)
  
 <div class="alert alert-info">
 Do you feel you are missing from that list? Please let us know - this did not happen

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -297,9 +297,15 @@ public class AbstractContextTest {
     }
 
     @Test
-    public void getAcceptContentType() {
+    public void getAcceptContentTypeLegacy() {
         AbstractContextImpl context = spy(abstractContext);
-        
+
+        doReturn("application/protobuf;q=1, application/json;q=0.7").when(context).getHeader("accept");
+        assertEquals("application/protobuf", context.getAcceptContentType());
+
+        doReturn("text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5").when(context).getHeader("accept");
+        assertEquals("text/html", context.getAcceptContentType());
+
         doReturn(null).when(context).getHeader("accept");
         assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
 
@@ -324,7 +330,45 @@ public class AbstractContextTest {
         doReturn("text/plain").when(context).getHeader("accept");
         assertEquals(Result.TEXT_PLAIN, context.getAcceptContentType());
 
-        doReturn("text/plain, application/json").when(context).getHeader("accept");
+        doReturn("application/json, text/plain").when(context).getHeader("accept");
+        assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
+    }
+
+    @Test
+    public void getAcceptContentType() {
+        AbstractContextImpl context = spy(abstractContext);
+
+        doReturn("application/protobuf;q=1, application/json;q=0.7").when(context).getHeader("accept");
+        assertEquals("application/protobuf", context.getAcceptContentType());
+
+        doReturn("text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5").when(context).getHeader("accept");
+        assertEquals("text/html", context.getAcceptContentType());
+
+        doReturn(null).when(context).getHeader("accept");
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        doReturn("").when(context).getHeader("accept");
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        doReturn("totally_unknown").when(context).getHeader("accept");
+        assertEquals("totally_unknown", context.getAcceptContentType());
+
+        doReturn("application/protobuf").when(context).getHeader("accept");
+        assertEquals("application/protobuf", context.getAcceptContentType());
+
+        doReturn("application/json").when(context).getHeader("accept");
+        assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
+
+        doReturn("text/html;q=1, application/json;q=0.9").when(context).getHeader("accept");
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        doReturn("application/xhtml;q=1, application/json;q=0.9").when(context).getHeader("accept");
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        doReturn("text/plain").when(context).getHeader("accept");
+        assertEquals(Result.TEXT_PLAIN, context.getAcceptContentType());
+
+        doReturn("text/plain;q=0.5, application/json;q=0.9").when(context).getHeader("accept");
         assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
     }
 

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -307,7 +307,10 @@ public class AbstractContextTest {
         assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
 
         doReturn("totally_unknown").when(context).getHeader("accept");
-        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+        assertEquals("totally_unknown", context.getAcceptContentType());
+
+        doReturn("application/protobuf").when(context).getHeader("accept");
+        assertEquals("application/protobuf", context.getAcceptContentType());
 
         doReturn("application/json").when(context).getHeader("accept");
         assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -341,6 +341,9 @@ public class AbstractContextTest {
         doReturn("application/protobuf;q=1, application/json;q=0.7").when(context).getHeader("accept");
         assertEquals("application/protobuf", context.getAcceptContentType());
 
+        doReturn("application/protobuf;q=0, application/json;q=0.7").when(context).getHeader("accept");
+        assertNotEquals("application/protobuf", context.getAcceptContentType());
+
         doReturn("text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5").when(context).getHeader("accept");
         assertEquals("text/html", context.getAcceptContentType());
 

--- a/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
@@ -585,6 +585,53 @@ public class NinjaServletContextTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
         assertEquals("totally_unknown", context.getAcceptContentType());
 
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/protobuf");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals("application/protobuf", context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/protobuf;q=1, application/json;q=0.7");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals("application/protobuf", context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/json");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/html;q=1, application/json;q=0.9");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/xhtml;q=1, application/json;q=0.9");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("text/plain");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_PLAIN, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/json;q=0.9, text/plain;q=0.5");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
+    }
+
+    @Test
+    public void testGetAcceptContentTypeLegacy() {
+        when(httpServletRequest.getHeader("accept")).thenReturn(null);
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+
+        when(httpServletRequest.getHeader("accept")).thenReturn("totally_unknown");
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+        assertEquals("totally_unknown", context.getAcceptContentType());
+
         when(httpServletRequest.getHeader("accept")).thenReturn("application/json");
         context.init(servletContext, httpServletRequest, httpServletResponse);
         assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
@@ -601,7 +648,7 @@ public class NinjaServletContextTest {
         context.init(servletContext, httpServletRequest, httpServletResponse);
         assertEquals(Result.TEXT_PLAIN, context.getAcceptContentType());
 
-        when(httpServletRequest.getHeader("accept")).thenReturn("text/plain, application/json");
+        when(httpServletRequest.getHeader("accept")).thenReturn("application/json, text/plain");
         context.init(servletContext, httpServletRequest, httpServletResponse);
         assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
     }

--- a/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
@@ -583,7 +583,7 @@ public class NinjaServletContextTest {
 
         when(httpServletRequest.getHeader("accept")).thenReturn("totally_unknown");
         context.init(servletContext, httpServletRequest, httpServletResponse);
-        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
+        assertEquals("totally_unknown", context.getAcceptContentType());
 
         when(httpServletRequest.getHeader("accept")).thenReturn("application/json");
         context.init(servletContext, httpServletRequest, httpServletResponse);


### PR DESCRIPTION
I've ran into much the same problem as issue #488, and took it upon myself to provide a way to use the _actual_ value of the `Accept` header.

This was prompted by me trying to use _Protocol Buffers_ in my application, and despite having created body parser engines and template rendering engines, the framework still insisted on using the wrong content type for my responses.