### PR TITLE
Include query string parameters as part of multi-part form upload request

### DIFF
--- a/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipartPost.java
+++ b/ninja-core/src/main/java/ninja/bodyparser/BodyParserEngineMultipartPost.java
@@ -13,6 +13,7 @@ public class BodyParserEngineMultipartPost extends BodyParserEnginePost {
         super(paramParsers);
     }
 
+    @Override
     public String getContentType() {
         return "multipart/form-data";
     }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,8 @@
+Version x.x.x
+=============
+
+* 2021-01-30 Include query string parameters if multi-part file upload logic is used (jjlauer)
+
 Version 6.6.1
 =============
 

--- a/ninja-servlet-integration-test/src/main/java/conf/Routes.java
+++ b/ninja-servlet-integration-test/src/main/java/conf/Routes.java
@@ -129,6 +129,9 @@ public class Routes implements ApplicationRoutes {
         // /////////////////////////////////////////////////////////////////////
         router.POST().route("/form").with(ApplicationController::postForm);
 
+        // query string, along with POST
+        router.POST().route("/form_with_parameters").with(ApplicationController::postFormWithQueryParameters);
+        
         // /////////////////////////////////////////////////////////////////////
         // Direct object rendering with template test
         // /////////////////////////////////////////////////////////////////////

--- a/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/ApplicationController.java
@@ -41,8 +41,10 @@ import org.slf4j.Logger;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.LinkedHashMap;
 
 import models.FormObject;
+import models.PersonWithParameters;
 
 @Singleton
 public class ApplicationController {
@@ -186,6 +188,32 @@ public class ApplicationController {
         return Results.json().render(formObject);
     }
 
+    public Result postFormWithQueryParameters(
+            Context context,
+            @Param("a") Long valueA,
+            @Param("b") String valueB,
+            PersonWithParameters personWithParameters) {
+        
+        // use context to build a map of all request parameters
+        Map<String,String> parameters = new LinkedHashMap<>();
+        Map<String,String[]> allParams = context.getParameters();
+        if (allParams != null) {
+            allParams.forEach((k,vs) -> {
+                for (String v : vs) {
+                    parameters.put(k, v);       // last one will win
+                }
+            });
+        }
+        
+        if (personWithParameters != null) {
+            personWithParameters.setParameters(parameters);
+            personWithParameters.setA(valueA);
+            personWithParameters.setB(valueB);
+        }
+        
+        return Results.json().render(personWithParameters);
+    }
+    
     @Timed
     public Result directObjectTemplateRendering() {
         // Uses Results.html().render(Object) to directly 

--- a/ninja-servlet-integration-test/src/main/java/controllers/UploadControllerAuto.java
+++ b/ninja-servlet-integration-test/src/main/java/controllers/UploadControllerAuto.java
@@ -45,6 +45,8 @@ import org.slf4j.Logger;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import models.FormObject;
 import models.FormWithFile;
@@ -112,8 +114,31 @@ public class UploadControllerAuto {
      * with the fact that a file have been received too.
      */
     @FileProvider(DiskFileItemProvider.class)
-    public Result postFormWithFile(Context context, FormWithFile formObject, @Param("file") File file) {
+    public Result postFormWithFile(
+            Context context,
+            FormWithFile formObject,
+            @Param("a") Long valueA,
+            @Param("b") String valueB,
+            @Param("file") File file) {
+        
+        // use context to build a map of all request parameters
+        Map<String,String> parameters = new LinkedHashMap<>();
+        Map<String,String[]> allParams = context.getParameters();
+        if (allParams != null) {
+            allParams.forEach((k,v) -> {
+                parameters.put(k, v[0]);
+            });
+        }
+        
         formObject.fileReceived = file != null ? file.exists() : Boolean.FALSE;
+        
+        if (!parameters.isEmpty()) {
+            formObject.parameters = parameters;
+        }
+        
+        formObject.a = valueA;
+        formObject.b = valueB;
+        
         return Results.json().render(formObject);
     }
 

--- a/ninja-servlet-integration-test/src/main/java/models/FormWithFile.java
+++ b/ninja-servlet-integration-test/src/main/java/models/FormWithFile.java
@@ -16,6 +16,8 @@
 
 package models;
 
+import java.util.Map;
+
 public class FormWithFile {
 
     public String name;
@@ -23,5 +25,11 @@ public class FormWithFile {
     public String email;
 
     public boolean fileReceived;
+    
+    public Map<String,String> parameters;
+    
+    public Long a;
+    
+    public String b;
 
 }

--- a/ninja-servlet-integration-test/src/main/java/models/PersonWithParameters.java
+++ b/ninja-servlet-integration-test/src/main/java/models/PersonWithParameters.java
@@ -1,0 +1,44 @@
+package models;
+
+import java.util.Map;
+
+public class PersonWithParameters {
+ 
+    private String name;
+    private Map<String, String> parameters;
+    private Long a;
+    private String b;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public Long getA() {
+        return a;
+    }
+
+    public void setA(Long a) {
+        this.a = a;
+    }
+
+    public String getB() {
+        return b;
+    }
+
+    public void setB(String b) {
+        this.b = b;
+    }
+    
+}

--- a/ninja-servlet-integration-test/src/test/java/controllers/UploadControllerAutoTest.java
+++ b/ninja-servlet-integration-test/src/test/java/controllers/UploadControllerAutoTest.java
@@ -34,6 +34,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 
 import models.FormWithFile;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
 
 public class UploadControllerAutoTest extends NinjaTest {
 
@@ -106,6 +109,35 @@ public class UploadControllerAutoTest extends NinjaTest {
         assertEquals("test@email.com", returnedObject.email);
         assertTrue(returnedObject.fileReceived);
         
+    }
+
+    @Test
+    public void testPostFormWithFileAndQueryString() throws IOException {
+
+        File file = new File("src/test/resources/test_for_upload.txt");
+
+        Map<String, String> formParameters = Maps.newHashMap();
+
+        formParameters.put("name", "tester");
+        formParameters.put("email", "test@email.com");
+        
+        // Let's upload a simple txt file...
+        String result = ninjaTestBrowser
+                .uploadFileWithForm(getServerAddress() + "uploadWithForm?a=1&b=hello&c=%E2%82%AC", 
+                        "file", file, formParameters);
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        FormWithFile returnedObject = objectMapper.readValue(result, FormWithFile.class);
+
+        // And assert that returned object has same values
+        assertEquals("tester", returnedObject.name);
+        assertEquals("test@email.com", returnedObject.email);
+        assertTrue(returnedObject.fileReceived);
+        assertThat(returnedObject.parameters, hasEntry("a", "1"));
+        assertThat(returnedObject.parameters, hasEntry("b", "hello"));
+        assertThat(returnedObject.parameters, hasEntry("c", "\u20AC"));
+        assertThat(returnedObject.a, is(1L));
+        assertThat(returnedObject.b, is("hello"));
     }
 
 

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
@@ -529,6 +529,15 @@ public class NinjaServletContext extends AbstractContext {
         ArrayListMultimap<String, String> formMap = ArrayListMultimap.create();
         ArrayListMultimap<String, FileItem> fileMap = ArrayListMultimap.create();
         
+        // Include any query string parameters as part of "formMap"
+        final Map<String,String[]> parameterMap = this.httpServletRequest.getParameterMap();
+        if (parameterMap != null) {
+            parameterMap.forEach((parameter, values) -> {
+                for (String value : values) {
+                    formMap.put(parameter, value);
+                }
+            });
+        }
         
         // This is the iterator we can use to iterate over the contents of the request.
         try {


### PR DESCRIPTION
Multi-part upload handling did not mirror how standard POST entities were handled for "Query String" parameters.  If you send a form post or json post, along with query string parameters, context.getParameters() would always return a merged view of any of those parameters.  On multi-part file uploads, however, any query string parameters were missing.  This patch fixes that.