### PR TITLE
Upgrade dependencies

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -2,6 +2,11 @@ Version x.x.x
 =============
 
 * 2021-01-30 Include query string parameters if multi-part file upload logic is used (jjlauer)
+* 2021-01-30 Updated Guava dependency to v30.1
+* 2021-01-30 Updated Guice dependency to v4.2.3
+* 2021-01-30 Updated Jetty dependency to v9.4.35
+* 2021-01-30 Updated commons-lang3 dependency to v3.11
+* 2021-01-30 Updated servlet-api dependency to v4.0.1
 
 Version 6.6.1
 =============

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <jetty.version>9.4.35.v20201120</jetty.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
         <jackson.version>2.9.8</jackson.version>
-        <guice.version>4.2.2</guice.version>
+        <guice.version>4.2.3</guice.version>
         <metrics.version>3.2.6</metrics.version>
         <slf4j.version>1.7.26</slf4j.version>
         <powermock.version>2.0.2</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -689,7 +689,7 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>3.1.0</version>
+                <version>4.0.1</version>
             </dependency>
             
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <siteProjectVersion>${project.version}</siteProjectVersion>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
         <jackson.version>2.9.8</jackson.version>
         <guice.version>4.2.2</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>27.1-jre</version>
+                <version>30.1-jre</version>
             </dependency>
 
             <!-- reflections is used for classpath scanning -->
@@ -591,7 +591,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
+                <version>3.11</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Bump Jetty to v9.4.35
Bump Guice to v4.2.3
Bump Guava v30.1
Bump commons-lang3 v3.11
Bump servlet-api to v4.0.1