### PR TITLE
Fix for Chrome, Android, etc. browsers setting signed-exchange Accept Header

### DIFF
--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -2,6 +2,7 @@ Version x.x.x
 =============
 
 * 2021-01-30 Include query string parameters if multi-part file upload logic is used (jjlauer)
+* 2021-01-30 Fix for Chrome, Android, etc. browsers setting signed-exchange Accept header as highest precedence (jjlauer)
 
 Version 6.6.1
 =============

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextTest.java
@@ -373,6 +373,10 @@ public class AbstractContextTest {
 
         doReturn("text/plain;q=0.5, application/json;q=0.9").when(context).getHeader("accept");
         assertEquals(Result.APPLICATION_JSON, context.getAcceptContentType());
+
+        // 2021 versions of chrome, samsung, and a few others
+        doReturn("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9").when(context).getHeader("accept");
+        assertEquals(Result.TEXT_HTML, context.getAcceptContentType());
     }
 
     @Test


### PR DESCRIPTION
Modern versions of Chrome, Android, etc. include "application/signed-exchange" as the highest precedence for content types. This can cause the standard HTML template renderer from being selected. 