### PR TITLE
forbid passing null argument to TimeUtil.parseDuration()

### DIFF
--- a/ninja-core/src/main/java/ninja/cache/NinjaCache.java
+++ b/ninja-core/src/main/java/ninja/cache/NinjaCache.java
@@ -16,14 +16,14 @@
 
 package ninja.cache;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
 import java.io.NotSerializableException;
 import java.io.Serializable;
 import java.util.Map;
 
-import ninja.utils.TimeUtil;
-
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
+import static ninja.utils.TimeUtil.parseDuration;
 
 /**
  * A convenience class to access the underlying cache implementation.
@@ -37,9 +37,10 @@ import com.google.inject.Singleton;
  */
 @Singleton
 public class NinjaCache {
-    
-    final Cache cache;
-    
+
+    private static final int ETERNITY = Integer.MAX_VALUE;
+    private final Cache cache;
+
     @Inject
     public NinjaCache(Cache cache) {
         this.cache = cache;
@@ -53,7 +54,7 @@ public class NinjaCache {
      */
     public void add(String key, Object value, String expiration) {
         checkSerializable(value);
-        cache.add(key, value, TimeUtil.parseDuration(expiration));
+        cache.add(key, value, parseDuration(expiration));
     }
 
     /**
@@ -66,7 +67,7 @@ public class NinjaCache {
      */
     public boolean safeAdd(String key, Object value, String expiration) {
         checkSerializable(value);
-        return cache.safeAdd(key, value, TimeUtil.parseDuration(expiration));
+        return cache.safeAdd(key, value, parseDuration(expiration));
     }
 
     /**
@@ -76,7 +77,7 @@ public class NinjaCache {
      */
     public void add(String key, Object value) {
         checkSerializable(value);
-        cache.add(key, value, TimeUtil.parseDuration(null));
+        cache.add(key, value, ETERNITY);
     }
 
     /**
@@ -87,7 +88,7 @@ public class NinjaCache {
      */
     public void set(String key, Object value, String expiration) {
         checkSerializable(value);
-        cache.set(key, value, TimeUtil.parseDuration(expiration));
+        cache.set(key, value, parseDuration(expiration));
     }
 
     /**
@@ -99,7 +100,7 @@ public class NinjaCache {
      */
     public boolean safeSet(String key, Object value, String expiration) {
         checkSerializable(value);
-        return cache.safeSet(key, value, TimeUtil.parseDuration(expiration));
+        return cache.safeSet(key, value, parseDuration(expiration));
     }
 
     /**
@@ -109,7 +110,7 @@ public class NinjaCache {
      */
     public void set(String key, Object value) {
         checkSerializable(value);
-        cache.set(key, value, TimeUtil.parseDuration(null));
+        cache.set(key, value, ETERNITY);
     }
 
     /**
@@ -120,7 +121,7 @@ public class NinjaCache {
      */
     public void replace(String key, Object value, String expiration) {
         checkSerializable(value);
-        cache.replace(key, value, TimeUtil.parseDuration(expiration));
+        cache.replace(key, value, parseDuration(expiration));
     }
 
     /**
@@ -133,7 +134,7 @@ public class NinjaCache {
      */
     public boolean safeReplace(String key, Object value, String expiration) {
         checkSerializable(value);
-        return cache.safeReplace(key, value, TimeUtil.parseDuration(expiration));
+        return cache.safeReplace(key, value, parseDuration(expiration));
     }
 
     /**
@@ -143,7 +144,7 @@ public class NinjaCache {
      */
     public void replace(String key, Object value) {
         checkSerializable(value);
-        cache.replace(key, value, TimeUtil.parseDuration(null));
+        cache.replace(key, value, ETERNITY);
     }
 
     /**

--- a/ninja-core/src/main/java/ninja/utils/TimeUtil.java
+++ b/ninja-core/src/main/java/ninja/utils/TimeUtil.java
@@ -16,9 +16,11 @@
 
 package ninja.utils;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@ParametersAreNonnullByDefault
 public class TimeUtil {
 
     private static final Pattern days = Pattern.compile("^([0-9]+)d$");
@@ -36,7 +38,7 @@ public class TimeUtil {
      */
     public static int parseDuration(String duration) {
         if (duration == null) {
-            return 60 * 60 * 24 * 30;
+            throw new IllegalArgumentException("duration cannot be null");
         }
         int toAdd = -1;
         if (days.matcher(duration).matches()) {

--- a/ninja-core/src/main/java/ninja/utils/TimeUtil.java
+++ b/ninja-core/src/main/java/ninja/utils/TimeUtil.java
@@ -20,48 +20,46 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.Integer.parseInt;
+
 @ParametersAreNonnullByDefault
 public class TimeUtil {
 
-    private static final Pattern days = Pattern.compile("^([0-9]+)d$");
-    private static final Pattern hours = Pattern.compile("^([0-9]+)h$");
-    private static final Pattern minutes = Pattern.compile("^([0-9]+)mi?n$");
-    private static final Pattern seconds = Pattern.compile("^([0-9]+)s$");
+    private static final Pattern REGEX = Pattern.compile("^([0-9]+)(d|h|min|mn|s)$");
 
     /**
      * Parse a duration from String to seconds. 
      * Eg. "10s" will result in 10.
      * 
-     * @param duration "3h" or "2mn" or "7s" or null.
+     * @param duration "3h" or "2mn" or "2min" or "7s" or "1d".
      * 
      * @return The number of seconds OR 30days (2592000) if null is entered.
+     *
+     * @throws IllegalArgumentException if parameter is null or has other format
      */
     public static int parseDuration(String duration) {
         if (duration == null) {
             throw new IllegalArgumentException("duration cannot be null");
         }
-        int toAdd = -1;
-        if (days.matcher(duration).matches()) {
-            Matcher matcher = days.matcher(duration);
-            matcher.matches();
-            toAdd = Integer.parseInt(matcher.group(1)) * (60 * 60) * 24;
-        } else if (hours.matcher(duration).matches()) {
-            Matcher matcher = hours.matcher(duration);
-            matcher.matches();
-            toAdd = Integer.parseInt(matcher.group(1)) * (60 * 60);
-        } else if (minutes.matcher(duration).matches()) {
-            Matcher matcher = minutes.matcher(duration);
-            matcher.matches();
-            toAdd = Integer.parseInt(matcher.group(1)) * (60);
-        } else if (seconds.matcher(duration).matches()) {
-            Matcher matcher = seconds.matcher(duration);
-            matcher.matches();
-            toAdd = Integer.parseInt(matcher.group(1));
-        }
-        if (toAdd == -1) {
+
+        Matcher m = REGEX.matcher(duration);
+        if (!m.matches()) {
             throw new IllegalArgumentException("Invalid duration pattern : " + duration);
         }
-        return toAdd;
+        int value = parseInt(m.group(1));
+        String units = m.group(2);
+        switch (units) {
+            case "d":
+                return value * 60 * 60 * 24;
+            case "h":
+                return value * 60 * 60;
+            case "min":
+            case "mn":
+                return value * 60;
+            case "s":
+                return value;
+            default:
+                throw new IllegalArgumentException("Unsupported time unit: " + units);
+        }
     }
-
 }

--- a/ninja-core/src/test/java/ninja/cache/NinjaCacheTest.java
+++ b/ninja-core/src/test/java/ninja/cache/NinjaCacheTest.java
@@ -16,17 +16,17 @@
 
 package ninja.cache;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import ninja.utils.TimeUtil;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NinjaCacheTest{
@@ -78,7 +78,7 @@ public class NinjaCacheTest{
         
         ninjaCache.add(key, value);  
         
-        verify(cache).add(key, value, TimeUtil.parseDuration(null));
+        verify(cache).add(key, value, Integer.MAX_VALUE);
     }
     
     @Test(expected = CacheException.class)
@@ -128,7 +128,7 @@ public class NinjaCacheTest{
         
         ninjaCache.set(key, value);  
         
-        verify(cache).set(key, value, TimeUtil.parseDuration(null));
+        verify(cache).set(key, value, Integer.MAX_VALUE);
     }
     
     @Test(expected = CacheException.class)
@@ -178,7 +178,7 @@ public class NinjaCacheTest{
         
         ninjaCache.replace(key, value);  
         
-        verify(cache).replace(key, value, TimeUtil.parseDuration(null));
+        verify(cache).replace(key, value, Integer.MAX_VALUE);
     }
     
     @Test(expected = CacheException.class)

--- a/ninja-core/src/test/java/ninja/utils/TimeUtilTest.java
+++ b/ninja-core/src/test/java/ninja/utils/TimeUtilTest.java
@@ -16,30 +16,35 @@
 
 package ninja.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 public class TimeUtilTest {
 
     @Test
-    public void test() {
+    public void durationInDays() {
         assertEquals(86400, TimeUtil.parseDuration("1d"));
-        assertEquals(10, TimeUtil.parseDuration("10s"));
         assertEquals(2592000, TimeUtil.parseDuration("30d"));
-        assertEquals(2592000, TimeUtil.parseDuration(null));
-        
-        boolean catchedException = false;
-        try {
-            TimeUtil.parseDuration("NOT_A_VALID_INPUT");
-            
-        } catch (IllegalArgumentException e) {
-                catchedException = true;
-        }
-
-        assertTrue(catchedException); 
-        
     }
 
+    @Test
+    public void durationInSeconds() {
+        assertEquals(10, TimeUtil.parseDuration("10s"));
+    }
+
+    @Test
+    public void durationCannotBeNull() {
+        assertThatThrownBy(() -> TimeUtil.parseDuration(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("duration cannot be null");
+    }
+
+    @Test
+    public void invalidDurationFormat() {
+      assertThatThrownBy(() -> TimeUtil.parseDuration("NOT_A_VALID_INPUT"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid duration pattern : NOT_A_VALID_INPUT");
+    }
 }

--- a/ninja-core/src/test/java/ninja/utils/TimeUtilTest.java
+++ b/ninja-core/src/test/java/ninja/utils/TimeUtilTest.java
@@ -18,6 +18,7 @@ package ninja.utils;
 
 import org.junit.Test;
 
+import static ninja.utils.TimeUtil.parseDuration;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
@@ -25,26 +26,51 @@ public class TimeUtilTest {
 
     @Test
     public void durationInDays() {
-        assertEquals(86400, TimeUtil.parseDuration("1d"));
-        assertEquals(2592000, TimeUtil.parseDuration("30d"));
+        assertEquals(0, parseDuration("0d"));
+        assertEquals(86400, parseDuration("1d"));
+        assertEquals(2592000, parseDuration("30d"));
+    }
+
+    @Test
+    public void durationInHours() {
+        assertEquals(0, parseDuration("0h"));
+        assertEquals(3600, parseDuration("1h"));
+        assertEquals(3600 * 24, parseDuration("24h"));
+    }
+
+    @Test
+    public void durationInMinutes() {
+        assertEquals(0, parseDuration("0mn"));
+        assertEquals(0, parseDuration("0min"));
+        assertEquals(60, parseDuration("1mn"));
+        assertEquals(60, parseDuration("1min"));
+        assertEquals(60 * 59, parseDuration("59mn"));
+        assertEquals(60 * 59, parseDuration("59min"));
     }
 
     @Test
     public void durationInSeconds() {
-        assertEquals(10, TimeUtil.parseDuration("10s"));
+        assertEquals(0, parseDuration("0s"));
+        assertEquals(1, parseDuration("1s"));
+        assertEquals(10, parseDuration("10s"));
+        assertEquals(1234567890, parseDuration("1234567890s"));
     }
 
     @Test
     public void durationCannotBeNull() {
-        assertThatThrownBy(() -> TimeUtil.parseDuration(null))
+        assertThatThrownBy(() -> parseDuration(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("duration cannot be null");
     }
 
     @Test
     public void invalidDurationFormat() {
-      assertThatThrownBy(() -> TimeUtil.parseDuration("NOT_A_VALID_INPUT"))
+      assertThatThrownBy(() -> parseDuration("NOT_A_VALID_INPUT"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage("Invalid duration pattern : NOT_A_VALID_INPUT");
+
+      assertThatThrownBy(() -> parseDuration("24x"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Invalid duration pattern : 24x");
     }
 }


### PR DESCRIPTION
it was a cause of errors: developer forgot to add configuration property with cache lifetime, and objects were accidentally cached for 30 days!

I know this PR does change the behaviour of the framework, but I believe this change can save users from accidental errors. 

it's always safer to explicitly forbid null arguments.