### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -99,12 +99,7 @@
             <artifactId>guice</artifactId>
         </dependency>
         
-        <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-assistedinject</artifactId>
-        </dependency>
-
-        <!-- We use Jackson for rendering jsons: -->
+        
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -136,18 +131,8 @@
         </dependency>
 		
         <!-- Replace commons-logging with slf4j bridge (that will use logback)-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
         
-        <!-- Replace log4j with slf4j bridge (that will use logback)-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
-
-        <!-- Some nice stuff for handling IO. Some overlap with guava though... -->
+        
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -173,25 +158,14 @@
 
         <!-- Bean validation and reference implementation for JSR 303 -->
         <!-- IMPORTANT: still using 4.3.1.Final because 5.0.1.Final NOT compatible with GAE -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-
-        <!-- XML parsing -->
+        
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         
         <!-- jackson-dataformat-xml prefers Woodstox as Stax impl -->
-        <dependency>
-            <groupId>com.fasterxml.woodstox</groupId>
-            <artifactId>woodstox-core</artifactId>
-        </dependency>
         
-        <!-- ehcache implementation -->
-        <!-- IMPORTANT: only pull in core (~1MB) vs. entire distro which includes a server (~7MB) -->
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
@@ -204,28 +178,12 @@
         </dependency>
 
         <!-- Migration framework -->
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
-
-        <!-- JPA dependencies -->
-        <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-persist</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-        </dependency>
         
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-c3p0</artifactId>
-        </dependency>
         
-        <!-- Testing -->
+
+        
+        
+        
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
@@ -246,22 +204,10 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
         
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
         
-        <!-- Jaxb was removed from Java 9 and onwards. So we add the dependency explicitly -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
+        
+        
          
     </dependencies>
     

--- a/ninja-jaxy-routes/pom.xml
+++ b/ninja-jaxy-routes/pom.xml
@@ -31,11 +31,7 @@
 			<artifactId>reflections</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.ninjaframework</groupId>
-			<artifactId>ninja-test-utilities</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
 	</dependencies>
 

--- a/ninja-maven-plugin/pom.xml
+++ b/ninja-maven-plugin/pom.xml
@@ -77,12 +77,7 @@
             <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/ninja-metrics-ganglia/pom.xml
+++ b/ninja-metrics-ganglia/pom.xml
@@ -59,15 +59,9 @@ and limitations under the License. -->
         </dependency>
 
         <!-- Testing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
+        
     </dependencies>
 
 </project>

--- a/ninja-metrics-influxdb/pom.xml
+++ b/ninja-metrics-influxdb/pom.xml
@@ -59,15 +59,9 @@ and limitations under the License. -->
         </dependency>
 
         <!-- Testing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
+        
     </dependencies>
 
 </project>

--- a/ninja-metrics-librato/pom.xml
+++ b/ninja-metrics-librato/pom.xml
@@ -59,15 +59,9 @@ and limitations under the License. -->
         </dependency>
 
         <!-- Testing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
+        
     </dependencies>
 
 </project>

--- a/ninja-postoffice/pom.xml
+++ b/ninja-postoffice/pom.xml
@@ -45,10 +45,7 @@
             <artifactId>junit</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
+        
 
         <dependency>
             <groupId>com.icegreen</groupId>

--- a/ninja-servlet-integration-test/build-run-jetty.sh
+++ b/ninja-servlet-integration-test/build-run-jetty.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mvn package -DskipTests=true
+mvn -T 1C package -DskipTests=true
 docker build -f Dockerfile.jetty --tag=ninja-jetty .
 docker run -it -p 8080:8080 ninja-jetty

--- a/ninja-servlet-integration-test/build-run-tomcat.sh
+++ b/ninja-servlet-integration-test/build-run-tomcat.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mvn clean package -DskipTests=true
+mvn -T 1C clean package -DskipTests=true
 docker build -f Dockerfile.tomcat --tag=ninja-tomcat2 .
 docker run -it -p 8080:8080 ninja-tomcat2

--- a/ninja-servlet-integration-test/build-run-wildfly.sh
+++ b/ninja-servlet-integration-test/build-run-wildfly.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mvn package -DskipTests=true
+mvn -T 1C package -DskipTests=true
 docker build -f Dockerfile.wildfly --tag=ninja-wildfly .
 docker run -it -p 8080:8080 ninja-wildfly

--- a/ninja-servlet-integration-test/pom.xml
+++ b/ninja-servlet-integration-test/pom.xml
@@ -147,15 +147,9 @@
         
         <!-- for web ui only -->
         
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>bootstrap</artifactId>
-        </dependency>
         
-        <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-        </dependency>
+        
+        
         
         <dependency>
             <groupId>org.ninjaframework</groupId>

--- a/ninja-servlet-jpa-blog-integration-test/pom.xml
+++ b/ninja-servlet-jpa-blog-integration-test/pom.xml
@@ -158,25 +158,13 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>tinymce-jquery</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>bootstrap</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.ninjaframework</groupId>
-            <artifactId>ninja-servlet</artifactId>
-        </dependency>
+        
         
         <dependency>
             <groupId>org.ninjaframework</groupId>

--- a/ninja-standalone/pom.xml
+++ b/ninja-standalone/pom.xml
@@ -76,10 +76,7 @@
             <scope>compile</scope>
         </dependency>
         
-        <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
-        </dependency>
+        
         
         <dependency>
             <groupId>junit</groupId>

--- a/ninja-test-utilities/pom.xml
+++ b/ninja-test-utilities/pom.xml
@@ -41,11 +41,7 @@
             <scope>compile</scope>
         </dependency>
         
-        <dependency>
-            <groupId>org.ninjaframework</groupId>
-            <artifactId>ninja-standalone</artifactId>
-            <scope>compile</scope>
-        </dependency>
+        
         
         <dependency>
             <groupId>org.ninjaframework</groupId>
@@ -55,11 +51,7 @@
 
         <!-- Testing is mainly done by mockito: -->
         <!-- Order of hamcrest first then junit is important -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <scope>compile</scope>
-        </dependency>
+        
         
         <dependency>
             <groupId>org.assertj</groupId>
@@ -84,25 +76,9 @@
             <artifactId>fluentlenium-junit</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>htmlunit-driver</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <!-- selenium uses jetty-client and has a version conflict with ours.
-          We must declare these to force the version to ours or websockets will break -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-client</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
         
-        <!--HttpCient is used to mainly test low level Json Apis -->
+        
+        
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
ninja
ninja-core
{groupId='com.google.inject.extensions', artifactId='guice-assistedinject'}
{groupId='org.slf4j', artifactId='jcl-over-slf4j'}
{groupId='org.slf4j', artifactId='log4j-over-slf4j'}
{groupId='org.hibernate', artifactId='hibernate-validator'}
{groupId='com.fasterxml.woodstox', artifactId='woodstox-core'}
{groupId='org.flywaydb', artifactId='flyway-core'}
{groupId='com.google.inject.extensions', artifactId='guice-persist'}
{groupId='org.hibernate', artifactId='hibernate-entitymanager'}
{groupId='org.hibernate', artifactId='hibernate-c3p0'}
{groupId='org.powermock', artifactId='powermock-module-junit4'}
{groupId='org.powermock', artifactId='powermock-api-mockito2'}
{groupId='javax.xml.bind', artifactId='jaxb-api'}
ninja-postoffice
{groupId='org.mockito', artifactId='mockito-core'}
ninja-websockets-jsr356
ninja-servlet
ninja-standalone
{groupId='javax.websocket', artifactId='javax.websocket-api'}
ninja-db-classic
ninja-test-utilities
{groupId='org.ninjaframework', artifactId='ninja-standalone'}
{groupId='org.hamcrest', artifactId='java-hamcrest'}
{groupId='org.seleniumhq.selenium', artifactId='htmlunit-driver'}
{groupId='org.eclipse.jetty', artifactId='jetty-client'}
{groupId='org.eclipse.jetty.websocket', artifactId='websocket-client'}
ninja-jaxy-routes
{groupId='org.ninjaframework', artifactId='ninja-test-utilities'}
ninja-metrics
ninja-metrics-graphite
ninja-metrics-ganglia
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-core'}
ninja-metrics-librato
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-core'}
ninja-metrics-influxdb
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-core'}
ninja-maven-plugin
{groupId='org.apache.maven', artifactId='maven-compat'}
ninja-servlet-integration-test
{groupId='org.webjars', artifactId='bootstrap'}
{groupId='org.mindrot', artifactId='jbcrypt'}
ninja-servlet-jpa-blog-integration-test
{groupId='org.webjars', artifactId='tinymce-jquery'}
{groupId='org.webjars', artifactId='bootstrap'}
{groupId='com.h2database', artifactId='h2'}
{groupId='org.ninjaframework', artifactId='ninja-servlet'}
ninja-servlet-jpa-blog-archetype
ninja-servlet-archetype-simple


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
