### PR TITLE
Add new Jackson modules to handle Java8 and Joda data types

### DIFF
--- a/ninja-core/pom.xml
+++ b/ninja-core/pom.xml
@@ -117,6 +117,23 @@
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
 
+        <!-- Jackson: handle new Java 8 data type -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <!-- Jackson: handle Joda data type -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+        </dependency>
+
         <!-- freemarker is our templating engine: -->
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/ninja-core/src/main/java/ninja/utils/ObjectMapperProvider.java
+++ b/ninja-core/src/main/java/ninja/utils/ObjectMapperProvider.java
@@ -17,6 +17,9 @@
 package ninja.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.inject.Provider;
 
@@ -28,18 +31,25 @@ import com.google.inject.Provider;
  * This provider makes it simple to configure the ObjectMapper in one place
  * for all places where it is used.
  */
-public class ObjectMapperProvider implements Provider<ObjectMapper>{
+public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
     @Override
     public ObjectMapper get() {
-        
+
         ObjectMapper objectMapper = new ObjectMapper();
-        
+
         // Afterburner optimizes performance of Pojo to Json mapper
         objectMapper.registerModule(new AfterburnerModule());
-        
+
+        // Java 8 data type
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new Jdk8Module());
+
+        // Joda
+        objectMapper.registerModule(new JodaModule());
+
         return objectMapper;
-        
+
     }
-    
+
 }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.8.2
 =============
 
+* 2021-12-18 Added Jackson Module to handle Java8 and Joda data types (thibaultmeyer)
 * 2021-03-19 Streamline tests (asolntsev)
 * 2021-03-19 Updated Guice dependency to 5.0.1 (asolntsev)
 * 2021-03-19 Updated dependencies: slf4j:1.7.30, jackson:2.12.2, httpclient:4.5.13, commons-codec:1.15 (asolntsev)

--- a/ninja-core/src/site/markdown/documentation/upgrade_guide.md
+++ b/ninja-core/src/site/markdown/documentation/upgrade_guide.md
@@ -6,6 +6,36 @@ into Ninja's behavior. This document describes which steps are needed to upgrade
 your application to the latest Ninja version. Simply start with your current 
 version and then work your way up to the top of the document.
 
+
+to 6.8.2
+--------
+
+Flyway has been updated to prior version 8.2.2. As mentioned in the Flyway
+documentation there is a small change with MySQL. Since the version 8.2.x,
+MySQL Driver is not included any more in Flyway distribution due to License.
+MariaDB will be used as fallback driver if no MySQL driver is present on the
+Classpath.
+
+If you still want to use a MySQL with MySQL Driver, you have to add new 
+dependencies on your project.
+
+```java
+    <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-mysql</artifactId>
+        <version>8.2.2</version>
+    </dependency>
+```
+
+```java
+   <dependency>
+       <groupId>mysql</groupId>
+       <artifactId>mysql-connector-java</artifactId>
+       <version>8.0.27</version>
+   </dependency>
+```
+
+
 to 6.7.0
 --------
 

--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,26 @@
                 <artifactId>jackson-dataformat-xml</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-            
+
+            <!-- Jackson: handle new Java 8 data type -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <!-- Jackson: handle Joda data type -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-joda</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
             <!-- Woodstox as a proper Stax API implementation -->
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
Jackson does not natively support Java8 (ie: LocalDate / LocalDateTime) and Joda data types. Some Modules have to be activated.

```log
12:00:28.655 [qtp1052195003-46] ERROR ninja.template.TemplateEngineJson - Error while rendering json
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.LocalDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.ArrayList[0]->entity.ReferenceCollection["createdAt"])
```