### PR TITLE
Fix NullPointerException on Message::getWithDefault

### DIFF
--- a/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
+++ b/ninja-core/src/main/java/ninja/i18n/MessagesImpl.java
@@ -121,9 +121,11 @@ public class MessagesImpl implements Messages {
         Optional<String> value = get(key, language, params);
         if (value.isPresent()) {
             return value.get();
-        } else {
+        } else if (defaultMessage != null) {
             MessageFormat messageFormat = getMessageFormatForLocale(defaultMessage, language);
             return messageFormat.format(params);
+        } else {
+            return null;
         }
     }
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,8 @@
 Version 6.8.2
 =============
 
+* 2021-12-24 Fixed NullPointerException on "Message::getWithDefault" when value and default value are both null
+  (thibaultmeyer)
 * 2021-03-19 Streamline tests (asolntsev)
 * 2021-03-19 Updated Guice dependency to 5.0.1 (asolntsev)
 * 2021-03-19 Updated dependencies: slf4j:1.7.30, jackson:2.12.2, httpclient:4.5.13, commons-codec:1.15 (asolntsev)


### PR DESCRIPTION
Fixes a NullPointerException in the use of `Message::getWithDefault` when both the value and the default value are `null`.

Resolves: #715
