### PR TITLE
Use primitive long

### DIFF
--- a/ninja-core/src/main/java/ninja/session/SessionImpl.java
+++ b/ninja-core/src/main/java/ninja/session/SessionImpl.java
@@ -121,7 +121,7 @@ public class SessionImpl implements Session {
                 // If an expiry time was set previously use that instead of the
                 // default session expire time.
                 if (data.containsKey(EXPIRY_TIME_KEY)) {
-                    Long expiryTime = Long.parseLong(data.get(EXPIRY_TIME_KEY));
+                    long expiryTime = Long.parseLong(data.get(EXPIRY_TIME_KEY));
                     if (expiryTime >= 0) {
                         sessionExpireTimeInMs = expiryTime;
                     }
@@ -142,7 +142,7 @@ public class SessionImpl implements Session {
                 return true;
             }
 
-            Long timestamp = Long.parseLong(data.get(TIMESTAMP_KEY));
+            long timestamp = Long.parseLong(data.get(TIMESTAMP_KEY));
 
             return (timestamp + sessionExpireTimeInMs < time.currentTimeMillis());
         }


### PR DESCRIPTION
The variables 'expiryTime' and 'timestamp" are only assigned values of
primitive type and are never 'null', but they are declared with the
boxed type 'Long'.
