### PR TITLE
Fix "log.debug()" call (bad number of arguments)

### DIFF
--- a/ninja-maven-plugin/src/main/java/ninja/build/WatchAndRestartMachine.java
+++ b/ninja-maven-plugin/src/main/java/ninja/build/WatchAndRestartMachine.java
@@ -219,7 +219,7 @@ public class WatchAndRestartMachine implements Runnable {
         log.debug(" matched rule: type={}, pattern={}, proceed={}", match.type, match.pattern, match.proceed);
         
         if (match.proceed) {
-            log.debug(" will trigger restart", newOrMod, f);
+            log.debug(" will trigger restart");
             restartTrigger.trigger();
         }
         else {


### PR DESCRIPTION
This format call refers to 0 argument(s) but supplies 2 argument(s)
