### PR TITLE
Add CRON like support on the annotation @Schedule

### DIFF
--- a/ninja-core/src/main/java/ninja/scheduler/Schedule.java
+++ b/ninja-core/src/main/java/ninja/scheduler/Schedule.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Schedule {
+
     /**
      * The delay between executions. Is used as the default if no delay property is found.
      *
@@ -63,7 +64,6 @@ public @interface Schedule {
      */
     long initialDelay() default -1;
 
-
     /**
      * The property to read the initial delay from.  If not specified, initialDelay is used.
      *
@@ -71,5 +71,20 @@ public @interface Schedule {
      */
     String initialDelayProperty() default NO_PROPERTY;
 
-    static String NO_PROPERTY = "_no-property";
+    /**
+     * A CRON-like expression containing the second, minute, hour, day of month, month, and day of week.
+     *
+     * @return The CRON expression
+     */
+    String cron() default NO_PROPERTY;
+
+    /**
+     * A time zone for which the CRON expression will be resolved. If not specified, the server's local time
+     * zone will be used.
+     *
+     * @return A zone id accepted by {@code TimeZone.getTimeZone(String)}
+     */
+    String cronZone() default NO_PROPERTY;
+
+    String NO_PROPERTY = "_no-property";
 }

--- a/ninja-core/src/main/java/ninja/scheduler/cron/BadCronExpressionException.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/BadCronExpressionException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+/**
+ * Exception thrown if there is a problem when parsing a CRON expression.
+ */
+public class BadCronExpressionException extends RuntimeException {
+
+    /**
+     * Build a new instance.
+     *
+     * @param errorMessage     The error message format
+     * @param stringFormatArgs The arguments for the error message format
+     */
+    protected BadCronExpressionException(final String errorMessage, final Object... stringFormatArgs) {
+        super(String.format(errorMessage, stringFormatArgs));
+    }
+
+    /**
+     * Build a new instance.
+     *
+     * @param causeException   The root exception
+     * @param errorMessage     The error message
+     * @param stringFormatArgs The arguments for the error message format
+     */
+    protected BadCronExpressionException(final BadCronExpressionException causeException,
+                                         final String errorMessage,
+                                         final Object... stringFormatArgs) {
+        super(String.format(errorMessage, stringFormatArgs), causeException);
+    }
+}

--- a/ninja-core/src/main/java/ninja/scheduler/cron/CronExpression.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/CronExpression.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Represent a CRON expression.
+ */
+public class CronExpression {
+
+    private static final Pattern REGEXP_PATTERN_RANGE = Pattern.compile("^([^-]+)-([^-/]+)(/(\\d+))?$");
+    private static final Pattern REGEXP_PATTERN_LIST = Pattern.compile("^([^-/]+)(/(\\d+))?$");
+    private static final Pattern REGEXP_PATTERN_SINGLE = Pattern.compile("^(\\d+)(/(\\d+))?$");
+
+    private static final List<String> WILDCARD_REPLACEMENT = Arrays.asList(
+            "0-59",  // Second
+            "0-59",  // Minute
+            "0-23",  // Hour
+            "1-31",  // Day of Month
+            "1-12",  // Month
+            "0-6");  // Day of Week
+
+    private static final List<Consumer<CronExpressionPart>> CRON_EXPRESSION_PART_VALIDATOR = Arrays.asList(
+            (c) -> c.assertViolation(1, 60, 0, 59),  // Second
+            (c) -> c.assertViolation(1, 60, 0, 59),  // Minute
+            (c) -> c.assertViolation(1, 24, 0, 23),  // Hour
+            (c) -> c.assertViolation(1, 32, 0, 31),  // Day of Month
+            (c) -> c.assertViolation(1, 13, 0, 12),  // Month
+            (c) -> c.assertViolation(1, 7, 0, 6));   // Day of Week
+
+    private static final int IDX_SECOND = 0;
+    private static final int IDX_MINUTE = 1;
+    private static final int IDX_HOUR = 2;
+    private static final int IDX_DAY_OF_MONTH = 3;
+    private static final int IDX_MONTH = 4;
+    private static final int IDX_DAY_OF_WEEK = 5;
+
+    final Map<DayOfWeek, Integer> DAY_OF_WEEK_CRON_VALUE = new HashMap<DayOfWeek, Integer>() {{
+        put(DayOfWeek.SUNDAY, 0);
+        put(DayOfWeek.MONDAY, 1);
+        put(DayOfWeek.TUESDAY, 2);
+        put(DayOfWeek.WEDNESDAY, 3);
+        put(DayOfWeek.THURSDAY, 4);
+        put(DayOfWeek.FRIDAY, 5);
+        put(DayOfWeek.SATURDAY, 6);
+    }};
+
+    private final CronExpressionPart[] cronExpressionPartArray;
+
+    /**
+     * Build a new instance.
+     *
+     * @param cron The CRON expression to parse
+     */
+    public CronExpression(final String cron) {
+        // ┌───────────── second (0 - 59)
+        // │ ┌───────────── minute (0 - 59)
+        // │ │ ┌───────────── hour (0 - 23)
+        // │ │ │ ┌───────────── day of the month (1 - 31)
+        // │ │ │ │ ┌───────────── month (1 - 12)
+        // │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
+        // │ │ │ │ │ │
+        // │ │ │ │ │ │
+        // * * * * * *
+
+
+        final String[] cronArray = cron.split(StringUtils.SPACE);
+        if (cronArray.length < 5) {
+            throw new BadCronExpressionException("CRON expression is invalid '%s'", cron);
+        }
+
+        cronExpressionPartArray = new CronExpressionPart[6];
+        for (int idx = 0; idx < cronExpressionPartArray.length; ++idx) {
+            // Standardize CRON expression
+            final String standardizedPart = cronArray[idx]
+                    .replace("?", "*")
+                    .replace("*", WILDCARD_REPLACEMENT.get(idx));
+
+            // Parse and validate each part
+            try {
+                cronExpressionPartArray[idx] = parseCronExpressionPart(standardizedPart);
+                if (idx < CRON_EXPRESSION_PART_VALIDATOR.size()) {
+                    CRON_EXPRESSION_PART_VALIDATOR.get(idx).accept(cronExpressionPartArray[idx]);
+                }
+            } catch (final BadCronExpressionException ex) {
+                throw new BadCronExpressionException(
+                        ex,
+                        "Can't use CRON '%s', error with the part #%d '%s'",
+                        cron,
+                        idx + 1,
+                        cronArray[idx]);
+            }
+        }
+    }
+
+    /**
+     * Retrieves the delay from now to the next match.
+     *
+     * @param zoneId The Zone to use for manipulating datetime
+     * @return The next delay in milliseconds
+     */
+    public long getNextDelayMilliseconds(final ZoneId zoneId) {
+        return getNextDelayMilliseconds(LocalDateTime.now(zoneId));
+    }
+
+    /**
+     * Retrieves the delay from given datetime to the next match.
+     *
+     * @param from The datetime
+     * @return The next delay in milliseconds
+     */
+    protected long getNextDelayMilliseconds(final LocalDateTime from) {
+        LocalDateTime nextTrigger = from.withNano(0).plusSeconds(1);
+
+        CronExpressionPart cronExpressionPart = cronExpressionPartArray[IDX_SECOND];
+        while (cronExpressionPart.isNotCompliant(nextTrigger.getSecond())) {
+            nextTrigger = nextTrigger.plusSeconds(1);
+        }
+
+        cronExpressionPart = cronExpressionPartArray[IDX_MINUTE];
+        while (cronExpressionPart.isNotCompliant(nextTrigger.getMinute())) {
+            nextTrigger = nextTrigger.plusMinutes(1);
+        }
+
+        cronExpressionPart = cronExpressionPartArray[IDX_HOUR];
+        while (cronExpressionPart.isNotCompliant(nextTrigger.getHour())) {
+            nextTrigger = nextTrigger.plusHours(1);
+        }
+
+        cronExpressionPart = cronExpressionPartArray[IDX_DAY_OF_MONTH];
+        while (cronExpressionPart.isNotCompliant(nextTrigger.getDayOfMonth())) {
+            nextTrigger = nextTrigger.plusDays(1);
+        }
+
+        cronExpressionPart = cronExpressionPartArray[IDX_MONTH];
+        while (cronExpressionPart.isNotCompliant(nextTrigger.getMonthValue())) {
+            nextTrigger = nextTrigger.plusMonths(1);
+        }
+
+        cronExpressionPart = cronExpressionPartArray[IDX_DAY_OF_WEEK];
+        while (cronExpressionPart.isNotCompliant(DAY_OF_WEEK_CRON_VALUE.get(nextTrigger.getDayOfWeek()))) {
+            nextTrigger = nextTrigger.plusDays(1);
+        }
+
+        return ChronoUnit.MILLIS.between(from, nextTrigger);
+    }
+
+    private CronExpressionPart parseCronExpressionPart(final String str) {
+        CronExpressionPart cronExpressionPart = null;
+
+        if (str.contains("-")) {
+            final Matcher matcher = REGEXP_PATTERN_RANGE.matcher(str);
+            if (matcher.find()) {
+                final int minRange = matcher.group(1) != null ? Integer.parseInt(matcher.group(1)) : 0;
+                final int maxRange = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : minRange;
+                final int stepValue = matcher.group(4) != null ? Integer.parseInt(matcher.group(4)) : -1;
+
+                cronExpressionPart = new CronExpressionPartRange(stepValue, minRange, maxRange);
+            }
+        } else if (str.contains(",")) {
+            final Matcher matcher = REGEXP_PATTERN_LIST.matcher(str);
+            if (matcher.find()) {
+                final String listValue = matcher.group(1);
+                final int stepValue = matcher.group(3) != null ? Integer.parseInt(matcher.group(3)) : -1;
+
+                cronExpressionPart = new CronExpressionPartList(
+                        stepValue,
+                        Arrays.stream(listValue.split(",")).map(Integer::parseInt).collect(Collectors.toList()));
+            }
+        } else {
+            final Matcher matcher = REGEXP_PATTERN_SINGLE.matcher(str);
+            if (matcher.find()) {
+                final int singleValue = Integer.parseInt(matcher.group(1));
+                final int stepValue = matcher.group(3) != null ? Integer.parseInt(matcher.group(3)) : -1;
+
+                cronExpressionPart = new CronExpressionPartRange(stepValue, singleValue, singleValue);
+            }
+        }
+
+        if (cronExpressionPart == null) {
+            throw new BadCronExpressionException("Can't parse CRON expression part: %s", str);
+        }
+
+        return cronExpressionPart;
+    }
+}

--- a/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPart.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPart.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+/**
+ * Represents a subpart of a CRON expression.
+ */
+public interface CronExpressionPart {
+
+    /**
+     * Checks that the value does not match
+     *
+     * @param value The value to test
+     * @return {@code true} if not compliant, otherwise, {@code false}
+     */
+    boolean isNotCompliant(final int value);
+
+    /**
+     * Checks that CRON expression has valid attributes.
+     *
+     * @param allowedMinStepValue The minimum value for the Step value
+     * @param allowedMaxStepValue The maximum value for the Step value
+     * @param allowedMinValue     The minimum value
+     * @param allowedMaxValue     The maximum value
+     */
+    void assertViolation(final int allowedMinStepValue,
+                         final int allowedMaxStepValue,
+                         final int allowedMinValue,
+                         final int allowedMaxValue);
+}

--- a/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartList.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartList.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * CRON expression part representing a list of integers.
+ */
+class CronExpressionPartList extends CronExpressionPartStepValue {
+
+    private final List<Integer> lst;
+
+    /**
+     * Build a new instance.
+     *
+     * @param stepValue The step value
+     * @param lst       A list of integers
+     */
+    public CronExpressionPartList(final int stepValue, final List<Integer> lst) {
+        super(stepValue);
+
+        this.lst = lst != null ? lst : Collections.emptyList();
+    }
+
+    @Override
+    public boolean isNotCompliant(final int value) {
+        return super.isNotCompliant(value) ^ lst.contains(value);
+    }
+
+    @Override
+    public void assertViolation(final int allowedMinStepValue,
+                                final int allowedMaxStepValue,
+                                final int allowedMinValue,
+                                final int allowedMaxValue) {
+        super.assertViolation(allowedMinStepValue, allowedMaxStepValue, allowedMinValue, allowedMaxValue);
+
+        if (lst.stream().anyMatch(value -> (value < allowedMinValue) || (value > allowedMaxValue))) {
+            throw new BadCronExpressionException(
+                    "List '%s' is invalid. All values must be between '%s..%s'.",
+                    Arrays.toString(lst.toArray()),
+                    allowedMinValue,
+                    allowedMaxValue);
+        }
+    }
+}

--- a/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartRange.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartRange.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+/**
+ * CRON expression part representing a range (min, max).
+ */
+class CronExpressionPartRange extends CronExpressionPartStepValue {
+
+    private final int min;
+    private final int max;
+
+    /**
+     * Build a new instance.
+     *
+     * @param stepValue The step value
+     * @param min       The min range value
+     * @param max       The max range value
+     */
+    public CronExpressionPartRange(final int stepValue, final int min, final int max) {
+        super(stepValue);
+
+        this.min = min;
+        this.max = max;
+    }
+
+    @Override
+    public boolean isNotCompliant(final int value) {
+        return super.isNotCompliant(value) ^ (value >= min && value <= max);
+    }
+
+    @Override
+    public void assertViolation(final int allowedMinStepValue,
+                                final int allowedMaxStepValue,
+                                final int allowedMinValue,
+                                final int allowedMaxValue) {
+        super.assertViolation(allowedMinStepValue, allowedMaxStepValue, allowedMinValue, allowedMaxValue);
+
+        if ((min < allowedMinValue) || (max > allowedMaxValue)) {
+            throw new BadCronExpressionException(
+                    "Range value '%s..%s' is invalid. Allowed Range is '%s..%s'.",
+                    min,
+                    max,
+                    allowedMinValue,
+                    allowedMaxValue);
+        }
+        if (min > max) {
+            throw new BadCronExpressionException("Min value '%s' can't be higher than Max value '%s'", min, max);
+        }
+    }
+}

--- a/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartStepValue.java
+++ b/ninja-core/src/main/java/ninja/scheduler/cron/CronExpressionPartStepValue.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+/**
+ * CRON expression part representing a step value.
+ */
+class CronExpressionPartStepValue implements CronExpressionPart {
+
+    private final int stepValue;
+
+    /**
+     * Build a new instance.
+     *
+     * @param stepValue The value
+     */
+    protected CronExpressionPartStepValue(final int stepValue) {
+        this.stepValue = stepValue;
+    }
+
+    @Override
+    public boolean isNotCompliant(final int value) {
+        return stepValue == -1 || value % stepValue == 0;
+    }
+
+    @Override
+    public void assertViolation(final int allowedMinStepValue,
+                                final int allowedMaxStepValue,
+                                final int allowedMinValue,
+                                final int allowedMaxValue) {
+        if (stepValue != -1) {
+            if (!(stepValue >= allowedMinStepValue && stepValue <= allowedMaxStepValue)) {
+                throw new BadCronExpressionException(
+                        "Step value '%s' is invalid. It must be between '%s..%s'.",
+                        stepValue,
+                        allowedMaxStepValue,
+                        allowedMinStepValue);
+            }
+        }
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.8.2
 =============
 
+* 2022-02-07 Added CRON like support on the annotation @Schedule (thibaultmeyer)
 * 2022-01-10 Updated Maven Archetype plugin to 3.2.1 (thibaultmeyer)
 * 2021-12-18 Added Jackson Module to handle Java8 and Joda data types (thibaultmeyer)
 * 2021-12-24 Fixed NullPointerException on "Message::getWithDefault" when value and default value are both null

--- a/ninja-core/src/site/markdown/documentation/scheduler.md
+++ b/ninja-core/src/site/markdown/documentation/scheduler.md
@@ -45,3 +45,84 @@ public class Module extends AbstractModule {
 By that Ninja will execute method doStuffEach60Seconds each - well - 60 seconds.
 
 
+CRON expression
+---------------
+
+Sometimes you need to schedule tasks in an advanced way and without depending on
+when the application has started. For this you can use a CRON expression.
+
+The format of the CRON expression must be : second, minute, hour, day of month,
+month and day of week.
+
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Unit</th>
+      <th scope="col">Value</th>
+      <th scope="col">Step Value</th>
+      <th scope="col">Extra Information</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Second</th>
+      <td>0 - 59</td>
+      <td>1 - 60</td>
+      <td>–</td>
+    </tr>
+    <tr>
+      <th scope="row">Minute</th>
+      <td>0 - 59</td>
+      <td>1 - 60</td>
+      <td>–</td>
+    </tr>
+    <tr>
+      <th scope="row">Hour</th>
+      <td>0 - 23</td>
+      <td>1 - 24</td>
+      <td>–</td>
+    </tr>
+    <tr>
+      <th scope="row">Day of Month</th>
+      <td>0 - 31</td>
+      <td>1 - 32</td>
+      <td>–</td>
+    </tr>
+   <tr>
+      <th scope="row">Month</th>
+      <td>0 - 12</td>
+      <td>1 - 13</td>
+      <td>–</td>
+    </tr>
+   <tr>
+      <th scope="row">Day of Week</th>
+      <td>0 - 6</td>
+      <td>1 - 7</td>
+      <td>0: Sunday, 1: Monday, ..., 6: Saturday</td>
+    </tr>
+  </tbody>
+</table>
+
+
+<pre class="prettyprint">
+@Singleton
+public class ScheduledAction {
+
+
+    @Schedule(cron = "0 */5 * * * *")
+    public void doStuffEach5minutes() {
+        // do stuff
+    }
+
+    @Schedule(cron = "0 0 23 * * *", cronZone = "Europe/Paris")
+    public void doStuffEachDayAt23HourEuropeParis() {
+        // do stuff
+    }
+
+    @Schedule(cron = "0 30 2,14 * * 1-5")
+    public void doStuffTwiceADayFromMondayToFriday() {
+        // do stuff
+    }
+}
+</pre>

--- a/ninja-core/src/test/java/ninja/scheduler/cron/CronExpressionTest.java
+++ b/ninja-core/src/test/java/ninja/scheduler/cron/CronExpressionTest.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ninja.scheduler.cron;
+
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.time.LocalDateTime;
+
+/**
+ * Unit tests for class {@link CronExpression}.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class CronExpressionTest {
+
+    @Test
+    public void everySeconds() {
+        final CronExpression cronExpression = new CronExpression("* * * * * *");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 1, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 1, 23, 12, 0, 1), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyMinutes() {
+        final CronExpression cronExpression = new CronExpression("0 * * * * *");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 1, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 1, 23, 12, 1, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyHours() {
+        final CronExpression cronExpression = new CronExpression("0 0 * * * *");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 1, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 1, 23, 13, 0, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyDays() {
+        final CronExpression cronExpression = new CronExpression("0 0 0 * * *");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 1, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 1, 24, 0, 0, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyMonths() {
+        final CronExpression cronExpression = new CronExpression("0 0 0 1 * *");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 3, 1, 0, 0, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyTwiceADayFromMondayToFriday() {
+        // Twice a day (2h30 & 14h30) from Monday to Friday
+        final CronExpression cronExpression = new CronExpression("0 30 2,14 * * 1-5");
+
+        // Given: Wednesday, February 23, 2022 12:00:00
+        // Expected: Wednesday, February 23, 2022 14:30:00
+        LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 23, 12, 0, 0);
+        long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 23, 14, 30, 0), nextTriggerLocalDateTime);
+
+        // Given: Friday, February 25, 2022 22:00:00
+        // Expected: Monday, February 28, 2022 02:30:00
+        localDateTime = LocalDateTime.of(2022, 2, 25, 22, 0, 0);
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 28, 2, 30, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyMondayAt22h28_30sec() {
+        final CronExpression cronExpression = new CronExpression("30 28 22 * * 1");
+        final LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 23, 12, 0, 0); // Wednesday, February 23, 2022
+
+        final long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        final LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 28, 22, 28, 30), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void every5Seconds() {
+        final CronExpression cronExpression = new CronExpression("*/5 * * * * *");
+
+        // Given: Friday, February 25, 2022 12:00:05
+        // Expected: Monday, February 25, 2022 12:00:10
+        LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 25, 12, 0, 5); // Wednesday, February 23, 2022
+        long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 25, 12, 0, 10), nextTriggerLocalDateTime);
+
+        // Given: Friday, February 25, 2022 12:00:11
+        // Expected: Monday, February 25, 2022 12:00:15
+        localDateTime = LocalDateTime.of(2022, 2, 25, 12, 0, 11); // Wednesday, February 23, 2022
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 25, 12, 0, 15), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void everyOddDayOfTheMonthAt23h59() {
+        final CronExpression cronExpression = new CronExpression("0 59 23 */2 * *");
+
+        // Given: Friday, February 25, 2022 12:00:00
+        // Expected: Monday, February 26, 2022 23:59:00
+        LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 25, 12, 0, 0); // Wednesday, February 23, 2022
+        long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 26, 23, 59, 0), nextTriggerLocalDateTime);
+
+        // Given: Friday, February 26, 2022 23:59:00
+        // Expected: Monday, February 28, 2022 23:59:00
+        localDateTime = LocalDateTime.of(2022, 2, 26, 23, 59, 0); // Wednesday, February 23, 2022
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 2, 28, 23, 59, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test
+    public void from2to5OfEachMonthAt10h12() {
+        final CronExpression cronExpression = new CronExpression("0 12 10 2-5 * *");
+
+        // Given: Friday, February 25, 2022 12:00:00
+        // Expected: Wednesday, March 02, 2022 10:12:00
+        LocalDateTime localDateTime = LocalDateTime.of(2022, 2, 25, 12, 0, 0); // Wednesday, February 23, 2022
+        long delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        LocalDateTime nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 3, 2, 10, 12, 0), nextTriggerLocalDateTime);
+
+        // Given: Wednesday, March 02, 2022 10:12:00
+        // Expected: Thursday, March 03, 2022 10:12:00
+        localDateTime = LocalDateTime.of(2022, 3, 2, 10, 12, 0); // Wednesday, February 23, 2022
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 3, 3, 10, 12, 0), nextTriggerLocalDateTime);
+
+        // Given: Friday, March 04, 2022 10:12:00
+        // Expected: Saturday, March 05, 2022 10:12:00
+        localDateTime = LocalDateTime.of(2022, 3, 4, 10, 12, 0); // Wednesday, February 23, 2022
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 3, 5, 10, 12, 0), nextTriggerLocalDateTime);
+
+        // Given: Saturday, March 05, 2022 10:12:00
+        // Expected: Saturday, April 02, 2022 10:12:00
+        localDateTime = LocalDateTime.of(2022, 3, 5, 10, 12, 0); // Wednesday, February 23, 2022
+        delay = cronExpression.getNextDelayMilliseconds(localDateTime);
+        nextTriggerLocalDateTime = localDateTime.plusSeconds(delay / 1000);
+        Assert.assertEquals(LocalDateTime.of(2022, 4, 2, 10, 12, 0), nextTriggerLocalDateTime);
+    }
+
+    @Test(expected = BadCronExpressionException.class)
+    public void badPartSingleValueTooHigh() {
+        new CronExpression("125 12 10 2-5 * *");
+    }
+
+    @Test(expected = BadCronExpressionException.class)
+    public void badPartListValueTooHigh() {
+        new CronExpression("1,2,71,4 12 10 2-5 * *");
+    }
+
+    @Test(expected = BadCronExpressionException.class)
+    public void badCronExpressionSize() {
+        new CronExpression("1,2,71,4 * *");
+    }
+
+    @Test(expected = BadCronExpressionException.class)
+    public void badCronExpressionTooManyWildcard() {
+        new CronExpression("0 12 10 2-5 ** *");
+    }
+}


### PR DESCRIPTION
### Information
- Enhancement
- Non-breaking API change


### Description

This PR adds the possibility to use a CRON expression to launch a job at regular intervals without worrying about when the application is started, without any extra dependencies.

The CRON expression can have second, minute, hour, day of month, month and day of week.

```
// ┌───────────── second (0 - 59)
// │ ┌───────────── minute (0 - 59)
// │ │ ┌───────────── hour (0 - 23)
// │ │ │ ┌───────────── day of the month (1 - 31)
// │ │ │ │ ┌───────────── month (1 - 12)
// │ │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
// │ │ │ │ │ │
// * * * * * *
```

Supported :

- Wildcards (`*` or `?`)
- Single value (ie: `1`), Range (ie: `0-59`) or list (ie: `10,20,30`) can be used
- Step value (ie : `*/5`)
