### PR TITLE
Raw access to the query parameter string

### DIFF
--- a/ninja-core/src/main/java/ninja/Context.java
+++ b/ninja-core/src/main/java/ninja/Context.java
@@ -108,6 +108,17 @@ public interface Context {
     String getRequestUri();
 
     /**
+     * Returns the parameter string that is contained in the request URL after the path.
+     * <br/>
+     * <b>Example:</b>
+     * For the URL <em>"http://domain.local/?key=private&hash=%93%af%f2%3b"</em>, this method
+     * will return <em>"key=private&hash=%93%af%f2%3b"</em>
+     *
+     * @return The parameter string
+     */
+    String getRequestParameterString();
+
+    /**
      * Returns the hostname as seen by the server.
      *
      * http://example.com/index would return "example.com".

--- a/ninja-core/src/main/java/ninja/WrappedContext.java
+++ b/ninja-core/src/main/java/ninja/WrappedContext.java
@@ -49,6 +49,11 @@ public class WrappedContext implements Context {
     }
 
     @Override
+    public String getRequestParameterString() {
+        return wrapped.getRequestParameterString();
+    }
+
+    @Override
     public String getHostname() {
         return wrapped.getHostname();
     }

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.8.2
 =============
 
+* 2022-01-19 Allow raw access to the parameter string (thibaultmeyer)
 * 2022-01-10 Updated Maven Archetype plugin to 3.2.1 (thibaultmeyer)
 * 2021-12-18 Added Jackson Module to handle Java8 and Joda data types (thibaultmeyer)
 * 2021-12-24 Fixed NullPointerException on "Message::getWithDefault" when value and default value are both null

--- a/ninja-core/src/test/java/ninja/utils/AbstractContextImpl.java
+++ b/ninja-core/src/test/java/ninja/utils/AbstractContextImpl.java
@@ -57,6 +57,11 @@ public class AbstractContextImpl extends AbstractContext {
     }
 
     @Override
+    public String getRequestParameterString() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
     public String getHostname() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
+++ b/ninja-servlet/src/main/java/ninja/servlet/NinjaServletContext.java
@@ -141,6 +141,11 @@ public class NinjaServletContext extends AbstractContext {
     }
 
     @Override
+    public String getRequestParameterString() {
+        return httpServletRequest.getQueryString();
+    }
+
+    @Override
     public String getHostname() {
         return httpServletRequest.getHeader("host");
     }

--- a/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
+++ b/ninja-servlet/src/test/java/ninja/servlet/NinjaServletContextTest.java
@@ -482,6 +482,19 @@ public class NinjaServletContextTest {
     }
 
     @Test
+    public void testGetRequestParameterString() {
+        // we got a context
+        when(httpServletRequest.getContextPath()).thenReturn("/");
+
+        // we got a request uri
+        when(httpServletRequest.getQueryString()).thenReturn("key=private&hash=%93%af%f2%3b");
+
+        context.init(servletContext, httpServletRequest, httpServletResponse);
+
+        assertEquals("key=private&hash=%93%af%f2%3b", context.getRequestParameterString());
+    }
+
+    @Test
     public void testContentTypeGetsConvertedProperlyUponFinalize() {
 
         //init the context
@@ -513,7 +526,6 @@ public class NinjaServletContextTest {
         //make sure utf-8 is used under all circumstances:
         verify(httpServletResponse).setCharacterEncoding(NinjaConstant.UTF_8);
     }
-
 
     @Test
     public void testGetRequestPathWorksAsExpectedWithContext() {

--- a/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
+++ b/ninja-test-utilities/src/main/java/ninja/utils/FakeContext.java
@@ -60,6 +60,7 @@ public class FakeContext implements Context {
     /** please use the requestPath stuff */
     @Deprecated
     private String requestUri;
+    private String requestParameterString;
     private String hostname;
     private String remoteAddr;
     private String scheme;
@@ -116,6 +117,17 @@ public class FakeContext implements Context {
     @Deprecated
     public String getRequestUri() {
         return requestUri;
+    }
+
+    @Deprecated
+    public FakeContext setRequestParameterString(String requestParameterString) {
+        this.requestParameterString = requestParameterString;
+        return this;
+    }
+
+    @Override
+    public String getRequestParameterString() {
+        return requestParameterString;
     }
 
     @Override


### PR DESCRIPTION
When dealing with external software, sometime we have to get the raw parameter string (query string) to work with.

This PR allow developer to get this data easily.