### PR TITLE
Can use @Schedule annotation with @UnitOfWork or @Transactional

### DIFF
--- a/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
+++ b/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
 
+import ninja.utils.AopUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,10 @@ public class Scheduler {
     }
 
     public boolean hasScheduledMethod(Class<?> clazz) {
-        for (Method method : clazz.getMethods()) {
+
+        for (final Method method : AopUtils.isAopProxy(clazz)
+                ? clazz.getSuperclass().getMethods()
+                : clazz.getMethods()) {
             Schedule schedule = method.getAnnotation(Schedule.class);
             if (schedule != null) {
                 return true;
@@ -75,7 +79,9 @@ public class Scheduler {
         if (executor == null) {
             objectsToSchedule.add(target);
         } else {
-            for (final Method method : target.getClass().getMethods()) {
+            for (final Method method : AopUtils.isAopProxy(target)
+                    ? target.getClass().getSuperclass().getMethods()
+                    : target.getClass().getMethods()) {
                 Schedule schedule = method.getAnnotation(Schedule.class);
                 if (schedule != null) {
                     schedule(target, method, schedule);
@@ -123,8 +129,12 @@ public class Scheduler {
             initialDelay = delay;
         }
 
-        log.info("Scheduling method " + method.getName() + " on " + target + " to be run every " + delay
+        final String targetName = AopUtils.isAopProxy(target)
+                ? target.getClass().getSuperclass().getName()
+                : target.getClass().getName();
+        log.info("Scheduling method " + method.getName() + " on " + targetName + " to be run every " + delay
                 + " " + timeUnit + " after " + initialDelay + " " + timeUnit);
+
         executor.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {

--- a/ninja-core/src/main/java/ninja/utils/AopUtils.java
+++ b/ninja-core/src/main/java/ninja/utils/AopUtils.java
@@ -1,0 +1,33 @@
+package ninja.utils;
+
+import java.lang.reflect.Proxy;
+
+/**
+ * AOP utility methods.
+ */
+public class AopUtils {
+
+    private static final String CGLIB_CLASS_SEPARATOR = "$$";
+
+    /**
+     * Check whether the given object is a proxy.
+     *
+     * @param object the object to check
+     * @return {@code true} if the object is a proxy
+     */
+    public static boolean isAopProxy(final Object object) {
+        return (object != null) &&
+                (Proxy.isProxyClass(object.getClass()) || object.getClass().getName().contains(CGLIB_CLASS_SEPARATOR));
+    }
+
+    /**
+     * Check whether the given class is a proxy.
+     *
+     * @param clazz the class to check
+     * @return {@code true} if the class is a proxy
+     */
+    public static boolean isAopProxy(final Class<?> clazz) {
+        return (clazz != null) &&
+                (Proxy.isProxyClass(clazz) || clazz.getName().contains(CGLIB_CLASS_SEPARATOR));
+    }
+}

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,6 +1,7 @@
 Version 6.8.2
 =============
 
+* 2022-01-20 Can use @Schedule annotation with @UnitOfWork or @Transactional (thibaultmeyer)
 * 2022-01-10 Updated Maven Archetype plugin to 3.2.1 (thibaultmeyer)
 * 2021-12-18 Added Jackson Module to handle Java8 and Joda data types (thibaultmeyer)
 * 2021-12-24 Fixed NullPointerException on "Message::getWithDefault" when value and default value are both null


### PR DESCRIPTION
This pull request adds support for the use `@Schedule` with annotations such as `@UnitOfWork` or `@Transactional` or more generally a proxy class.


### Before

```java
@Singleton
public class TestJob {

    private final TestService testService;

    @Inject
    public TestJob (final TestService testService) {
        this.testService= testService;
    }

    @Schedule(delay = 30, initialDelay = 30, timeUnit = TimeUnit.SECONDS)
    public void every30seconds() {
        runOnTransaction();
    }

    @UnitOfWork
    public void runOnTransaction() {
        testService.doWork();
    }
}
```


### After

```java
@Singleton
public class TestJob {

    private final TestService testService;

    @Inject
    public TestJob (final TestService testService) {
        this.testService= testService;
    }

    @Schedule(delay = 30, initialDelay = 30, timeUnit = TimeUnit.SECONDS)
    @UnitOfWork 
    public void every30seconds() {
        testService.doWork();
    }
}
```