### PR TITLE
Fix error during the error message generation on "buildErrorMessage"

### DIFF
--- a/ninja-core/src/main/java/ninja/NinjaDefault.java
+++ b/ninja-core/src/main/java/ninja/NinjaDefault.java
@@ -31,6 +31,7 @@ import ninja.diagnostics.DiagnosticError;
 import ninja.diagnostics.DiagnosticErrorBuilder;
 import ninja.exceptions.BadRequestException;
 import ninja.exceptions.ForbiddenRequestException;
+import ninja.exceptions.NinjaException;
 import ninja.exceptions.RenderingException;
 import ninja.exceptions.RequestNotFoundException;
 import ninja.i18n.Messages;
@@ -422,15 +423,15 @@ public class NinjaDefault implements Ninja {
                                         Optional<Throwable> exception,
                                         Optional<Result> underlyingResult) {
 
-        String messageI18n 
+        String messageI18n
                 = messages.getWithDefault(
                         errorTextKey,
                         errorTextDefault,
                         context,
                         underlyingResult);
 
-        String errorI18n 
-                = !exception.isPresent()
+        String errorI18n
+                = !exception.filter(NinjaException.class::isInstance).isPresent()
                     ? null 
                     : messages.getWithDefault(
                         exception.get().getMessage(),

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version 6.9.1
+=============
+
+* 2022-01-21 Fix error during the error message generation on "buildErrorMessage" (thibaultmeyer)
+
+
 Version 6.9.0
 =============
 


### PR DESCRIPTION
Not all exceptions are necessarily compliant with the expectations of this method, such as business exceptions. It is necessary to ensure that the exception inherits from `NinjaException` before starting to use it with the translation system.

This error only appear on PROD mode
