### PR TITLE
Display the right target name when using CRON scheduler and Proxy class

### DIFF
--- a/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
+++ b/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
@@ -116,7 +116,10 @@ public class Scheduler {
                 ? ZoneId.systemDefault()
                 : ZoneId.of(schedule.cronZone());
 
-        log.info("Scheduling method " + method.getName() + " on " + target
+        final String targetName = AopUtils.isAopProxy(target)
+                ? target.getClass().getSuperclass().getName()
+                : target.getClass().getName();
+        log.info("Scheduling method " + method.getName() + " on " + targetName
                 + " using CRON expression " + schedule.cron()
                 + " (TimeZone: " + zoneId + ")");
 

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version 6.9.1
+=============
+
+* 2022-01-22 Display the right target name when using CRON scheduler and Proxy class (thibaultmeyer)
+
+
 Version 6.9.0
 =============
 


### PR DESCRIPTION
**Before**

```
INFO  ninja.scheduler.Scheduler - Scheduling method doWork on jobs.TestJob$$EnhancerByGuice$$25319309@2eee4cb3 using CRON expression 0 */30 * * * * (TimeZone: UTC)
```

**After (without "_$$EnhancerByGuice$$25319309@2eee4cb3_")**

```
INFO  ninja.scheduler.Scheduler - Scheduling method doWork on jobs.TestJob using CRON expression 0 */30 * * * * (TimeZone: UTC)
```