### PR TITLE
Can configure Scheduler execution thread pool size

### DIFF
--- a/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
+++ b/ninja-core/src/main/java/ninja/scheduler/Scheduler.java
@@ -32,6 +32,8 @@ import ninja.lifecycle.Start;
 
 import ninja.utils.AopUtils;
 import ninja.scheduler.cron.CronExpression;
+import ninja.utils.NinjaConstant;
+import ninja.utils.NinjaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,12 +53,20 @@ public class Scheduler {
 
     @Inject
     private Injector injector;
+
+    @Inject
+    private NinjaProperties ninjaProperties;
+
     private volatile ScheduledExecutorService executor;
     private final List<Object> objectsToSchedule = Collections.synchronizedList(new ArrayList<Object>());
 
     @Start(order = 90)
     public void start() {
-        executor = Executors.newSingleThreadScheduledExecutor();
+        final int threadPoolSize = ninjaProperties.getIntegerWithDefault(
+                NinjaConstant.SCHEDULER_THREAD_POOL_SIZE_CONFIG_KEY,
+                NinjaConstant.SCHEDULER_THREAD_POOL_SIZE_DEFAULT);
+
+        executor = Executors.newScheduledThreadPool(threadPoolSize);
         scheduleCachedObjects();
     }
 

--- a/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
+++ b/ninja-core/src/main/java/ninja/utils/NinjaConstant.java
@@ -252,7 +252,11 @@ public interface NinjaConstant {
     String NINJA_JSONP_CALLBACK_PARAMETER = "ninja.jsonp.callbackParameter";
     
     String AUTHENTICITY_TOKEN = "authenticityToken";
-    
+
+    /** Scheduler Thread pool configuration */
+    String SCHEDULER_THREAD_POOL_SIZE_CONFIG_KEY = "scheduler.thread_pool_size";
+    int SCHEDULER_THREAD_POOL_SIZE_DEFAULT = 1;
+
     ///////////////////////////////////////////////////////////////////////////
     // File uploads constants used by FileProvider implementations.
     ///////////////////////////////////////////////////////////////////////////

--- a/ninja-core/src/site/markdown/developer/changelog.md
+++ b/ninja-core/src/site/markdown/developer/changelog.md
@@ -1,3 +1,9 @@
+Version 6.9.1
+=============
+
+* 2022-02-01 Can configure @Schedule thread pool size (thibaultmeyer)
+
+
 Version 6.9.0
 =============
 

--- a/ninja-core/src/site/markdown/documentation/scheduler.md
+++ b/ninja-core/src/site/markdown/documentation/scheduler.md
@@ -126,3 +126,16 @@ public class ScheduledAction {
     }
 }
 </pre>
+
+
+Execution thread pool
+---------------------
+
+By default, scheduled tasks run on a single thread, which can be sufficient
+for most cases. However, if you need to run several tasks at the same time
+or if the execution of your tasks takes too much time and delays the others,
+you can change the size of the thread pool allocated to scheduled tasks.
+
+To change the size of the thread pool used by scheduled tasks, you must use
+the <code>scheduler.thread_pool_size</code> configuration key in the
+configuration file.

--- a/ninja-core/src/test/java/ninja/scheduler/SchedulerSupportTest.java
+++ b/ninja-core/src/test/java/ninja/scheduler/SchedulerSupportTest.java
@@ -28,6 +28,9 @@ import javassist.util.proxy.ProxyFactory;
 import ninja.lifecycle.FailedStartException;
 import ninja.lifecycle.LifecycleService;
 import ninja.lifecycle.LifecycleSupport;
+import ninja.utils.NinjaMode;
+import ninja.utils.NinjaProperties;
+import ninja.utils.NinjaPropertiesImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -129,6 +132,12 @@ public class SchedulerSupportTest {
 
     private Injector createInjector(Module... modules) {
         List<Module> ms = new ArrayList<>(asList(modules));
+        ms.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(NinjaProperties.class).toInstance(NinjaPropertiesImpl.builder().withMode(NinjaMode.test).build());
+            }
+        });
         ms.add(LifecycleSupport.getModule());
         ms.add(SchedulerSupport.getModule());
         return Guice.createInjector(ms);


### PR DESCRIPTION
By default, scheduled tasks run on a single thread, which may be sufficient in most cases. However, sometimes we need to run several tasks at the same time or just have the possibility to run a task even if another one is already running.

I keep the value of `1` (single thread) by default to stay compliant with the behavior that was present before the modification.

Resolves: #375
