### PR TITLE
Fix issue with non-Optional generic parameters in controller methods throwing an exception

### DIFF
--- a/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
+++ b/ninja-core/src/main/java/ninja/params/ControllerMethodInvoker.java
@@ -417,6 +417,13 @@ public class ControllerMethodInvoker {
                     if (maybeOptional.isAssignableFrom(Optional.class)) {
                         isOptional = true;
                         parameterClass = getClass(parameterizedType.getActualTypeArguments()[0]);
+                    } else {
+                        // This case is necessary here for types like List<String>
+                        // because genericType is not a class in that case, so letting it fall through below throws an exception.
+                        // So we explicitly handle the case here and use parameterizedType.getRawType() as the parameterClass
+                        // (which would be List in the example above), and matches the behavior of older Ninja versions.
+                        isOptional = false;
+                        parameterClass = maybeOptional;
                     }
                 }
                 

--- a/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
+++ b/ninja-core/src/test/java/ninja/params/ControllerMethodInvokerTest.java
@@ -58,6 +58,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
@@ -1073,6 +1074,14 @@ public class ControllerMethodInvokerTest {
         verify(mockController).bodyWithOptional(Optional.empty());
     }
 
+    @Test
+    public void bodyWithGenericTypeShouldRun() {
+        List<String> body = Arrays.asList("value1", "value2");
+        when(context.parseBody(List.class)).thenReturn(body);
+        create("bodyWithGenericType").invoke(mockController, context);
+        verify(mockController).bodyWithGenericType(body);
+    }
+
     // JSR303Validation(@Pattern(regexp = "[a-z]*") String param1,
     // @Length(min = 5, max = 10) String param2, @Min(3) @Max(10) int param3);
     @Test
@@ -1426,6 +1435,8 @@ public class ControllerMethodInvokerTest {
         public Result badValidatorWithOptional(@Param("param1") @NumberValue(min = 10) Optional<String> param1);
 
         public Result body(Object body);
+
+        public Result bodyWithGenericType(List<String> myList);
         
         public Result bodyWithOptional(Optional<Object> body);
 


### PR DESCRIPTION
We were upgrading from Ninja 5.8.0 to 7.0.0, and we ran into an issue where we had a controller method that took a `List<String>` as a method parameter. In this case the request body is a JSON array, so we allow the built-in JSON support to deserialize the body into that parameter (which worked fine on 5.8.0).

However, I discovered that some logic added to support `Optional` seemed to cause issues if the parameter was a non-Optional generic type, because `getClass(genericType)` would throw an exception:

```
java.lang.RuntimeException: Oops. Something went wrong while investigating method parameters for controller class invocation

	at ninja.params.ControllerMethodInvoker$MethodParameter.<init>(ControllerMethodInvoker.java:435)
	at ninja.params.ControllerMethodInvoker$MethodParameter.convertIntoMethodParameters(ControllerMethodInvoker.java:443)
	at ninja.params.ControllerMethodInvoker.build(ControllerMethodInvoker.java:118)
	at ninja.params.ControllerMethodInvokerTest.create(ControllerMethodInvokerTest.java:1304)
	at ninja.params.ControllerMethodInvokerTest.bodyWithGenericTypeShouldRun(ControllerMethodInvokerTest.java:1081)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:55)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:100)
	at org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:107)
	at org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:41)
	at org.mockito.junit.MockitoJUnitRunner.run(MockitoJUnitRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:231)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.RuntimeException: Oops. That's a strange internal Ninja error.
Seems someone tried to convert a type into a class that is not a real class. ( java.util.List<java.lang.String>)
	at ninja.params.ControllerMethodInvoker$MethodParameter.getClass(ControllerMethodInvoker.java:454)
	at ninja.params.ControllerMethodInvoker$MethodParameter.<init>(ControllerMethodInvoker.java:432)
	... 37 more
```