### PR TITLE
Replace InetAddress.getByName with Guava InetAddresses.isInetAddress to avoid DNS lookups triggered by X-Forwarded-For hostnames

### DIFF
--- a/ninja-core/src/main/java/ninja/utils/AbstractContext.java
+++ b/ninja-core/src/main/java/ninja/utils/AbstractContext.java
@@ -16,9 +16,7 @@
 
 package ninja.utils;
 
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +24,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.net.InetAddresses;
 import ninja.bodyparser.BodyParserEngine;
 import ninja.bodyparser.BodyParserEngineManager;
 import ninja.params.ParamParsers;
@@ -177,12 +176,8 @@ abstract public class AbstractContext implements Context.Impl {
                     // we just want the client
                     forwardHeader = StringUtils.split(forwardHeader, ',')[0].trim();
                 }
-                try {
-                    // If ip4/6 address string handed over, simply does pattern validation.
-                    InetAddress.getByName(forwardHeader);
+                if (InetAddresses.isInetAddress(forwardHeader)) {
                     return forwardHeader;
-                } catch (UnknownHostException e) {
-                    // give up
                 }
             }
         }


### PR DESCRIPTION
This addresses https://github.com/ninjaframework/ninja/issues/752

This replaces the use of `InetAddress.getByName` (which as described in the issue thread above will do a DNS lookup if a hostname is provided in the X-Forwarded-For header) with Guava's `InetAddresses.isInetAddress` which just validates that the provided string is an IPv4/v6 address (which seems to be the original intent of the code).